### PR TITLE
added array of arrays implementation of dictionary

### DIFF
--- a/hdt-java-core/hdt.cfg
+++ b/hdt-java-core/hdt.cfg
@@ -1,0 +1,19 @@
+# Parameters of the Generated HDT
+header.type = <http://purl.org/HDT/hdt#headerSimple>
+triples.type = <http://purl.org/HDT/hdt#triplesBitmap>
+triples.component.order = SPO
+dictionary.type = dictionaryFourBig
+#stream.y = <http://purl.org/HDT/hdt#streamLog>
+#stream.z = <http://purl.org/HDT/hdt#streamLog>
+
+# Parameters of the temporary dictionary used for building the HDT
+# impl  = hash | jdbm
+#tempDictionary.impl = jdbm
+# memory for cache can be specified as <number><K|k|M|m|G|g> 
+#tempDictionary.cache = 100G
+
+#parameters of the temporary triples used for building the HDT
+# impl  = list|jdbm
+#tempTriples.impl = jdbm
+# cache memory for disk-based implementations, can be specified as <number><K|k|M|m|G|g>
+#tempTriples.cache = 100M

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -47,6 +47,11 @@
         <artifactId>commons-compress</artifactId>
         <version>1.6</version>
       </dependency>
+         <dependency>
+        <groupId>pl.edu.icm</groupId>
+        <artifactId>JLargeArrays</artifactId>
+        <version>1.6</version>
+        </dependency>
 	</dependencies>
 
 	<build>
@@ -60,6 +65,14 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+                        <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.2.1</version>
+                        <configuration>
+                        <mainClass>org.rdfhdt.hdt.example.ExampleGenerate</mainClass>
+                        </configuration>
+                       </plugin>
 		</plugins>
 	</build>
 </project>

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Jarray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Jarray.java
@@ -1,0 +1,412 @@
+/**
+ * File: $HeadURL: https://hdt-java.googlecode.com/svn/trunk/hdt-java/src/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java $
+ * Revision: $Rev: 130 $
+ * Last modified: $Date: 2013-01-21 00:09:42 +0000 (lun, 21 ene 2013) $
+ * Last modified by: $Author: mario.arias $
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Contacting the authors:
+ *   Mario Arias:               mario.arias@deri.org
+ *   Javier D. Fernandez:       jfergar@infor.uva.es
+ *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ *   Alejandro Andres:          fuzzy.alej@gmail.com
+ */
+
+package org.rdfhdt.hdt.compact.sequence;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import org.rdfhdt.hdt.compact.integer.VByte;
+import org.rdfhdt.hdt.exceptions.CRCException;
+import org.rdfhdt.hdt.exceptions.IllegalFormatException;
+import org.rdfhdt.hdt.hdt.HDTVocabulary;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.util.BitUtil;
+import org.rdfhdt.hdt.util.crc.CRC32;
+import org.rdfhdt.hdt.util.crc.CRC8;
+import org.rdfhdt.hdt.util.crc.CRCInputStream;
+import org.rdfhdt.hdt.util.crc.CRCOutputStream;
+import org.rdfhdt.hdt.util.io.IOUtil;
+
+import pl.edu.icm.jlargearrays.LongLargeArray;
+import pl.edu.icm.jlargearrays.LargeArrayUtils;
+/**
+ * @author mario.arias,Lyudmila Balakireva
+ *
+ */
+public class SequenceLog64Jarray implements DynamicSequence { 
+	private static final byte W = 64;
+	
+	//private long [] data;
+	LongLargeArray  data;
+	private int numbits;
+	private long numentries=0;
+	private long maxvalue;
+	
+	public SequenceLog64Jarray() {
+		this(W);
+	}
+	
+	public SequenceLog64Jarray(int numbits) {
+		this(numbits, 0);
+	}
+	
+	public SequenceLog64Jarray(int numbits, long capacity) {
+		this.numentries = 0;
+		this.numbits = numbits;
+		this.maxvalue = BitUtil.maxVal(numbits);
+		
+		long size = numWordsFor(numbits, capacity);
+		//assert size>=0 && size<=Integer.MAX_VALUE;
+		 LongLargeArray.setMaxSizeOf32bitArray(1073741824);
+		//data = new long[Math.max((int)size,1)];
+		
+		 data = new LongLargeArray(Math.max((int)size,1)); 
+	}
+	
+	public SequenceLog64Jarray(int numbits, long capacity, boolean initialize) {
+		this(numbits, capacity);
+		if(initialize) {
+			numentries = capacity;
+		}
+	}
+	
+	/** longs required to represent "total" integers of "bitsField" bits each */
+	public static final long numWordsFor(int bitsField, long total) {
+		return ((bitsField*total+63)/64);
+	}
+	
+	/** Number of bits required for last word */
+	public static final long lastWordNumBits(int bitsField, long total) {
+		long totalBits = bitsField*total;
+		if(totalBits==0) {
+			return 0;
+		}
+		return (long) ((totalBits-1) % W)+1;	// +1 To have output in the range 1-64, -1 to compensate.
+	}
+	
+	/** Number of bits required for last word */
+	public static final long lastWordNumBytes(int bitsField, long total) {
+		return ((lastWordNumBits(bitsField, total)-1)/8)+1;	// +1 To have output in the range 1-8, -1 to compensate.
+	}
+
+	/** Number of bytes required to represent n integers of e bits each */
+	public static final long numBytesFor(int bitsField, long total) {
+		return (bitsField*total+7)/8;
+	}
+
+	 /** Retrieve a given index from array data where every value uses bitsField bits
+     * @param data Array
+     * @param bitsField Length in bits of each field
+     * @param index Position to be retrieved
+     */
+	private static final long getField(LongLargeArray data, int bitsField, long index) {
+		if(bitsField==0) return 0;
+		
+        long bitPos = index*bitsField;
+        long i=(long)(bitPos / W);
+        long j=(long)(bitPos % W);
+        long result;
+        if (j+bitsField <= W) {
+        	result = (data.get(i) << (W-j-bitsField)) >>> (W-bitsField);
+        } else {
+        	result = data.get(i) >>> j;
+        	result = result | (data.get(i+1) << ( (W<<1) -j-bitsField)) >>> (W-bitsField);
+        }
+        return result;
+	}
+	
+	/** Store a given value in index into array data where every value uses bitsField bits
+     * @param data Array
+     * @param bitsField Length in bits of each field
+     * @param index Position to store in
+     * @param value Value to be stored
+     */
+	private static final void setField(LongLargeArray data, int bitsField, long index, long value) {
+		if(bitsField==0) return;
+		
+		long bitPos = index*bitsField;
+		long i=(long)(bitPos/W);
+		long j=(long)(bitPos%W);
+		
+		long mask = ~(~0L << bitsField) << j;
+		data.set(i, (data.getLong(i) & ~mask) | (value << j));
+			
+		if((j+bitsField>W)) {
+			mask = ~0L << (bitsField+j-W);
+			data.set(i+1 , (data.get(i+1) & mask) | value >>> (W-j));
+		}
+	}
+	
+	private final void resizeArray(long size) {
+		//data = Arrays.copyOf(data, size);	
+		
+		LongLargeArray a = new LongLargeArray(size);
+		if (size < data.length()) {
+			LargeArrayUtils.arraycopy(data, 0, a, 0, size);
+			}
+			else {
+		    LargeArrayUtils.arraycopy(data, 0, a, 0, data.length());
+			}
+		data = a;
+		
+	}
+	
+	
+	
+	/* (non-Javadoc)
+	 * @see hdt.triples.array.Stream#add(java.util.Iterator)
+	 */
+	@Override
+	public void add(Iterator<Long> elements) {
+		long max = 0;
+		numentries = 0;
+		
+		// Count and calculate number of bits needed per element.
+		while(elements.hasNext()) {
+			long val = elements.next().longValue();
+			max = val>max ? val : max;
+			numentries++;
+		}
+		
+        // Prepare array
+        numbits = BitUtil.log2(max);
+        long size = (long) numWordsFor(numbits, numentries);
+        data = new LongLargeArray(size);
+
+        // Save
+        int count = 0;
+        while(elements.hasNext()) {
+        	long element = elements.next().longValue();
+        	assert element<=maxvalue;
+        	setField(data, numbits, count, element);
+        	count++;
+        }
+	}
+
+	public void addIntegers(ArrayList<Integer> elements) {
+		long max = 0;
+		numentries = 0;
+		
+		// Count and calculate number of bits needed per element.
+		for (int i=0;i<elements.size();i++){
+			long val = elements.get(i).longValue();
+			max = val>max ? val : max;
+			numentries++;
+		}
+		
+        // Prepare array
+        numbits = BitUtil.log2(max);
+        long size = (long) numWordsFor(numbits, numentries);
+        data = new LongLargeArray(size);
+
+        // Save
+        int count = 0;
+    	for (int i=0;i<elements.size();i++){
+        	long element = elements.get(i).longValue();
+        	assert element<=maxvalue;
+        	setField(data, numbits, count, element);
+        	count++;
+        }
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.triples.array.Stream#get(int)
+	 */
+	@Override
+	public long get(long position) {
+		if(position<0 || position>=numentries) {
+			//System.out.println("pos, numentries:"+position+","+numentries);
+			//throw new IndexOutOfBoundsException();
+		}
+		
+		return getField(data, numbits, position);
+	}
+	
+	public void set(long position, long value) {
+		//if(value<0 || value>maxvalue) {
+			//throw new IllegalArgumentException("Value exceeds the maximum for this data structure");
+		//}
+		setField(data, numbits, position, value);
+	}
+	
+	public void append(long value) {
+
+		//assert numentries<Integer.MAX_VALUE;
+		
+		//if(value<0 || value>maxvalue) {
+			//throw new IllegalArgumentException("Value exceeds the maximum for this data structure");
+		//}
+		
+		long neededSize = numWordsFor(numbits, numentries+1);
+		//System.out.println("append needed size:"+neededSize);
+		if(data.length()<neededSize) {
+			resizeArray(data.length()*2);
+		}
+		
+		this.set((long)numentries, value);
+		numentries++;
+	}
+	
+	public void aggresiveTrimToSize() {
+		long max = 0;
+		// Count and calculate number of bits needed per element.
+		for(long i=0; i<numentries; i++) {
+			long value = this.get(i);
+			max = value>max ? value : max;
+		}
+		int newbits = BitUtil.log2(max);
+		
+		assert newbits <= numbits;
+		//System.out.println("newbits"+newbits);
+		if(newbits!=numbits) {
+			for(long i=0;i<numentries;i++) {
+				long value = getField(data, numbits, i);
+				setField(data, newbits, i, value);
+			}
+			numbits = newbits;
+			maxvalue = BitUtil.maxVal(numbits);
+			
+			long totalSize = numWordsFor(numbits, numentries);
+			
+			if (totalSize!=data.length()){
+			resizeArray((int)totalSize);
+			}
+		}
+
+	}
+	
+	public void trimToSize() {
+		resizeArray((long)numWordsFor(numbits, numentries));
+	}
+	
+	public void resize(long numentries) {
+		this.numentries = numentries;
+		resizeArray((long)numWordsFor(numbits, numentries));	
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.triples.array.Stream#getNumberOfElements()
+	 */
+	@Override
+	public long getNumberOfElements() {
+		return numentries;
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.triples.array.Stream#save(java.io.OutputStream, hdt.ProgressListener)
+	 */
+	@Override
+	public void save(OutputStream output, ProgressListener listener) throws IOException {
+		
+		CRCOutputStream out = new CRCOutputStream(output, new CRC8());
+		
+		out.write(SequenceFactory.TYPE_SEQLOG);
+		out.write(numbits);
+		VByte.encode(out, numentries);
+		
+		out.writeCRC();
+		
+		out.setCRC(new CRC32());
+		
+		long numwords = (long)numWordsFor(numbits, numentries);	
+		for(long i=0;i<numwords-1;i++) {
+			IOUtil.writeLong(out, data.getLong(i));
+		}
+		
+		if(numwords>0) {
+			// Write only used bits from last entry (byte aligned, little endian)
+			long lastWordUsedBits = lastWordNumBits(numbits, numentries);
+			BitUtil.writeLowerBitsByteAligned(data.get(numwords-1), lastWordUsedBits, out);
+		}
+		
+		out.writeCRC();
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.triples.array.Stream#load(java.io.InputStream, hdt.ProgressListener)
+	 */
+	@Override
+	public void load(InputStream input, ProgressListener listener) throws IOException {
+		CRCInputStream in = new CRCInputStream(input, new CRC8());
+		
+		int type = in.read();
+		if(type!=SequenceFactory.TYPE_SEQLOG){
+			throw new IllegalFormatException("Trying to read a LogArray but the data is not LogArray");
+		}
+		numbits = in.read();
+		numentries = VByte.decode(in);
+		
+		if(!in.readCRCAndCheck()) {
+			throw new CRCException("CRC Error while reading LogArray64 header.");
+		}
+		
+		if(numbits>64) {
+			throw new IllegalFormatException("LogArray64 cannot deal with more than 64bit per entry");
+		}
+		
+		in.setCRC(new CRC32());
+		
+		long numwords = (long)numWordsFor(numbits, numentries);
+		data = new LongLargeArray(numwords);
+		for(long i=0;i<numwords-1;i++) {
+			data.set(i , IOUtil.readLong(in));
+		}
+		
+		if(numwords>0) {
+			// Read only used bits from last entry (byte aligned, little endian)
+			long lastWordUsed = lastWordNumBits(numbits, numentries);
+			data.set(numwords-1 , BitUtil.readLowerBitsByteAligned(lastWordUsed, in));
+		}
+		
+		if(!in.readCRCAndCheck()) {
+			throw new CRCException("CRC Error while reading LogArray64 data.");
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.triples.array.Stream#size()
+	 */
+	@Override
+	public long size() {
+		return numBytesFor(numbits, numentries);
+	}
+	
+	public long getRealSize() {
+		return data.length()*8L;
+	}
+	
+	public int getNumBits() {
+		return numbits;
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.compact.array.Stream#getType()
+	 */
+	@Override
+	public String getType() {
+		return HDTVocabulary.SEQ_TYPE_LOG;
+	}
+
+	@Override
+	public void close() throws IOException {
+		data=null;
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryFactory.java
@@ -28,6 +28,7 @@
 package org.rdfhdt.hdt.dictionary;
 
 import org.rdfhdt.hdt.dictionary.impl.FourSectionDictionary;
+import org.rdfhdt.hdt.dictionary.impl.FourSectionDictionaryBig;
 import org.rdfhdt.hdt.dictionary.impl.HashDictionary;
 import org.rdfhdt.hdt.exceptions.IllegalFormatException;
 import org.rdfhdt.hdt.hdt.HDTFactory;
@@ -43,7 +44,7 @@ import org.rdfhdt.hdt.options.HDTSpecification;
 public class DictionaryFactory {
 
 	public static final String MOD_DICT_IMPL_HASH = "hash";
-
+	public static final String DICTIONARY_TYPE_FOUR_SECTION_BIG ="dictionaryFourBig";
 
 	/**
 	 * Creates a default dictionary (HashDictionary)
@@ -76,6 +77,9 @@ public class DictionaryFactory {
 		String name = spec.get("dictionary.type");
 		if(name==null || HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION.equals(name)) {
 			return new FourSectionDictionary(spec);
+		}
+		else if (DICTIONARY_TYPE_FOUR_SECTION_BIG.equals(name)){
+			return new FourSectionDictionaryBig(spec);
 		}
 		throw new IllegalFormatException("Implementation of ditionary not found for "+name);
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionaryBig.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionaryBig.java
@@ -1,0 +1,173 @@
+/**
+ * File: $HeadURL: https://hdt-java.googlecode.com/svn/trunk/hdt-java/src/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionary.java $
+ * Revision: $Rev: 191 $
+ * Last modified: $Date: 2013-03-03 11:41:43 +0000 (dom, 03 mar 2013) $
+ * Last modified by: $Author: mario.arias $
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Contacting the authors:
+ *   Mario Arias:               mario.arias@deri.org
+ *   Javier D. Fernandez:       jfergar@infor.uva.es
+ *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ *   Alejandro Andres:          fuzzy.alej@gmail.com
+ */
+
+package org.rdfhdt.hdt.dictionary.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.rdfhdt.hdt.dictionary.DictionarySectionPrivate;
+import org.rdfhdt.hdt.dictionary.TempDictionary;
+import org.rdfhdt.hdt.dictionary.impl.section.DictionarySectionFactory;
+import org.rdfhdt.hdt.dictionary.impl.section.PFCDictionarySection;
+import org.rdfhdt.hdt.dictionary.impl.section.PFCDictionarySectionBig;
+import org.rdfhdt.hdt.exceptions.IllegalFormatException;
+import org.rdfhdt.hdt.hdt.HDTVocabulary;
+import org.rdfhdt.hdt.header.Header;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.ControlInfo;
+import org.rdfhdt.hdt.options.ControlInfo.Type;
+import org.rdfhdt.hdt.options.ControlInformation;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.util.io.CountInputStream;
+import org.rdfhdt.hdt.util.listener.IntermediateListener;
+
+
+/**
+ * @author mario.arias,Lyudmila Balakireva
+ *
+ */
+public class FourSectionDictionaryBig extends BaseDictionary {
+
+	public FourSectionDictionaryBig(HDTOptions spec, 
+			DictionarySectionPrivate s, DictionarySectionPrivate p, DictionarySectionPrivate o, DictionarySectionPrivate sh) {
+		super(spec);
+		this.subjects = s;
+		this.predicates = p;
+		this.objects = o;
+		this.shared = sh;
+	}
+	
+	public FourSectionDictionaryBig(HDTOptions spec) {
+		super(spec);
+		// FIXME: Read type from spec.
+		subjects = new PFCDictionarySectionBig(spec);
+		predicates = new PFCDictionarySectionBig(spec);
+		objects = new PFCDictionarySectionBig(spec);
+		shared = new PFCDictionarySectionBig(spec);
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.dictionary.Dictionary#load(hdt.dictionary.Dictionary)
+	 */
+	@Override
+	public void load(TempDictionary other, ProgressListener listener) {
+		IntermediateListener iListener = new IntermediateListener(listener);
+		subjects.load(other.getSubjects(), iListener);
+		predicates.load(other.getPredicates(), iListener);
+		objects.load(other.getObjects(), iListener);
+		shared.load(other.getShared(), iListener);
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.dictionary.Dictionary#save(java.io.OutputStream, hdt.ControlInformation, hdt.ProgressListener)
+	 */
+	@Override
+	public void save(OutputStream output, ControlInfo ci, ProgressListener listener) throws IOException {
+		ci.setType(Type.DICTIONARY);
+		ci.setFormat(HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION);
+		ci.setInt("elements", this.getNumberOfElements());
+		ci.save(output);
+
+		IntermediateListener iListener = new IntermediateListener(listener);
+		shared.save(output, iListener);
+		subjects.save(output, iListener);
+		predicates.save(output, iListener);
+		objects.save(output, iListener);
+
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.dictionary.Dictionary#load(java.io.InputStream)
+	 */
+	@Override
+	public void load(InputStream input, ControlInfo ci, ProgressListener listener) throws IOException {
+		if(ci.getType()!=ControlInfo.Type.DICTIONARY) {
+			throw new IllegalFormatException("Trying to read a dictionary section, but was not dictionary.");
+		}
+		
+		IntermediateListener iListener = new IntermediateListener(listener);
+
+		shared = DictionarySectionFactory.loadFrom(input, iListener);
+		subjects = DictionarySectionFactory.loadFrom(input, iListener);
+		predicates = DictionarySectionFactory.loadFrom(input, iListener);
+		objects = DictionarySectionFactory.loadFrom(input, iListener);
+	}
+	
+	@Override
+	public void mapFromFile(CountInputStream in, File f, ProgressListener listener) throws IOException {
+		ControlInformation ci = new ControlInformation();
+		ci.load(in);
+		if(ci.getType()!=ControlInfo.Type.DICTIONARY) {
+			throw new IllegalFormatException("Trying to read a dictionary section, but was not dictionary.");
+		}
+		
+		IntermediateListener iListener = new IntermediateListener(listener);
+		shared = DictionarySectionFactory.loadFrom(in, f, iListener);
+		subjects = DictionarySectionFactory.loadFrom(in, f, iListener);
+		predicates = DictionarySectionFactory.loadFrom(in, f, iListener);
+		objects = DictionarySectionFactory.loadFrom(in, f, iListener);
+		
+		// Use cache only for predicates. Preload only up to 100K predicates.
+		// FIXME: DISABLED
+//		predicates = new DictionarySectionCacheAll(predicates, predicates.getNumberOfElements()<100000);
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.dictionary.Dictionary#populateHeader(hdt.header.Header, java.lang.String)
+	 */
+	@Override
+	public void populateHeader(Header header, String rootNode) {
+		header.insert(rootNode, HDTVocabulary.DICTIONARY_TYPE, HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION);
+//		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMSUBJECTS, getNsubjects());
+//		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMPREDICATES, getNpredicates());
+//		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMOBJECTS, getNobjects());
+		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMSHARED, getNshared());
+//		header.insert(rootNode, HDTVocabulary.DICTIONARY_MAXSUBJECTID, getMaxSubjectID());
+//		header.insert(rootNode, HDTVocabulary.DICTIONARY_MAXPREDICATEID, getMaxPredicateID());
+//		header.insert(rootNode, HDTVocabulary.DICTIONARY_MAXOBJECTTID, getMaxObjectID());
+		header.insert(rootNode, HDTVocabulary.DICTIONARY_SIZE_STRINGS, size());
+	}
+
+	/* (non-Javadoc)
+	 * @see hdt.dictionary.Dictionary#getType()
+	 */
+	@Override
+	public String getType() {
+		return HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION;
+	}
+
+	@Override
+	public void close() throws IOException {
+		shared.close();
+		subjects.close();
+		predicates.close();
+		objects.close();
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionBig.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionBig.java
@@ -27,6 +27,11 @@
 
 package org.rdfhdt.hdt.dictionary.impl.section;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -34,6 +39,7 @@ import java.util.Iterator;
 
 import org.rdfhdt.hdt.compact.integer.VByte;
 import org.rdfhdt.hdt.compact.sequence.SequenceLog64;
+import org.rdfhdt.hdt.compact.sequence.SequenceLog64Jarray;
 import org.rdfhdt.hdt.dictionary.DictionarySectionPrivate;
 import org.rdfhdt.hdt.dictionary.TempDictionarySection;
 import org.rdfhdt.hdt.exceptions.CRCException;
@@ -41,10 +47,12 @@ import org.rdfhdt.hdt.exceptions.IllegalFormatException;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.util.BitUtil;
 import org.rdfhdt.hdt.util.Mutable;
 import org.rdfhdt.hdt.util.crc.CRC32;
 import org.rdfhdt.hdt.util.crc.CRC8;
 import org.rdfhdt.hdt.util.crc.CRCInputStream;
+import org.rdfhdt.hdt.util.crc.CRCOutputStream;
 import org.rdfhdt.hdt.util.io.IOUtil;
 import org.rdfhdt.hdt.util.string.ByteStringUtil;
 import org.rdfhdt.hdt.util.string.CompactString;
@@ -57,7 +65,7 @@ import org.rdfhdt.hdt.util.string.ReplazableString;
  *  It allows loading much bigger files, but waste some memory in pointers to the blocks and 
  *  some CPU to locate the array at search time.
  *  
- * @author mario.arias
+ * @author mario.arias, Lyudmila Balakireva
  *
  */
 public class PFCDictionarySectionBig implements DictionarySectionPrivate {
@@ -67,13 +75,17 @@ public class PFCDictionarySectionBig implements DictionarySectionPrivate {
 	
 	byte [][] data;
 	long [] posFirst;
-	protected SequenceLog64 blocks;
+	protected SequenceLog64Jarray blocks;
 	protected int blocksize;
 	protected int numstrings;
 	protected long size;
+	static int filecounter = 0;
 	
 	public PFCDictionarySectionBig(HDTOptions spec) {
-
+		this.blocksize = (int) spec.getInt("pfc.blocksize");
+		if(blocksize==0) {
+			blocksize = DEFAULT_BLOCK_SIZE;
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -81,8 +93,135 @@ public class PFCDictionarySectionBig implements DictionarySectionPrivate {
 	 */
 	@Override
 	public void load(TempDictionarySection other, ProgressListener listener) {
-		throw new NotImplementedException();
+		this.blocks = new SequenceLog64Jarray(BitUtil.log2(other.size()), other.getNumberOfElements()/blocksize);
+		System.out.println("numbits:"+BitUtil.log2(other.size()));
+		Iterator<? extends CharSequence> it = other.getSortedEntries();		
+		this.load((Iterator<CharSequence>)it, other.getNumberOfElements(), listener);
+		
 	}
+	
+	
+	
+	public void load(Iterator<CharSequence> it, long numentries, ProgressListener listener)  {		
+		
+		this.blocks = new SequenceLog64Jarray(64, numentries/blocksize);
+		this.numstrings = 0;
+		
+		filecounter++;
+		String name = ".test"+filecounter+".tmp";
+		File file = new File(name);
+		FileOutputStream out=null;
+		
+			try {
+				if (!file.exists()) {
+					file.createNewFile();
+				}
+				out = new FileOutputStream(file);
+			} catch (FileNotFoundException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		
+		long byteoutsize = 0;
+		ByteArrayOutputStream byteOut = new ByteArrayOutputStream(16*1024);		
+		CharSequence previousStr=null;
+		
+		try {
+			while(it.hasNext()) {
+				CharSequence str = it.next();
+
+				if(numstrings%blocksize==0) {
+					// Add new block pointer
+					byteOut.flush();
+					byteoutsize = byteoutsize+byteOut.size();
+					
+					blocks.append(byteoutsize);
+					byteOut.writeTo(out);
+					byteOut.reset();
+					// Copy full string
+					ByteStringUtil.append(byteOut, str, 0);
+				
+				} else {
+					// Find common part.
+					int delta = ByteStringUtil.longestCommonPrefix(previousStr, str);
+					// Write Delta in VByte
+					VByte.encode(byteOut, delta);
+					// Write remaining
+					ByteStringUtil.append(byteOut, str, delta);
+					
+				}
+				byteOut.write(0); // End of string
+			
+				numstrings++;
+								
+				previousStr = str;
+				
+			}
+			
+			// Ending block pointer.
+			byteOut.flush();
+			byteoutsize = byteoutsize + byteOut.size();
+			
+			//blocks.append(byteOut.size());
+			blocks.append(byteoutsize);
+			// Trim text/blocks
+			blocks.aggresiveTrimToSize();
+			
+			byteOut.flush();
+			byteOut.writeTo(out);
+			out.close();
+			
+			InputStream in = new FileInputStream(name);
+			// Read block by block
+			// Read packed data
+			
+			int block = 0;
+			int buffer = 0;
+			long bytePos = 0;
+			long numBlocks = blocks.getNumberOfElements();
+			//System.out.println("numblocks:"+numBlocks);
+			
+			long numBuffers = 1+numBlocks/BLOCK_PER_BUFFER;
+			data = new byte[(int)numBuffers][];
+			posFirst = new long[(int)numBuffers];
+			
+			while(block<numBlocks-1) {
+				int nextBlock = (int) Math.min(numBlocks-1, block+BLOCK_PER_BUFFER);
+				long nextBytePos = blocks.get(nextBlock);
+				
+				//System.out.println("Loding block: "+i+" from "+previous+" to "+ current+" of size "+ (current-previous));
+				data[buffer]=IOUtil.readBuffer(in, (int)(nextBytePos-bytePos), null);
+				
+				posFirst[buffer] = bytePos;
+				
+				bytePos = nextBytePos;
+				block+=BLOCK_PER_BUFFER;
+				buffer++;
+			}
+			
+			
+			
+			
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		finally {
+			try {
+				out.close();
+				file.delete();
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	
+	
+	
 	
 	/**
 	 * Locate the block of a string doing binary search.
@@ -278,7 +417,28 @@ public class PFCDictionarySectionBig implements DictionarySectionPrivate {
 	 */
 	@Override
 	public void save(OutputStream output, ProgressListener listener) throws IOException {
-		throw new NotImplementedException();
+		
+        CRCOutputStream out = new CRCOutputStream(output, new CRC8());		
+		out.write(TYPE_INDEX);
+		VByte.encode(out, numstrings);		
+		
+		long datasize=0;
+	
+		for (int i =0; i<data.length;i++) {
+			datasize = data[i].length+ datasize;
+			
+		}
+		System.out.println("datasize:"+datasize);		
+		VByte.encode(out, datasize);
+		VByte.encode(out, blocksize);				
+		out.writeCRC();
+		blocks.save(output, listener);	// Write blocks directly to output, they have their own CRC check.		
+		out.setCRC(new CRC32());
+		for (int i =0; i<data.length;i++) {			
+		IOUtil.writeBuffer(out, data[i], 0, data[i].length, listener);		
+		}
+		out.writeCRC();
+		//throw new NotImplementedException();
 	}
 
 	/* (non-Javadoc)
@@ -287,6 +447,7 @@ public class PFCDictionarySectionBig implements DictionarySectionPrivate {
 	@SuppressWarnings("resource")
 	@Override
 	public void load(InputStream input, ProgressListener listener) throws IOException {
+		
 		CRCInputStream in = new CRCInputStream(input, new CRC8());
 		
 		// Read type
@@ -303,7 +464,7 @@ public class PFCDictionarySectionBig implements DictionarySectionPrivate {
 		}
 		
 		// Load block pointers
-		blocks = new SequenceLog64();
+		blocks = new SequenceLog64Jarray();
 		blocks.load(input, listener);
 		
 		// Initialize global block array

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/example/ExampleGenerate.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/example/ExampleGenerate.java
@@ -1,0 +1,73 @@
+/**
+ * File: $HeadURL: https://hdt-java.googlecode.com/svn/trunk/hdt-java/examples/org/rdfhdt/hdt/examples/ExampleGenerate.java $
+ * Revision: $Rev: 191 $
+ * Last modified: $Date: 2013-03-03 11:41:43 +0000 (dom, 03 mar 2013) $
+ * Last modified by: $Author: mario.arias $
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Contacting the authors:
+ *   Mario Arias:               mario.arias@deri.org
+ *   Javier D. Fernandez:       jfergar@infor.uva.es
+ *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ *   Alejandro Andres:          fuzzy.alej@gmail.com
+ */
+
+package org.rdfhdt.hdt.example;
+import org.rdfhdt.hdt.enums.RDFNotation;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.header.Header;
+import org.rdfhdt.hdt.options.HDTSpecification;
+
+/**
+ * @author mario.arias
+ *
+ */
+public class ExampleGenerate {
+
+	public static void main(String[] args) throws Exception {
+		// Configuration variables
+		 String baseURI = "http://example.com/3.5";
+		//String rdfInput = "/nfsmnt/proto_space/dbpedia/3.5/dbpedia";
+		String rdfInput = "/nfsmnt/proto_space/dbpedia/3.5/dbpedia";
+		String inputType = "ntriples";
+		String hdtOutput = "/home/ludab/hdt-java/hdt-java-core/3_5_0.hdt";
+	 	
+		String configFile = "/home/ludab/hdt-java/hdt-java-core/hdt.cfg";
+		// Create HDT from RDF file
+		
+		HDT hdt = HDTManager.generateHDT(rdfInput, baseURI, RDFNotation.parse(inputType), new HDTSpecification(configFile), null);
+		
+		// Add additional domain-specific properties to the header:
+		//Header header = hdt.getHeader();
+		//header.insert("myResource1", "property" , "value");
+		
+		//System.out.println("now try to save to file"); 
+		// Save generated HDT to a file
+		hdt.saveToHDT(hdtOutput, null); 
+		
+		//HDT mhdt = HDTManager.loadHDT("/home/ludab/hdt-java/hdt-java-core/3_8_0.hdt", null);
+		
+		//HDT hdt = HDTManager.mapHDT(args[0], null);
+
+		
+		hdt = HDTManager.indexedHDT(hdt,null);
+		if (hdt!=null) {
+			hdt.close();
+		}
+			
+	}
+}


### PR DESCRIPTION
@luda171 updated java-hdt  to be able to process bigger files with 64 bit address space.
The problems with java-hdt were related to the fact that java's native array types use 32-bit int for length and indexing.
This means the maximum length of each array is   (2 power of 31 -1) ~ 2 billion elements.  
Also other java classes like ByteArrayOutputStream etc depend on arrays in the internal implementation, so they are fast becoming out of capacity.


All changes are in the hdt-java-core .
The patch  consists  of update of PFCDictionarySectionBig.java where I implemented  2 missed methods : load and save. I used the same array of array approach here as in the other methods already was present in this class.. 
Also I  added  SequenceLog64Jarray.java  where I ported code from  SequenceLog64.java   with  LongLargeArray class from pl.edu.icm.jlargearrays library. 

Right now the default dictionary is still the  FourSectionDictionary.java  I added  FourSectionDictionaryBig.java  which is based on two classes discussed above.
The  FourSectionDictionaryBig.java can be invoked with dictionary.type = dictionaryFourBig

I made example config  file   hdt.cfg in hdt-java-core .  After changing 
hdt-java/hdt-java-core/src/main/java/org/rdfhdt/hdt/example/ExampleGenerate.java to your local parameters you can test it with maven   /usr/bin/mvn -e exec:java

Also, just for reference to set java heap for maven

export MAVEN_OPTS=" -Xmx100G "