### PR TITLE
Fix Maven dependencies issues with hdt-jena-core and hdt-fuseki

### DIFF
--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -23,12 +23,11 @@
   		<artifactId>hdt-jena</artifactId>
   		<version>2.0</version>
   	</dependency>
-  	<dependency>
-  		<groupId>org.apache.jena</groupId>
-  		<artifactId>jena-fuseki</artifactId>
-  		<version>2.3.1</version>
-  		<type>pom</type>
-  	</dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-fuseki1</artifactId>
+        <version>1.4.0</version>
+    </dependency>
   </dependencies>
   
   

--- a/hdt-fuseki/src/main/java/org/rdfhdt/hdt/fuseki/FusekiHDTCmd.java
+++ b/hdt-fuseki/src/main/java/org/rdfhdt/hdt/fuseki/FusekiHDTCmd.java
@@ -27,7 +27,7 @@ import java.util.List;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.lib.StrUtils;
-import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.mgt.ManagementServer;
 import org.apache.jena.fuseki.server.FusekiConfig;
@@ -43,20 +43,20 @@ import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdtjena.HDTGraph;
 import org.slf4j.Logger;
 
-import arq.cmd.CmdException;
-import arq.cmdline.ArgDecl;
+import jena.cmd.CmdException;
+import jena.cmd.ArgDecl;
 import arq.cmdline.CmdARQ;
 import arq.cmdline.ModDatasetAssembler;
 
-import com.hp.hpl.jena.graph.Graph;
-import com.hp.hpl.jena.query.ARQ;
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.sparql.core.DatasetGraph;
-import com.hp.hpl.jena.sparql.core.DatasetGraphFactory;
-import com.hp.hpl.jena.sparql.core.DatasetGraphMap;
-import com.hp.hpl.jena.tdb.TDB;
-import com.hp.hpl.jena.tdb.TDBFactory;
-import com.hp.hpl.jena.tdb.transaction.TransactionManager;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.DatasetGraphMap;
+import org.apache.jena.tdb.TDB;
+import org.apache.jena.tdb.TDBFactory;
+import org.apache.jena.tdb.transaction.TransactionManager;
 
 /**
  * 
@@ -101,7 +101,7 @@ public class FusekiHDTCmd extends CmdARQ
     static {
         // Check if default command logging.
         if ( "set".equals(System.getProperty("log4j.configuration", "set") ) )
-            Log.resetLogging(log4Jsetup) ; 
+            LogCtl.resetLogging(log4Jsetup) ;
     }
     
     // Arguments:

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.rdfhdt</groupId>
 		<artifactId>hdt-java-parent</artifactId>
-		<version>1.1.1-SNAPSHOT</version>
+		<version>2.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	


### PR DESCRIPTION
Hello,
I cloned your library this morning and when I tried to build it, I noticed several issues with Maven dependencies in **hdt-jena-core** and **hdt-fuseki**. So, here is the fixes I propose to correct them.

The issues were the following :

### hdt-jena-core

The Maven reference for **hdt-java-parent** in the *pom.xml* file was using the wrong version number (1.1.1-SNAPSHOT instead of 2.0). I fix it by putting the correct number.

### hdt-fuseki

@bendiken open a pull request #8 to add a missing dependency to jena-fuseki for it, which correspond to the v2 of fuseki. But **hdt-fuseki** seems to use the fuseki v1, so I change the dependency to jena-fuseki1 14.0. This was the source of the issue #10 .
There was also an issue with the imports in *FusekiHDTCmd.java*. Most of the imported package were incorrect, since the content of the package `com.hp.hpl.jena.*` had been merged with the package `org.apache.jena.*` in a previous Jena version. I fix all the incorrect imports to use the good ones.

I tested **hdt-fuseki**, to ensure my modifications didn't break the software, by launching a Fuseki endpoint using the given config file *fuseki_example.ttl* with the data from *books.ttl*, compressed in the HDT format. I perform some request against the endpoint and everything seems to work as expected and I didn't notify any incorrect behavior.

Thank you for reviewing my modifications and have a nice day :octocat: 