### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryUtil.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryUtil.java
@@ -5,6 +5,9 @@ import org.rdfhdt.hdt.triples.TripleID;
 import org.rdfhdt.hdt.triples.TripleString;
 
 public class DictionaryUtil {
+	
+	private DictionaryUtil() {}
+	
 	/**
 	 * Converts a TripleID to a TripleString using a dictionary.
 	 * 

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTVocabulary.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTVocabulary.java
@@ -118,4 +118,6 @@ public class HDTVocabulary {
     // Misc
 	public static final String ORIGINAL_SIZE = HDT_BASE+"originalSize>";
 	public static final String HDT_SIZE = HDT_BASE+"hdtSize>";
+	
+	private HDTVocabulary() {}
 }

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/header/HeaderUtil.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/header/HeaderUtil.java
@@ -6,6 +6,9 @@ import org.rdfhdt.hdt.triples.IteratorTripleString;
 import org.rdfhdt.hdt.triples.TripleString;
 
 public class HeaderUtil {
+	
+	private HeaderUtil() {}
+	
 	public static String cleanURI(CharSequence str) {
 		String uri = str.toString();
 		if(uri!=null && uri.length()>=2 && uri.charAt(0)=='<' && uri.charAt(uri.length()-1)=='>') {

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/util/UnicodeEscape.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/util/UnicodeEscape.java
@@ -4,6 +4,9 @@ package org.rdfhdt.hdt.util;
 import java.io.IOException;
 
 public class UnicodeEscape {
+	
+	private UnicodeEscape() {}
+	
 	   /**
      * Checks whether the supplied character is a letter or number
      * according to the N-Triples specification.

--- a/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDTVerify.java
+++ b/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDTVerify.java
@@ -11,6 +11,8 @@ import org.rdfhdt.hdt.util.string.CompactString;
 public class HDTVerify {
 
 	private static Comparator<CharSequence> comparator = CharSequenceComparator.getInstance();
+	
+	private HDTVerify() {}
 
 	private static void print(byte[] arr) {
 		for (int i = 0; i < arr.length; i++) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/BitmapFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/BitmapFactory.java
@@ -37,6 +37,9 @@ import org.rdfhdt.hdt.exceptions.IllegalFormatException;
  *
  */
 public class BitmapFactory {
+	
+	private BitmapFactory() {}
+	
 	public static final byte TYPE_BITMAP_PLAIN = 1;
 	
 	public static Bitmap createBitmap(String type) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
@@ -48,6 +48,9 @@ import org.rdfhdt.hdt.util.Mutable;
  *
  */
 public class VByte {
+	
+	private VByte() {}
+	
 	public static void encode(OutputStream out, long value) throws IOException {
 		if(value<0) {
 			throw new IllegalArgumentException("Only can encode VByte of positive values");

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceFactory.java
@@ -45,6 +45,8 @@ public class SequenceFactory {
 	public static final byte TYPE_SEQ32 = 2;
 	public static final byte TYPE_SEQ64 = 3;
 	
+	private SequenceFactory() {}
+	
 	public static Sequence createStream(String name) {
 		if(name==null) {
 			return new SequenceLog64();

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryFactory.java
@@ -44,6 +44,7 @@ public class DictionaryFactory {
 
 	public static final String MOD_DICT_IMPL_HASH = "hash";
 
+	private DictionaryFactory() {}
 
 	/**
 	 * Creates a default dictionary (HashDictionary)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionFactory.java
@@ -42,6 +42,8 @@ import org.rdfhdt.hdt.util.io.CountInputStream;
  */
 public class DictionarySectionFactory {
 	
+	private DictionarySectionFactory() {}
+	
 	public static DictionarySectionPrivate loadFrom(InputStream input, ProgressListener listener) throws IOException {
 		if(!input.markSupported()) {
 			throw new IllegalArgumentException("Need support for mark()/reset(). Please wrap the InputStream with a BufferedInputStream");

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTFactory.java
@@ -40,6 +40,8 @@ import org.rdfhdt.hdt.options.HDTSpecification;
 public class HDTFactory {
 	private static TempDictTriplesFactory tempFactory=null;
 	
+	private HDTFactory() {}
+	
 	public static TempDictTriplesFactory getTempFactory() {
 		if(tempFactory==null) {
 			try {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/Iter.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/Iter.java
@@ -4,6 +4,8 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 public class Iter {
+	
+	private Iter() {}
 
 	public static <T, R> Iterable<R> mapIterable(final Iterable<T> iter1, final Transform<T, R> converter) {
 		return new Iterable<R>() {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/RDFParserFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/RDFParserFactory.java
@@ -39,6 +39,9 @@ import org.rdfhdt.hdt.rdf.parsers.RDFParserTar;
  *
  */
 public class RDFParserFactory {
+	
+	private RDFParserFactory() {}
+	
 	public static RDFParserCallback getParserCallback(RDFNotation notation) {
 		// NOTE: Very fast but does not validate input. Might not be fully NTriples spec compliant.
 		if(notation == RDFNotation.NTRIPLES) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesFactory.java
@@ -44,6 +44,7 @@ public class TriplesFactory {
 		
 	public static final String TEMP_TRIPLES_IMPL_LIST = "list";
 
+	private TriplesFactory() {}
 	
 	/**
 	 * Creates a new TempTriples (writable triples structure)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TripleOrderConvert.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TripleOrderConvert.java
@@ -93,6 +93,8 @@ public class TripleOrderConvert {
                 {true, false, false, false, false, true},
                 {false, false, true, false, true, false}
     };
+    
+    private TripleOrderConvert() {}
 	
 	public static void swapComponentOrder(TripleID triple, TripleComponentOrder from, TripleComponentOrder to) {
 		if(from==to) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/BitUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/BitUtil.java
@@ -32,6 +32,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class BitUtil {
+	
+	private BitUtil() {}
+	
 	/**
 	 * Number of bits needed to store up to n
 	 * @param n

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/ProfilingUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/ProfilingUtil.java
@@ -44,6 +44,8 @@ public class ProfilingUtil {
 
 	// field to store the hotspot diagnostic MBean 
 	private static volatile HotSpotDiagnosticMXBean hotspotMBean;
+	
+	private ProfilingUtil() {}
 
 	/**
 	 * Call this method from your application whenever you want to dump the heap snapshot into a file.

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/RDFInfo.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/RDFInfo.java
@@ -49,6 +49,8 @@ public class RDFInfo {
 	public static final String size_prop = "rdf.sizeInBytes";
 	public static final String triples_prop = "rdf.triples";
 	public static final String compression_prop = "rdf.expectedCompression";
+	
+	private RDFInfo() {}
 
 	/**
 	 * Fills the given HDTSpecification object with the given information about the (RDF)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/StringUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/StringUtil.java
@@ -38,6 +38,8 @@ import java.util.TimeZone;
  */
 public class StringUtil {
 	
+	private StringUtil() {}
+	
 	public static String getPercent(long v1, long max) {
 		if(max==0) {
 			return "%";

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
@@ -46,6 +46,9 @@ import org.rdfhdt.hdt.util.string.ByteStringUtil;
  *
  */
 public class IOUtil {
+	
+	private IOUtil() {}
+	
 	public static String readLine(InputStream in, char character) throws IOException {
 		ByteArrayOutputStream buf = new ByteArrayOutputStream();
 		while(true) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/listener/ListenerUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/listener/ListenerUtil.java
@@ -34,6 +34,9 @@ import org.rdfhdt.hdt.listener.ProgressListener;
  *
  */
 public class ListenerUtil {
+	
+	private ListenerUtil() {}
+	
 	public static void notify(ProgressListener listener, String message, float value, float total) {
 		if(listener!=null) {
 			listener.notifyProgress( ((value)*100/total), message);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ByteStringUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ByteStringUtil.java
@@ -39,6 +39,8 @@ import org.rdfhdt.hdt.exceptions.NotImplementedException;
  */
 public class ByteStringUtil {
 	
+	private ByteStringUtil() {}
+	
 	/**
 	 * For use in the project when using String.getBytes() and making Strings from byte[]
 	 */

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/UnicodeEscape.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/UnicodeEscape.java
@@ -3,6 +3,9 @@ package org.rdfhdt.hdt.util.string;
 import java.io.IOException;
 
 public class UnicodeEscape {
+	
+	private UnicodeEscape() {}
+	
 	   /**
      * Checks whether the supplied character is a letter or number
      * according to the N-Triples specification.

--- a/hdt-jena/src/main/java/org/apache/jena/graph/JenaNodeCreator.java
+++ b/hdt-jena/src/main/java/org/apache/jena/graph/JenaNodeCreator.java
@@ -38,6 +38,9 @@ import org.rdfhdt.hdtjena.CustomDatatype;
  *
  */
 public class JenaNodeCreator {
+	
+	private JenaNodeCreator() {}
+	
 	public static Node createAnon() {
 		return new Node_Blank( BlankNodeId.create() );
 	}

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/HDTJenaConstants.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/HDTJenaConstants.java
@@ -42,4 +42,6 @@ public class HDTJenaConstants {
 	
 	public static final Symbol REMOVE_DUPLICATES = Symbol.create(HDTJENA_NS+"removeDuplicates");
 	public static final Symbol FILTER_SYMBOL = Symbol.create(HDTJENA_NS+"filter");
+	
+	private HDTJenaConstants() {}
 }

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OptimizedCount.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OptimizedCount.java
@@ -65,6 +65,8 @@ SELECT count(distinct ?o) { A ?p ?o }		// Distinct only allowed for ? ? ?
 */
 public class OptimizedCount {
 	
+	private OptimizedCount() {}
+	
 	public static Plan getPlan(HDTQueryEngine engine, Query query, DatasetGraph dataset, Binding input, Context context) {
 		if( (query.getAggregators().size()!=1) )
 			return null;	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed