### PR TITLE
Code quality fix - "@Override" annotation should be used on any method overriding.

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionCache.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionCache.java
@@ -53,6 +53,7 @@ public class DictionarySectionCache implements DictionarySectionPrivate {
 	@SuppressWarnings("serial")
 	Map<CharSequence, Integer> cacheString = new LinkedHashMap<CharSequence,Integer>(CACHE_ENTRIES+1, .75F, true) {
 					    // This method is called just after a new entry has been added
+						@Override
 					    public boolean removeEldestEntry(Map.Entry<CharSequence,Integer> eldest) {
 					        return size() > CACHE_ENTRIES;
 					    }
@@ -61,6 +62,7 @@ public class DictionarySectionCache implements DictionarySectionPrivate {
 	@SuppressWarnings("serial")
 	Map<Integer, CharSequence> cacheID = new LinkedHashMap<Integer,CharSequence>(CACHE_ENTRIES+1, .75F, true) {
 						// This method is called just after a new entry has been added
+						@Override
 						public boolean removeEldestEntry(Map.Entry<Integer,CharSequence> eldest) {
 							return size() > CACHE_ENTRIES;
 						}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionCachePerThread.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionCachePerThread.java
@@ -53,9 +53,11 @@ public class DictionarySectionCachePerThread implements DictionarySectionPrivate
 	private ThreadLocal<Map<CharSequence,Integer>> cacheString =
 			new ThreadLocal<Map<CharSequence,Integer>>() {
 				@SuppressWarnings("serial")
+				@Override
 				protected java.util.Map<CharSequence,Integer> initialValue() {
 					return new LinkedHashMap<CharSequence,Integer>(CACHE_ENTRIES+1, .75F, true) {
 					    // This method is called just after a new entry has been added
+						@Override
 					    public boolean removeEldestEntry(Map.Entry<CharSequence,Integer> eldest) {
 					        return size() > CACHE_ENTRIES;
 					    }
@@ -66,9 +68,11 @@ public class DictionarySectionCachePerThread implements DictionarySectionPrivate
 	private ThreadLocal<Map<Integer,CharSequence>> cacheID =
 			new ThreadLocal<Map<Integer,CharSequence>>() {
 				@SuppressWarnings("serial")
+				@Override
 				protected java.util.Map<Integer,CharSequence> initialValue() {
 					return new LinkedHashMap<Integer,CharSequence>(CACHE_ENTRIES+1, .75F, true) {
 					    // This method is called just after a new entry has been added
+						@Override
 					    public boolean removeEldestEntry(Map.Entry<Integer,CharSequence> eldest) {
 					        return size() > CACHE_ENTRIES;
 					    }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/LRUCache.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/LRUCache.java
@@ -50,6 +50,7 @@ public class LRUCache<K,V> extends LinkedHashMap<K, V> {
 	}
 	
 	 // This method is called just after a new entry has been added
+	@Override
     public boolean removeEldestEntry(Map.Entry<K,V> eldest) {
         return size() > entries;
     }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/ByteBufferInputStream.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/ByteBufferInputStream.java
@@ -42,6 +42,7 @@ public class ByteBufferInputStream extends InputStream {
 		this.buf = buf;
 	}
 	
+	@Override
 	public synchronized int read() throws IOException {
         if (!buf.hasRemaining()) {
             return -1;
@@ -49,6 +50,7 @@ public class ByteBufferInputStream extends InputStream {
         return buf.get();
     }
 
+	@Override
     public synchronized int read(byte[] bytes, int off, int len) throws IOException {
     	if (!buf.hasRemaining()) {
             return -1;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/CompactString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/CompactString.java
@@ -77,6 +77,7 @@ public class CompactString implements CharSequence, Serializable, Comparable<Com
 		this.data = data;
 	}
 
+	@Override
 	public char charAt(int index) {
 		int ix = index;
 		if (ix >= data.length) {
@@ -85,10 +86,12 @@ public class CompactString implements CharSequence, Serializable, Comparable<Com
 		return (char) (data[ix] & 0xff);
 	}
 
+	@Override
 	public int length() {
 		return data.length;
 	}
 
+	@Override
 	public CharSequence subSequence(int start, int end) {
 		if (start < 0 || end > (this.length()) || (end-start)<0) {
 			throw new IllegalArgumentException("Illegal range " +
@@ -99,10 +102,12 @@ public class CompactString implements CharSequence, Serializable, Comparable<Com
 		return new CompactString(newdata);
 	}
 
+	@Override
 	public String toString() {
 		return new String(data, 0, data.length, ByteStringUtil.STRING_ENCODING);
 	}
 	
+	@Override
 	public int hashCode() {
 		// FNV Hash function: http://isthe.com/chongo/tech/comp/fnv/
 		if(hash==0){
@@ -116,6 +121,7 @@ public class CompactString implements CharSequence, Serializable, Comparable<Com
 		return hash;
 	}
 	
+	@Override
 	public boolean equals(Object o) {
 		if(o==null) {
 			return false;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
@@ -185,7 +185,8 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 	public int length() {
 		return used;
 	}
-	
+
+	@Override
 	public int hashCode() {
 		// FNV Hash function: http://isthe.com/chongo/tech/comp/fnv/
 		int hash = (int) 2166136261L; 				
@@ -197,7 +198,8 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 
 		return hash;
 	}
-	
+
+	@Override
 	public boolean equals(Object o) {
 		if(o==null) {
 			return false;
@@ -254,7 +256,8 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 		System.arraycopy(buffer, start, newdata, 0, end-start);
 		return new ReplazableString(newdata);
 	}
-	
+
+	@Override
 	public String toString() {
 		return new String(buffer, 0, used, ByteStringUtil.STRING_ENCODING);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - "@Override" annotation should be used on any method overriding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal Hameed