### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/util/UnicodeEscape.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/util/UnicodeEscape.java
@@ -28,7 +28,7 @@ public class UnicodeEscape {
      * the N-Triples specification. N-Triples numbers are 0 - 9.
      */
     private static boolean isNumber(int c) {
-        return (c >= 48 && c <= 57); // 0 - 9
+        return c >= 48 && c <= 57; // 0 - 9
     }
 
     /**

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375.java
@@ -145,7 +145,7 @@ public class Bitmap375 extends Bitmap64 implements ModifiableBitmap {
         	return false;
         }
         
-        return ((words[wordIndex] & (1L << bitIndex)) != 0);
+        return (words[wordIndex] & (1L << bitIndex)) != 0;
 	}
 	
 	public void set(long bitIndex, boolean value) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64.java
@@ -132,7 +132,7 @@ public class Bitmap64 {
         	return false;
         }
         
-        return ((words[wordIndex] & (1L << bitIndex)) != 0);
+        return (words[wordIndex] & (1L << bitIndex)) != 0;
 	}
 	
 	/* (non-Javadoc)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
@@ -86,7 +86,7 @@ public class SequenceLog64 implements DynamicSequence {
 	
 	/** longs required to represent "total" integers of "bitsField" bits each */
 	public static final long numWordsFor(int bitsField, long total) {
-		return ((bitsField*total+63)/64);
+		return (bitsField*total+63)/64;
 	}
 	
 	/** Number of bits required for last word */
@@ -145,7 +145,7 @@ public class SequenceLog64 implements DynamicSequence {
 		long mask = ~(~0L << bitsField) << j;
 		data[i] = (data[i] & ~mask) | (value << j);
 			
-		if((j+bitsField>W)) {
+		if(j+bitsField>W) {
 			mask = ~0L << (bitsField+j-W);
 			data[i+1] = (data[i+1] & mask) | value >>> (W-j);
 		}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/ProfilingUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/ProfilingUtil.java
@@ -130,14 +130,14 @@ public class ProfilingUtil {
 		char lastChar = property.charAt(property.length()-1);
 		
 		switch(lastChar){
-		case ('k'):
-		case ('K'):
+		case 'k':
+		case 'K':
 			return Long.parseLong(property.substring(0, property.length()-1))*1024;
-		case ('m'):
-		case ('M'):
+		case 'm':
+		case 'M':
 			return Long.parseLong(property.substring(0, property.length()-1))*1024*1024;
-		case ('g'):
-		case ('G'):
+		case 'g':
+		case 'G':
 			return Long.parseLong(property.substring(0, property.length()-1))*1024*1024*1024;
 		default:
 			return Long.parseLong(property);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/crc/CRC16.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/crc/CRC16.java
@@ -83,7 +83,7 @@ public class CRC16 implements CRC {
 	@Override
 	public boolean readAndCheck(InputStream in) throws IOException {
 		int readCRC = IOUtil.readShort(in)&0xFFFF;
-		return (readCRC==crc16);
+		return readCRC==crc16;
 	}
 
 	@Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/crc/CRC32.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/crc/CRC32.java
@@ -89,7 +89,7 @@ public class CRC32 implements CRC {
 	@Override
 	public boolean readAndCheck(InputStream in) throws IOException {
 		int readCRC = IOUtil.readInt(in);
-		return (readCRC== (crc32 ^ 0xFFFFFFFF));
+		return readCRC== (crc32 ^ 0xFFFFFFFF);
 	}
 
 	@Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
@@ -172,14 +172,14 @@ public class IOUtil {
 			n += count;
 		}
 
-		return ( ((long)readBuffer[7] << 56) +
+		return   ((long)readBuffer[7] << 56) +
 				 ((long)(readBuffer[6] & 255) << 48) +
 				 ((long)(readBuffer[5] & 255) << 40) +
 				 ((long)(readBuffer[4] & 255) << 32) +
 				 ((long)(readBuffer[3] & 255) << 24) +
 				 ((readBuffer[2] & 255) << 16) +
 				 ((readBuffer[1] & 255) <<  8) +
-				 ((readBuffer[0] & 255))
+				 ((readBuffer[0] & 255)
 			);
 	}
 
@@ -223,7 +223,7 @@ public class IOUtil {
 		int ch4 = in.read();
 		if ((ch1 | ch2 | ch3 | ch4) < 0)
 			throw new EOFException();
-		return ((ch4 << 24) + (ch3 << 16) + (ch2 << 8) + (ch1 << 0));
+		return (ch4 << 24) + (ch3 << 16) + (ch2 << 8) + (ch1 << 0);
 	}
 
 	/**
@@ -232,7 +232,7 @@ public class IOUtil {
 	 * @return
 	 */
 	public static int byteArrayToInt(byte[] value){
-		return ((value[3] << 24) + (value[2] << 16) + (value[1] << 8) + (value[0] << 0));
+		return (value[3] << 24) + (value[2] << 16) + (value[1] << 8) + (value[0] << 0);
 	}
 
 	/**

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/CompactString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/CompactString.java
@@ -139,7 +139,7 @@ public class CompactString implements CharSequence, Serializable, Comparable<Com
 			return true;
 		} else if (o instanceof CharSequence) {
 			CharSequence other = (CharSequence) o;
-			return (length()==other.length() && CharSequenceComparator.getInstance().compare(this, other)==0);
+			return length()==other.length() && CharSequenceComparator.getInstance().compare(this, other)==0;
 		}
 		throw new NotImplementedException();
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
@@ -235,7 +235,7 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 			return true;
 		} else if (o instanceof CharSequence) {
 			CharSequence other = (CharSequence) o;
-			return (length()==other.length() && CharSequenceComparator.getInstance().compare(this, other)==0);
+			return length()==other.length() && CharSequenceComparator.getInstance().compare(this, other)==0;
 		}
 		throw new NotImplementedException();
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/UnicodeEscape.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/UnicodeEscape.java
@@ -27,7 +27,7 @@ public class UnicodeEscape {
      * the N-Triples specification. N-Triples numbers are 0 - 9.
      */
     public static boolean isNumber(int c) {
-        return (c >= 48 && c <= 57); // 0 - 9
+        return c >= 48 && c <= 57; // 0 - 9
     }
 
     /**

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OpExecutorHDT.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OpExecutorHDT.java
@@ -70,7 +70,7 @@ public class OpExecutorHDT extends OpExecutor {
 	protected OpExecutorHDT(ExecutionContext execCtx) {
 		super(execCtx);
 		
-		isForHDT = (execCtx.getActiveGraph() instanceof HDTGraph) ;
+		isForHDT = execCtx.getActiveGraph() instanceof HDTGraph ;
 	}
 	
     @Override

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OptimizedCount.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OptimizedCount.java
@@ -66,7 +66,7 @@ SELECT count(distinct ?o) { A ?p ?o }		// Distinct only allowed for ? ? ?
 public class OptimizedCount {
 	
 	public static Plan getPlan(HDTQueryEngine engine, Query query, DatasetGraph dataset, Binding input, Context context) {
-		if( (query.getAggregators().size()!=1) )
+		if(query.getAggregators().size()!=1)
 			return null;	
 			
 		// Must be count aggregator without "having" nor "group by"
@@ -184,7 +184,7 @@ public class OptimizedCount {
 			
 			// SELECT count(?s) { ?s ?p ?o }
 			// At least one variable must be the output
-			if( (ag instanceof AggCountVar) ) {
+			if(ag instanceof AggCountVar) {
 				ExprList exprList = ag.getExprList();
 				if(exprList.size()!=1) {
 					return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed