### PR TITLE
Code quality fix - "switch" statements should end with a "default" clause.

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceFactory.java
@@ -69,8 +69,9 @@ public class SequenceFactory {
 			return new SequenceInt32();
 		case TYPE_SEQ64:
 			return new SequenceLog64();
-		}
-		throw new IllegalFormatException("Implementation not found for Sequence with code "+type);
+		default :
+			throw new IllegalFormatException("Implementation not found for Sequence with code "+type);
+		}		
 	}
 	
 	public static Sequence createStream(CountInputStream input, File f) throws IOException {
@@ -85,8 +86,9 @@ public class SequenceFactory {
 		case TYPE_SEQ64:
 //			return new SequenceLog64();
 			throw new NotImplementedException();
+		default:
+			throw new IllegalFormatException("Implementation not found for Sequence with code "+type);
 		}
-		throw new IllegalFormatException("Implementation not found for Sequence with code "+type);
 	}
 	
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/BaseDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/BaseDictionary.java
@@ -65,9 +65,9 @@ public abstract class BaseDictionary implements DictionaryPrivate {
 		case PREDICATE:
 		case SHARED:	                
 			return id;
+		default:
+			throw new IllegalArgumentException();
 		}
-
-		throw new IllegalArgumentException();
 	}
 
 	protected int getLocalId(int id, TripleComponentRole position) {
@@ -81,9 +81,9 @@ public abstract class BaseDictionary implements DictionaryPrivate {
 			}
 		case PREDICATE:
 			return id;
+		default:
+			throw new IllegalArgumentException();
 		}
-
-		throw new IllegalArgumentException();
 	}
 	
 	/* (non-Javadoc)
@@ -131,8 +131,9 @@ public abstract class BaseDictionary implements DictionaryPrivate {
 				return getGlobalId(ret, DictionarySectionRole.OBJECT);
 			}
 			return -1;
+		default:
+			throw new IllegalArgumentException();
 		}
-		throw new IllegalArgumentException();
 	}	
 	
 	@Override
@@ -201,8 +202,9 @@ public abstract class BaseDictionary implements DictionaryPrivate {
 			} else {
 				return (DictionarySectionPrivate)objects;
 			}
+		default:
+			throw new IllegalArgumentException();
 		}
-		throw new IllegalArgumentException();
 	}
 
 	/* (non-Javadoc)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/BaseTempDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/BaseTempDictionary.java
@@ -73,8 +73,9 @@ public abstract class BaseTempDictionary implements TempDictionary {
 		case OBJECT:
 			isOrganized = false;
 			return ((TempDictionarySection)objects).add(str);
+		default:
+			throw new IllegalArgumentException();
 		}
-		throw new IllegalArgumentException();
 	}
 
 	@Override
@@ -162,9 +163,9 @@ public abstract class BaseTempDictionary implements TempDictionary {
 		case PREDICATE:
 		case SHARED:	                
 			return id;
+		default:
+			throw new IllegalArgumentException();
 		}
-
-		throw new IllegalArgumentException();
 	}
 	
 	/* (non-Javadoc)
@@ -205,7 +206,8 @@ public abstract class BaseTempDictionary implements TempDictionary {
 				return getGlobalId(ret, DictionarySectionRole.OBJECT);
 			}
 			return -1;
+		default:
+			throw new IllegalArgumentException();
 		}
-		throw new IllegalArgumentException();
 	}	
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionFactory.java
@@ -65,8 +65,9 @@ public class DictionarySectionFactory {
 				section.load(input, listener);
 			}
 			return section;
+		default:
+			throw new IOException("DictionarySection implementation not available for id "+dictType);
 		}
-		throw new IOException("DictionarySection implementation not available for id "+dictType);
 	}
 	
 	public static DictionarySectionPrivate loadFrom(CountInputStream input, File f, ProgressListener listener) throws IOException {
@@ -81,7 +82,8 @@ public class DictionarySectionFactory {
 			DictionarySectionPrivate section= new PFCDictionarySectionMap(input, f);
 
 			return section;
+		default:
+			throw new IOException("DictionarySection implementation not available for id "+dictType);
 		}
-		throw new IOException("DictionarySection implementation not available for id "+dictType);
 	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/RoleIteratorTripleID.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/RoleIteratorTripleID.java
@@ -77,9 +77,10 @@ public class RoleIteratorTripleID implements Iterator<Integer> {
 			return iterator.next().getPredicate();
 		case OBJECT:
 			return iterator.next().getObject();
+		default:
+			// Never reached
+			return 0;
 		}
-		// Never reached
-		return 0;
 	}
 
 	/*


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.
 
Faisal Hameed