### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
@@ -151,7 +151,7 @@ public final class TripleID implements Comparable<TripleID> {
 	 */
 	@Override
 	public String toString() {
-		return "" + subject + " " + predicate + " " + object;
+		return Integer.toString(subject) + " " + predicate + " " + object;
 	}
 	
 	public boolean equals(TripleID other) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/ProfilingUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/ProfilingUtil.java
@@ -97,19 +97,19 @@ public class ProfilingUtil {
 		if (size >= 1024 * 1024 * 1024)
 		{
 			calcSize = (long) (((double)size) / (1024 * 1024 * 1024));
-			str = ""+calcSize +"GB";
+			str = Long.toString(calcSize) +"GB";
 		}
 		else if (size>= 1024 * 1024) {
 			calcSize = (long) (((double)size) / (1024 * 1024 ));
-			str = ""+ calcSize +"MB";
+			str = Long.toString(calcSize) +"MB";
 		}
 		else if (size>= 1024) {
 			calcSize = (long) (((double)size) / (1024));
-			str = ""+ calcSize +"KB";
+			str = Long.toString(calcSize) +"KB";
 		}
 		else {
 			calcSize = size;
-			str = ""+ calcSize +"B";
+			str = Long.toString(calcSize) +"B";
 		}
 		return str;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed