### PR TITLE
Code quality fix - Declarations should use Java collection interfaces such as "List" rather than specific implementation.

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/DeflateIntegerIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/DeflateIntegerIterator.java
@@ -30,7 +30,7 @@ package org.rdfhdt.hdt.compact.sequence;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Iterator;
 import java.util.zip.InflaterInputStream;
 
@@ -40,11 +40,11 @@ import java.util.zip.InflaterInputStream;
  */
 public class DeflateIntegerIterator implements Iterator<Integer> {
 
-	protected ArrayList<byte[]> buffer;
+	protected List<byte[]> buffer;
 	protected DataInputStream stream;
 	int current, next;
 	
-	public DeflateIntegerIterator(ArrayList<byte[]> buffer) {
+	public DeflateIntegerIterator(List<byte[]> buffer) {
 		this.buffer = buffer;
 	}
 	

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
@@ -30,7 +30,7 @@ package org.rdfhdt.hdt.compact.sequence;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Iterator;
 
 import org.rdfhdt.hdt.exceptions.IllegalFormatException;
@@ -170,7 +170,7 @@ public class SequenceInt32 implements DynamicSequence {
 		}
 	}
 
-	public void addIntegers(ArrayList<Integer> elements) {
+	public void addIntegers(List<Integer> elements) {
 		for (int i=0;i<elements.size();i++){
 			long value = elements.get(i).longValue();
 			append(value);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
@@ -30,7 +30,7 @@ package org.rdfhdt.hdt.compact.sequence;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -187,7 +187,7 @@ public class SequenceLog64 implements DynamicSequence {
         }
 	}
 
-	public void addIntegers(ArrayList<Integer> elements) {
+	public void addIntegers(List<Integer> elements) {
 		long max = 0;
 		numentries = 0;
 		


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319

Please let me know if you have any questions.

Faisal Hameed