### PR TITLE
HDTGraphAssembler : add static initialization

### DIFF
--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/HDTGraphAssembler.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/HDTGraphAssembler.java
@@ -74,4 +74,8 @@ public class HDTGraphAssembler extends AssemblerBase implements Assembler {
 			throw new AssemblerException(root, "Error reading HDT file: "+file+" / "+e.toString());
 		}
 	}
+
+	static {
+		init();
+	}
 }


### PR DESCRIPTION
To make the assembler compatible with jena-spatial, it must be initialized during class loading.
