### PR TITLE
Support CONSTRUCT/DESCRIBE/ASK in hdtsparql command line tool

### DIFF
--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
@@ -22,7 +22,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 
 public class HDTSparql {
 	/**
-	 * HDTSparql, receives a SPARQL SELECT query and executes it against an HDT file.
+	 * HDTSparql, receives a SPARQL query and executes it against an HDT file.
 	 * @param args
 	 */
 	public static void main(String[] args) throws Throwable {
@@ -47,15 +47,20 @@ public class HDTSparql {
 			QueryExecution qe = QueryExecutionFactory.create(query, model);
 
 			try {
-				// FIXME: Do ASK/DESCRIBE/CONSTRUCT 
-				ResultSet results = qe.execSelect();
-
-				/*while(results.hasNext()) {
-				QuerySolution sol = results.nextSolution();
-				System.out.println(sol.toString());
-				}*/
-				// Output query results	
-				ResultSetFormatter.outputAsCSV(System.out, results);
+				// Perform the query and output the results, depending on query type
+				if (query.isSelectType()) {
+					ResultSet results = qe.execSelect();
+					ResultSetFormatter.outputAsCSV(System.out, results);
+				} else if (query.isDescribeType()) {
+					Model result = qe.execDescribe();
+					result.write(System.out, "N-TRIPLES", null);
+				} else if (query.isConstructType()) {
+					Model result = qe.execConstruct();
+					result.write(System.out, "N-TRIPLES", null);
+				} else if (query.isAskType()) {
+					boolean b = qe.execAsk();
+					System.out.println(b);
+				}
 			} finally {
 				qe.close();				
 			}


### PR DESCRIPTION
I wanted to perform a CONSTRUCT query against a HDT file but found that the hdtsparql command line tool only supports SELECT queries. I extended it to support CONSTRUCT, DESCRIBE and ASK queries as well.

This is very simplistic as the output formats are hardwired (N-Triples for CONSTRUCT/DESCRIBE, and a simple true/false string for ASK). It would be ideal to add a command line option for selecting the output format, but that is beyond the scope of this PR.
