### PR TITLE
Move Maven dependency version specs into parent pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 hdt-fuseki/config-hdt.ttl
+
+# IntelliJ IDEA project files
+.idea
+*.iml

--- a/hdt-api/pom.xml
+++ b/hdt-api/pom.xml
@@ -9,7 +9,6 @@
 	    <groupId>org.rdfhdt</groupId>
 	    <artifactId>hdt-java-parent</artifactId>
 	    <version>2.0-SNAPSHOT</version>
-	    <relativePath>../</relativePath>
 	</parent>
 	  
   	<licenses>

--- a/hdt-api/pom.xml
+++ b/hdt-api/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 	    <groupId>org.rdfhdt</groupId>
 	    <artifactId>hdt-java-parent</artifactId>
-	    <version>2.0</version>
+	    <version>2.0-SNAPSHOT</version>
 	    <relativePath>../</relativePath>
 	</parent>
 	  
@@ -21,17 +21,4 @@
 		</license>
 	</licenses>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
-    <version>2.0</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -16,42 +16,36 @@
   	<dependency>
   		<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-jena</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
-        <version>3.0.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.0.1</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-api</artifactId>
-        <version>2.0</version>
+        <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-tdb</artifactId>
-        <version>3.0.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-core</artifactId>
-        <version>3.0.1</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.12</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki1</artifactId>
-        <version>1.3.0</version>
     </dependency>
 
   </dependencies>
@@ -59,21 +53,10 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-
             <!-- The configuration of maven-assembly-plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <!-- The configuration of the plugin -->
                 <configuration>
                     <!-- Specifies the configuration file of the assembly plugin -->

--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -9,7 +9,6 @@
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
     <version>2.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <dependencies>

--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -11,6 +11,10 @@
     <version>2.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <jdk.version>${jena-jdk.version}</jdk.version>
+  </properties>
+
   <dependencies>
   	<dependency>
   		<groupId>org.rdfhdt</groupId>

--- a/hdt-java-cli/pom.xml
+++ b/hdt-java-cli/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
-    <version>2.0</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -16,25 +16,17 @@
   	<dependency>
   		<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-java-core</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-api</artifactId>
-        <version>2.0</version>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>com.beust</groupId>
+        <artifactId>jcommander</artifactId>
     </dependency>
   </dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+
 </project>

--- a/hdt-java-cli/pom.xml
+++ b/hdt-java-cli/pom.xml
@@ -9,7 +9,6 @@
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
     <version>2.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <dependencies>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-java-parent</artifactId>
-        <version>2.0</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 	
@@ -25,60 +25,40 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-            <version>1.32</version>
         </dependency>
         <dependency>
             <groupId>org.rdfhdt</groupId>
             <artifactId>hdt-api</artifactId>
-            <version>2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-base</artifactId>
-            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>pl.edu.icm</groupId>
             <artifactId>JLargeArrays</artifactId>
-            <version>1.6</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
                 <configuration>
                     <mainClass>org.rdfhdt.hdt.example.ExampleGenerate</mainClass>
                 </configuration>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -9,7 +9,6 @@
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-java-parent</artifactId>
         <version>2.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 	
     <licenses>

--- a/hdt-java-package/pom.xml
+++ b/hdt-java-package/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
-    <version>2.0</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   
@@ -16,22 +16,22 @@
   	<dependency>
   		<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-api</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
   	<dependency>
   	<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-java-core</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
   	<dependency>
   	<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-java-cli</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
   	<dependency>
   	<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-jena</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
   </dependencies>
   
@@ -41,7 +41,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <!-- The configuration of the plugin -->
                 <configuration>
                     <!-- Specifies the configuration file of the assembly plugin -->

--- a/hdt-java-package/pom.xml
+++ b/hdt-java-package/pom.xml
@@ -9,7 +9,6 @@
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
     <version>2.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   
   <dependencies>

--- a/hdt-java-package/pom.xml
+++ b/hdt-java-package/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>hdt-java-parent</artifactId>
     <version>2.0-SNAPSHOT</version>
   </parent>
-  
+
   <dependencies>
   	<dependency>
   		<groupId>org.rdfhdt</groupId>

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
-    <version>2.0</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -16,46 +16,30 @@
   	<dependency>
   		<groupId>org.rdfhdt</groupId>
   		<artifactId>hdt-java-core</artifactId>
-  		<version>2.0</version>
+  		<version>${project.version}</version>
   	</dependency>
   	<dependency>
   		<groupId>org.apache.jena</groupId>
   		<artifactId>jena-core</artifactId>
-  		<version>3.0.1</version>
   	</dependency>
 	<dependency>
 	    <groupId>org.apache.jena</groupId>
 		<artifactId>jena-arq</artifactId>
-		<version>3.0.1</version>
 	</dependency>
 	<dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-	    <version>4.11</version>
+	<scope>test</scope>
 	</dependency>
 	<dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.0.1</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-api</artifactId>
-        <version>2.0</version>
+        <version>${project.version}</version>
     </dependency>
   </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -9,7 +9,6 @@
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
     <version>2.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <dependencies>

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -11,6 +11,10 @@
     <version>2.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <jdk.version>${jena-jdk.version}</jdk.version>
+  </properties>
+
   <dependencies>
   	<dependency>
   		<groupId>org.rdfhdt</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <jdk.version>1.7</jdk.version>
+
     <jena.version>3.0.1</jena.version>
+    <jena-jdk.version>1.8</jena-jdk.version>
   </properties>
 
   <scm>
@@ -180,8 +183,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>hdt-java-parent</artifactId>
   <packaging>pom</packaging>
   <name>RDF/HDT</name>
-  <version>2.0</version>
+  <version>2.0-SNAPSHOT</version>
   <description>HDT (Header, Dictionary, Triples) is a compact data structure and binary serialization format for RDF that keeps big datasets compressed to save space while maintaining search and browse operations without prior decompression. This makes it an ideal format for storing and sharing RDF datasets on the Web.</description>
   <url>http://www.rdfhdt.org/</url>
 
@@ -32,12 +32,14 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <jena.version>3.0.1</jena.version>
   </properties>
 
   <scm>
-    <connection>scm:git:https://code.google.com/p/hdt-java/ </connection>
-    <developerConnection>scm:git:https://code.google.com/p/hdt-java/</developerConnection>
-    <url>http://code.google.com/p/hdt-java/source/browse</url>
+    <connection>scm:git:git://github.com/rdfhdt/hdt-java.git</connection>
+    <developerConnection>scm:git:git@github.com:rdfhdt/hdt-java.git</developerConnection>
+    <url>https://github.com/rdfhdt/hdt-java</url>
   </scm>
 
 <developers>
@@ -85,5 +87,116 @@
     <system>Google Code</system>
     <url>https://code.google.com/p/hdt-java/issues/list</url>
   </issueManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.beust</groupId>
+        <artifactId>jcommander</artifactId>
+        <version>1.32</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-arq</artifactId>
+        <version>${jena.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-base</artifactId>
+        <version>${jena.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-cmds</artifactId>
+        <version>${jena.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-core</artifactId>
+        <version>${jena.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-fuseki1</artifactId>
+        <version>1.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-tdb</artifactId>
+        <version>${jena.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.12</version>
+      </dependency>
+      <dependency>
+        <groupId>pl.edu.icm</groupId>
+        <artifactId>JLargeArrays</artifactId>
+        <version>1.6</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.2.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
Maven best practice is to specify dependency versions in the parent pom to help ensure all modules use the same versions of dependencies.

Also, performed a little Maven cleanup, including the following:

* Changed the project version from `2.0` to `2.0-SNAPSHOT`.  Although `2.1-SNAPSHOT` might be a better choice.

* Changed the JUnit dependency scope from `compile` to `test`.

* `hdt-java-core` no longer depends on JCommander.

* Updated `maven-compiler-plugin` config to reflect the fact that `hdt-java-core` requires Java 7 to compile and all Jena code requires Java 8 to compile.  I did not move `hdt-api` and `hdt-java-core` up to Java 8 yet to avoid possibly breaking `hdt-mr` w/old versions of Hadoop.