### PR TITLE
HDT format identifier uses only HDT version.

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTVocabulary.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTVocabulary.java
@@ -34,8 +34,7 @@ package org.rdfhdt.hdt.hdt;
 public class HDTVocabulary {
 	// Base
 	public static final String HDT_BASE = "<http://purl.org/HDT/hdt#";
-	public static final String HDT_CONTAINER = HDT_BASE+"HDT" + HDTVersion.get_version_string("-") + ">";
-	public static final String HDT_CONTAINER_BASE = HDT_BASE+"HDTv" + HDTVersion.HDT_VERSION;
+	public static final String HDT_CONTAINER = HDT_BASE+"HDTv" + HDTVersion.HDT_VERSION+">";
 	 
 	public static final String HDT_HEADER = HDT_BASE+"header";
 	public static final String HDT_DICTIONARY_BASE = HDT_BASE+"dictionary";

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -140,8 +140,7 @@ public class HDTImpl implements HDTPrivate {
 		ci.clear();
 		ci.load(input);
 		String hdtFormat = ci.getFormat();
-		//if(!hdtFormat.equals(HDTVocabulary.HDT_CONTAINER)) {
-		if (!hdtFormat.contains(HDTVocabulary.HDT_CONTAINER_BASE)){			
+		if(!hdtFormat.equals(HDTVocabulary.HDT_CONTAINER)) {
 			throw new IllegalFormatException("This software (v" + HDTVersion.HDT_VERSION + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
 		}
 
@@ -220,7 +219,7 @@ public class HDTImpl implements HDTPrivate {
 		ci.clear();
 		ci.load(input);
 		String hdtFormat = ci.getFormat();
-		if (!hdtFormat.contains(HDTVocabulary.HDT_CONTAINER_BASE)){			
+		if(!hdtFormat.equals(HDTVocabulary.HDT_CONTAINER)) {
 			throw new IllegalFormatException("This software (v" + HDTVersion.HDT_VERSION + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
 		}
 


### PR DESCRIPTION
**Issue: HDT files produced by the current master cannot be read by other HDT libraries, nor an earlier version of this library, and unnecessarily so.**

Starting with 1e62eb178e503c717e53aa45a38bf3114cd5d3b9, HDT files were being written with a format IRI of `http://purl.org/HDT/hdt#HDTv1-1-2`. This unnecessarily breaks compatibility with existing HDT libraries, which expect the version URL to be `http://purl.org/HDT/hdt#HDTv1`. Since the version number indicates `HDT_version.index_version.release`, only the first component matters to the HDT file itself. This commit reverts the version IRI to `http://purl.org/HDT/hdt#HDTv1`, restoring backward compatibility with other HDT libraries. It also reverts the version detection code to simple equality.

Partially reverts 1e62eb178e503c717e53aa45a38bf3114cd5d3b9.

Also see https://github.com/rdfhdt/hdt-cpp/pull/43.