### PR TITLE
Fix hdt2rdf usage message. Fixes #38

### DIFF
--- a/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDT2RDF.java
+++ b/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDT2RDF.java
@@ -46,7 +46,7 @@ import com.beust.jcommander.internal.Lists;
  *
  */
 public class HDT2RDF implements ProgressListener {
-	@Parameter(description = "<input RDF> <output HDT>")
+	@Parameter(description = "<input HDT> <output NT>")
 	public List<String> parameters = Lists.newArrayList();
 	
 	@Parameter(names = "-version", description = "Prints the HDT version number")


### PR DESCRIPTION
This PR fixes the order of parameters in the usage message and makes it obvious that the output file is always in N-Triples format.