### PR TITLE
Fix invalid cast that breaks lookup of non-ASCII literals. Fixes #36

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
@@ -175,7 +175,7 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 	 */
 	@Override
 	public char charAt(int index) {
-		return (char)buffer[index];
+		return (char)(buffer[index] & 0xFF);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
See issue #36 for a description of the problem that this PR fixes.