### PR TITLE
Proposed fix for problem with handling nodes that don't exist in HDT in bindings.

### DIFF
--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/HDTSolverLib.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/HDTSolverLib.java
@@ -131,7 +131,7 @@ public class HDTSolverLib
 		if(id>0) {
 			return new HDTId(id, TripleComponentRole.OBJECT, dict);
 		}
-		return null; // NOT FOUND
+		return new HDTId(id, null, dict); // NOT FOUND
 	}
 	
 	// Conversions


### PR DESCRIPTION
hdtjena seems to have problems with handling nodes that have been bound to variables in SPARQL using BIND or VALUES, but don't actually exist within the HDT dictionary. This is an attempt at fixing the problem, but I'm not at all sure that it's the correct approach. It seems to fix the particular issue I had (#37) but there may be side effects such as NPEs in other code paths. The unit tests that do exist seem to pass though.