### PR TITLE
Add streaming option to hdtsparql for CONSTRUCT and DESCRIBE queries (#42)

### DIFF
--- a/hdt-java-package/bin/hdtsparql.sh
+++ b/hdt-java-package/bin/hdtsparql.sh
@@ -2,9 +2,14 @@
 
 source `dirname $0`/javaenv.sh
 
+if [[ $1 =~ ^- ]]; then
+	export option=$1
+	shift
+fi
+
 export hdtFile=$1
 shift
 
-$JAVA $JAVA_OPTIONS -cp $CP:$CLASSPATH org.rdfhdt.hdtjena.cmd.HDTSparql $hdtFile "$*"
+$JAVA $JAVA_OPTIONS -cp $CP:$CLASSPATH org.rdfhdt.hdtjena.cmd.HDTSparql $option "$hdtFile" "$*"
 
 exit $?

--- a/hdt-jena/bin/hdtsparql.sh
+++ b/hdt-jena/bin/hdtsparql.sh
@@ -2,8 +2,13 @@
 
 source `dirname $0`/javaenv.sh
 
+if [[ $1 =~ ^- ]]; then
+	export option=$1
+	shift
+fi
+
 export hdtFile=$1
 shift
-mvn exec:java -Dexec.mainClass="org.rdfhdt.hdtjena.cmd.HDTSparql" -Dexec.args="$hdtFile '$1'"
+mvn exec:java -Dexec.mainClass="org.rdfhdt.hdtjena.cmd.HDTSparql" -Dexec.args="$option $hdtFile '$1'"
 
 exit $?

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
@@ -38,7 +38,7 @@ public class HDTSparql {
 	@Parameter(description = "<HDT file> <SPARQL query>")
 	public List<String> parameters = Lists.newArrayList();
 
-	@Parameter(names="-stream", description="Output CONSTRUCT/DESCRIBE query results directly as they are generated")
+	@Parameter(names="--stream", description="Output CONSTRUCT/DESCRIBE query results directly as they are generated")
 	public boolean streamMode = false;
 
 	public String fileHDT;

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
@@ -5,6 +5,13 @@ import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdtjena.HDTGraph;
 
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.internal.Lists;
+
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -21,19 +28,13 @@ import org.apache.jena.rdf.model.ModelFactory;
  */
 
 public class HDTSparql {
-	/**
-	 * HDTSparql, receives a SPARQL query and executes it against an HDT file.
-	 * @param args
-	 */
-	public static void main(String[] args) throws Throwable {
-		if (args.length != 2) {
-			System.err.println("Usage: hdtsparql <hdt input> <SPARQL Query>.");
-			System.exit(1);
-		}
+	@Parameter(description = "<HDT file> <SPARQL query>")
+	public List<String> parameters = Lists.newArrayList();
 
-		String fileHDT = args[0];
-		String sparqlQuery = args[1];
+	public String fileHDT;
+	public String sparqlQuery;
 
+	public void execute() throws IOException {
 		// Create HDT
 		HDT hdt = HDTManager.mapIndexedHDT(fileHDT, null);
 
@@ -68,5 +69,25 @@ public class HDTSparql {
 			// Close
 			hdt.close();
 		}
+	}
+
+	/**
+	 * HDTSparql, receives a SPARQL query and executes it against an HDT file.
+	 * @param args
+	 */
+	public static void main(String[] args) throws Throwable {
+		HDTSparql hdtSparql = new HDTSparql();
+		JCommander com = new JCommander(hdtSparql, args);
+		com.setProgramName("hdtsparql");
+
+		if (hdtSparql.parameters.size() != 2) {
+			com.usage();
+			System.exit(1);
+		}
+
+		hdtSparql.fileHDT = hdtSparql.parameters.get(0);
+		hdtSparql.sparqlQuery = hdtSparql.parameters.get(1);
+
+		hdtSparql.execute();
 	}
 }


### PR DESCRIPTION
This PR implements #42 i.e. adds a `-stream` option to the `hdtsparql` command line tool which causes it to return CONSTRUCT and DESCRIBE query results in a streaming fashion, as they are generated by the query engine. There is an attempt to suppress duplicate triples using a 1000-slot cache to check for already emitted triples, but of course, some duplicate triples may still occur in the output.