### PR TITLE
Upgrade Jena to version 3.2.0 (#44)

### DIFF
--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -21,12 +21,12 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>
@@ -36,12 +36,12 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-tdb</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-core</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
@@ -51,7 +51,7 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki1</artifactId>
-        <version>1.4.1</version>
+        <version>1.5.0</version>
     </dependency>
 
   </dependencies>

--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
@@ -36,7 +36,7 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-tdb</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
@@ -51,7 +51,7 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki1</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </dependency>
 
   </dependencies>

--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -21,12 +21,12 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>
@@ -36,12 +36,12 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-tdb</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-core</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
@@ -51,7 +51,7 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki1</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0</version>
     </dependency>
 
   </dependencies>

--- a/hdt-fuseki/pom.xml
+++ b/hdt-fuseki/pom.xml
@@ -21,12 +21,12 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>
@@ -36,12 +36,12 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-tdb</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-core</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
@@ -51,7 +51,7 @@
     <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki1</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
     </dependency>
 
   </dependencies>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.1.1</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.1.1</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-base</artifactId>
-            <version>3.1.1</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>pl.edu.icm</groupId>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-base</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>pl.edu.icm</groupId>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-base</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>pl.edu.icm</groupId>

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/IteratorConcat.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/IteratorConcat.java
@@ -18,12 +18,12 @@
 
 package org.rdfhdt.hdt.iterator.utils;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.apache.jena.atlas.iterator.IteratorCons;
-import org.apache.jena.atlas.lib.DS;
 
 /** Iterator of Iterators */
 
@@ -32,7 +32,7 @@ public class IteratorConcat<T> implements Iterator<T>
     // No - we don't really need IteratorCons and IteratorConcat
     // Historical.
     
-    private List<Iterator<T>> iterators = DS.list(); 
+    private List<Iterator<T>> iterators = new ArrayList<>(); 
     int idx = -1 ;
     private Iterator<T> current;
     private Iterator<T> removeFrom;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRIOT.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRIOT.java
@@ -30,12 +30,8 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.jena.atlas.lib.Tuple;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Node_Literal;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -21,12 +21,12 @@
   	<dependency>
   		<groupId>org.apache.jena</groupId>
   		<artifactId>jena-core</artifactId>
-  		<version>3.1.0</version>
+  		<version>3.1.1</version>
   	</dependency>
 	<dependency>
 	    <groupId>org.apache.jena</groupId>
 		<artifactId>jena-arq</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1</version>
 	</dependency>
 	<dependency>
         <groupId>junit</groupId>
@@ -36,7 +36,7 @@
 	<dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -21,12 +21,12 @@
   	<dependency>
   		<groupId>org.apache.jena</groupId>
   		<artifactId>jena-core</artifactId>
-  		<version>3.1.1</version>
+  		<version>3.2.0</version>
   	</dependency>
 	<dependency>
 	    <groupId>org.apache.jena</groupId>
 		<artifactId>jena-arq</artifactId>
-		<version>3.1.1</version>
+		<version>3.2.0</version>
 	</dependency>
 	<dependency>
         <groupId>junit</groupId>
@@ -36,7 +36,7 @@
 	<dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -21,12 +21,12 @@
   	<dependency>
   		<groupId>org.apache.jena</groupId>
   		<artifactId>jena-core</artifactId>
-  		<version>3.0.1</version>
+  		<version>3.1.0</version>
   	</dependency>
 	<dependency>
 	    <groupId>org.apache.jena</groupId>
 		<artifactId>jena-arq</artifactId>
-		<version>3.0.1</version>
+		<version>3.1.0</version>
 	</dependency>
 	<dependency>
         <groupId>junit</groupId>
@@ -36,7 +36,7 @@
 	<dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-base</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.rdfhdt</groupId>

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/HDTSolverLib.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/HDTSolverLib.java
@@ -32,10 +32,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import org.apache.jena.atlas.iterator.Iter;
-import org.apache.jena.atlas.lib.Tuple;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.shared.PrefixMapping;
@@ -44,7 +42,6 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.util.iterator.Filter;
 import org.rdfhdt.hdt.enums.TripleComponentRole;
 import org.rdfhdt.hdtjena.HDTGraph;
 import org.rdfhdt.hdtjena.NodeDictionary;
@@ -61,7 +58,7 @@ public class HDTSolverLib
 	public static long numBGPs;
 	
     protected static QueryIterator execute(HDTGraph graph, BasicPattern pattern, QueryIterator input,
-    										Predicate<Tuple<HDTId>> filter, ExecutionContext execCxt)
+    										ExecutionContext execCxt)
     {
     	numBGPs++;
     	
@@ -80,7 +77,7 @@ public class HDTSolverLib
 
         for ( Triple triplePattern : pattern )
         {
-            chain = solve(graph, triplePattern, chain, filter, mapVar, execCxt) ;
+            chain = solve(graph, triplePattern, chain, mapVar, execCxt) ;
             chain = IterAbortable.makeAbortable(chain, killList) ; 
         }
         
@@ -108,7 +105,7 @@ public class HDTSolverLib
 
     
     private static Iterator<BindingHDTId> solve(HDTGraph graph, Triple tuple, Iterator<BindingHDTId> chain, 
-    											Predicate<Tuple<HDTId>> filter, Map<Var, VarAppearance> mapVar,
+    											Map<Var, VarAppearance> mapVar,
                                                  ExecutionContext execCxt)
     {
         return new StageMatchTripleID(graph, chain, tuple, execCxt, mapVar) ;

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OpExecutorHDT.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OpExecutorHDT.java
@@ -26,12 +26,7 @@
 
 package org.rdfhdt.hdtjena.solver;
 
-import org.apache.jena.atlas.lib.Tuple;
 import org.apache.jena.atlas.logging.Log;
-import org.rdfhdt.hdtjena.HDTGraph;
-import org.rdfhdt.hdtjena.HDTJenaConstants;
-import org.rdfhdt.hdtjena.bindings.HDTId;
-
 import org.apache.jena.graph.Graph;
 import org.apache.jena.sparql.ARQInternalErrorException;
 import org.apache.jena.sparql.algebra.Op;
@@ -52,7 +47,7 @@ import org.apache.jena.sparql.engine.optimizer.reorder.ReorderProc;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.mgt.Explain;
-import org.apache.jena.util.iterator.Filter;
+import org.rdfhdt.hdtjena.HDTGraph;
 
 public class OpExecutorHDT extends OpExecutor {
 	
@@ -213,13 +208,9 @@ public class OpExecutorHDT extends OpExecutor {
     /** An op executor that simply executes a BGP or QuadPattern without any reordering */ 
     private static class OpExecutorPlainHDT extends OpExecutor
     {
-        Filter<Tuple<HDTId>> filter;
-        
-        @SuppressWarnings("unchecked")
 		public OpExecutorPlainHDT(ExecutionContext execCxt)
         {
             super(execCxt) ;
-            filter = (Filter<Tuple<HDTId>>)execCxt.getContext().get(HDTJenaConstants.FILTER_SYMBOL);
         }
         
         @Override
@@ -232,7 +223,7 @@ public class OpExecutorHDT extends OpExecutor {
                 BasicPattern bgp = opBGP.getPattern() ;
                 Explain.explain("Execute", bgp, execCxt.getContext()) ;
                 // Triple-backed (but may be named as explicit default graph).
-                return HDTSolverLib.execute((HDTGraph)g, bgp, input, filter, execCxt) ;
+                return HDTSolverLib.execute((HDTGraph)g, bgp, input, execCxt) ;
             }
             Log.warn(this, "Non-HDTGraph passed to OpExecutorPlainHDT") ;
             return super.execute(opBGP, input) ;

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OptimizedCount.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/solver/OptimizedCount.java
@@ -8,7 +8,6 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphMaker;
 import org.apache.jena.sparql.core.DatasetGraphOne;
 import org.apache.jena.sparql.core.PathBlock;
 import org.apache.jena.sparql.core.TriplePath;
@@ -134,7 +133,7 @@ public class OptimizedCount {
 		Graph g=null;
 		if(dataset instanceof DatasetGraphOne ) {
 			g = dataset.getDefaultGraph();
-		} else if(dataset instanceof DatasetGraphMaker) {
+		} else {
 			if(graphName!=null) {
 				g = dataset.getGraph(graphName);
 			} else {


### PR DESCRIPTION
This PR will upgrade the Jena dependency from 3.0.0/3.0.1 to the recently released 3.2.0, as proposed in issue #44.

I've split it into commits that upgrade one Jena version step at a time so if problems turn up later, it is easier to backtrack.

For the 3.0.1 to 3.1.0 upgrade there were some issues with the use of the class `Tuple` which was reworked (became an interface) in [JENA-1107](https://issues.apache.org/jira/browse/JENA-1107). But after analyzing the code I found out that the `filter` variable, which needed this class, was not actually used down the line. So I simply removed that dead code.

Also there was a check whether a `DatasetGraph` variable is of the type `DatasetGraphMaker`, which was removed in Jena 3.1.0. I figured that this check was probably not relevant (there is no casting after the check, just calling regular `DatasetGraph` methods) so I removed the test.

Finally in the upgrade to Jena 3.2.0 I replaced a call to `DS.list()` with `new ArrayList()`, which does the same, as the `DS` class was removed from Jena.

I've performed a very brief round of testing of all the command line utilities as well as starting a hdt-fuseki endpoint and issuing a SPARQL query. I couldn't find any issues. But it's always possible that there are some assumptions about Jena behavior built into `hdt-java` that have been adversely affected by the Jena upgrade.