### PR TITLE
Copy missing tools from hdt-java-cli to hdt-java-package

### DIFF
--- a/hdt-java-cli/bin/rdf2hdtcat.sh
+++ b/hdt-java-cli/bin/rdf2hdtcat.sh
@@ -85,7 +85,7 @@ split -l $lines $input "$input"_split_
 echo "***************************************************************"
 echo "Serializing into HDT $splits files using $threads threads"
 echo "***************************************************************"
-echo -n "$input"_split_* | xargs -I{} -d' ' -P$threads $rdf2hdt {} {}_"$splits".hdt
+echo -n "$input"_split_* | xargs -I{} -d' ' -P$threads $rdf2hdt -rdftype ntriples {} {}_"$splits".hdt
 
 for (( i=$splits; i>1; i=i/2 )); do
     echo "***************************************************************"

--- a/hdt-java-package/bin/hdtCat.sh
+++ b/hdt-java-package/bin/hdtCat.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source `dirname $0`/javaenv.sh
+
+#export MAVEN_OPTS="-Xmx6g"
+#mvn exec:java -Dexec.mainClass="org.rdfhdt.hdt.tools.HDTCat" -Dexec.args="$*"
+
+$JAVA $JAVA_OPTIONS -cp $CP:$CLASSPATH org.rdfhdt.hdt.tools.HDTCat $*
+
+exit $?

--- a/hdt-java-package/bin/hdtVerify.sh
+++ b/hdt-java-package/bin/hdtVerify.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source `dirname $0`/javaenv.sh
+
+$JAVA $JAVA_OPTIONS -cp $CP:$CLASSPATH org.rdfhdt.hdt.tools.HDTVerify $*
+
+exit $?

--- a/hdt-java-package/bin/rdf2hdtcat.sh
+++ b/hdt-java-package/bin/rdf2hdtcat.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+function showhelp {
+	echo
+	echo "Script to serialize a big RDF file in n-triples format into HDT"
+	echo "It splits the file in N parts, compress each one with rdf2hdt, and merges them iteratively with hdtCat."
+	echo
+	echo "Usage $0 [OPTION]"
+	echo
+    echo "  -c, --catscript location of hdtCat script (bin/hdtCat.sh by default)"
+    echo "  -i, --input     input file (input.rdf by default)"
+	echo "  -h, --help      shows this help and exits"
+	echo "  -n, --number    number of files to split FILE (2 by default)"
+    echo "  -o, --output    output file (output.hdt by default)"
+    echo "  -p, --parallel  number of threads to serialize RDF into HDT in parallel (1 by default)"
+    echo "  -r, --rdf2hdt   location of rdf2hdt script (bin/hdt2rdf.sh by deafult)"
+	echo
+}
+
+# Defaults
+declare rdf2hdt="bin/rdf2hdt.sh"
+declare hdtCat="bin/hdtCat.sh"
+declare input="input.rdf"
+declare -i lines
+declare output="output.hdt"
+declare -i splits=2
+declare -i threads=1
+
+getopt --test > /dev/null
+if [[ $? -eq 4 ]]; then
+    # enhanced getopt works
+    OPTIONS=c:i:hn:o:p:r:
+	LONGOPTIONS=cat:,input:,help,number:,output:,parallel:,rdf2hdr:
+    COMMAND=$(getopt -o $OPTIONS -l $LONGOPTIONS -n "$0" -- "$@")
+    if [[ $? -ne 0 ]]; then
+    	exit 2
+    fi
+    eval set -- "$COMMAND"
+else
+	echo "Enhanced getopt not supported. Brace yourself, this is not tested, but it should work :-)"
+fi
+
+while true; do
+	case "$1" in
+        -c|--cat)
+            hdtCat=$2
+            shift 2
+            ;;
+        -i|--input)
+            input=$2
+            shift 2
+            ;;
+		-n|--number)
+			splits=$2
+			shift 2
+			;;
+        -o|--output)
+            output=$2
+            shift 2
+            ;;
+        -p|--parallel)
+            threads=$2
+            shift 2
+            ;;
+        -r|--rdf2hdt)
+            rdf2hdt=$2
+            shift 2
+            ;;
+		--)
+			shift
+			break
+			;;
+		*)
+			showhelp
+			exit 0
+			;;
+	esac
+done
+
+total_lines=$(wc -l < $input)
+lines=($total_lines+$splits-1)/$splits #Set number of lines rounding up
+
+split -l $lines $input "$input"_split_
+
+echo "******************************************************************************************************************"
+echo "Serializing into HDT $splits files using $threads threads"
+echo "******************************************************************************************************************"
+echo -n "$input"_split_* | xargs -I{} -d' ' -P$threads $rdf2hdt {} {}_"$splits".hdt
+
+for (( i=$splits; i>1; i=i/2 )); do
+    echo "******************************************************************************************************************"
+    echo "Merging $i hdt files: " "$input"_split_*_"$i".hdt
+    echo "******************************************************************************************************************"
+    echo -n "$input"_split_*_"$i".hdt | xargs -d' ' -n2 -P$threads bash -c 'temp=${2%_*.hdt} ; bin/hdtCat.sh $1 $2 ${1%_*.hdt}_${temp#*split_}_$0.hdt' $((i/2))
+done

--- a/hdt-java-package/bin/rdf2hdtcat.sh
+++ b/hdt-java-package/bin/rdf2hdtcat.sh
@@ -85,7 +85,7 @@ split -l $lines $input "$input"_split_
 echo "***************************************************************"
 echo "Serializing into HDT $splits files using $threads threads"
 echo "***************************************************************"
-echo -n "$input"_split_* | xargs -I{} -d' ' -P$threads $rdf2hdt {} {}_"$splits".hdt
+echo -n "$input"_split_* | xargs -I{} -d' ' -P$threads $rdf2hdt -rdftype ntriples {} {}_"$splits".hdt
 
 for (( i=$splits; i>1; i=i/2 )); do
     echo "***************************************************************"


### PR DESCRIPTION
Now that the `hdtCat` has been merged, several tools that can be found in `hdt-java-cil/bin` are missing in `hdt-java-package/bin`:

* hdtCat.sh
* hdtVerify.sh
* rdf2hdtcat.sh

 This means that when compiling with `mvn assembly:single` they will be missing from the distribution directory.

Additionally, I fixed some typos and changed rdf2hdtcat.sh to assume that other tools are in `$PATH`