### PR TITLE
Always compare TripleString and DelayedString by value

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleString.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleString.java
@@ -126,11 +126,25 @@ public class TripleString {
 		this.predicate = predicate;
 		this.object = object;
 	}
-	
-	public boolean equals(TripleString other) {
-		return !( !subject.equals(other.subject) || !predicate.equals(other.predicate) || !object.equals(other.object) );
+
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof TripleString) {
+			TripleString ts = (TripleString) other;
+			return subject.equals(ts.subject) && predicate.equals(ts.predicate)
+					&& object.equals(ts.object);
+		}
+		return false;
 	}
-	
+
+	@Override public int hashCode() {
+		// Same as Objects.hashCode(subject, predicate, object), with fewer calls
+		int s = subject   == null ? 0 : subject.hashCode();
+		int p = predicate == null ? 0 : predicate.hashCode();
+		int o = object    == null ? 0 : object.hashCode();
+		return 31 * (31 * (31 * s) + p) + o;
+	}
+
 	/**
 	 * Check whether this triple matches a pattern. A pattern is just a TripleString where each empty component means <em>any</em>.
 	 * @param pattern

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/DelayedString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/DelayedString.java
@@ -48,4 +48,18 @@ public final class DelayedString implements CharSequence {
 		return str;
 	}
 
+	@Override
+	public int hashCode() {
+		ensure();
+		return str.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ((obj instanceof CharSequence)) {
+			ensure();
+			return str.equals(obj);
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
This PR fixes TripleString equality (using equals) being sometimes by value and sometimes by reference. The issue was observed when comparing a `List<TripleString>` produced from an `HDT.search()` call against a list of expected values in a unit test of another project.

Since there was a `TripleString.equals(TripleString)` method, I figured the intention was to have equality by value and not equality by reference. This PR makes equality by value consistent. All tests pass, but if the intention was to have only equality by reference, maybe `TripleString.equals(TripleString)` should be renamed (or removed since it is not called).

Changes:
- `TripleString` now overrides Object.equals(Object) instead of overloading. Thus `left.equals(right)` works even if at compile time `left` is an Object or if `left` is a `Collection` of `TripleString`.
- `TripleString`now implements hashCode() with the same effect of `Arrays.asList(subject, predicate, object).hashCode()`, but with fewer calls and instantiations.
- `DelayedString` now implements `equals()` and `hashCode()` by delegating them to the materialized `String` object it holds (as nearly all methods in this class). 
 
Other implementations of `CharSequence` in hdt-java-core, `ReplazableString` and `CompactString`  use a different  `hashCode` implementation (different seed and using ^ instead of +). Those classes were not changed and, as far I can tell, instances of those classes are not exposed to users of the `HDT` and `HDTManager` interfaces. 