### PR TITLE
fix: remove spurious system.out.println from api triples/tripleID:equ…

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
@@ -160,11 +160,6 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 		return Long.toString(subject) + " " + predicate + " " + object;
 	}
 
-
-	public boolean equals(TripleID other) {
-		return !( subject!=other.subject || predicate!=other.predicate || object!=other.object );
-	}
-
 	/**
 	 * Compare TripleID to another one using SPO Order. 
 	 * To compare using other orders use @see org.rdfhdt.hdt.triples.TripleStringComparator

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
@@ -162,7 +162,6 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 
 
 	public boolean equals(TripleID other) {
-		System.out.println(!( subject!=other.subject || predicate!=other.predicate || object!=other.object ));
 		return !( subject!=other.subject || predicate!=other.predicate || object!=other.object );
 	}
 


### PR DESCRIPTION
I'm guessing this was left over from some diagnostics.I don't know if this code is ever called.