### PR TITLE
Catch 'does not exist Id' case in translate

### DIFF
--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/NodeDictionary.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/NodeDictionary.java
@@ -204,9 +204,13 @@ public class NodeDictionary {
     }
 
 	public static long translate(NodeDictionary dictionary, HDTId id, TripleComponentRole role) {
-		if(dictionary==id.getDictionary()) {
+		// "Does not exist ID, see HDTId"
+		if (id.getValue() == -1) {
+			return -1;
+		}
+		if (dictionary == id.getDictionary()) {
 			if (role == id.getRole()) {
-			return id.getValue();
+				return id.getValue();
 			} else if (isSO(role) && isSO(id.getRole())) {
 				return id.getValue() <= dictionary.dictionary.getNshared() ? id.getValue() : -1;
 			}


### PR DESCRIPTION
I was running into the issue that triples that could not be joined produced the following:

```
java.lang.NullPointerException: null
	at org.rdfhdt.hdt.dictionary.impl.BaseDictionary.getSection(BaseDictionary.java:192) ~[hdt-java-core-2.1.3-SNAPSHOT.jar:?]
	at org.rdfhdt.hdt.dictionary.impl.BaseDictionary.idToString(BaseDictionary.java:217) ~[hdt-java-core-2.1.3-SNAPSHOT.jar:?]
	at org.rdfhdt.hdtjena.NodeDictionary.translate(NodeDictionary.java:217) ~[hdt-jena-2.1.3-SNAPSHOT.jar:?]
	at org.rdfhdt.hdtjena.solver.StageMatchTripleID.translateBinding(StageMatchTripleID.java:185) ~[hdt-jena-2.1.3-SNAPSHOT.jar:?]
```
My assumption was that this these were `"Does not exist" ids` as documented in `org.rdfhdt.hdtjena.bindings.HDTId`. This patch fixes this issue.