### PR TITLE
Ability to search over triples with their IDs

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/rdf/RDFAccess.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/rdf/RDFAccess.java
@@ -52,4 +52,21 @@ public interface RDFAccess {
 	 * @throws NotFoundException when the triple cannot be found
 	 */
 	IteratorTripleString search(CharSequence subject, CharSequence predicate, CharSequence object) throws NotFoundException;
+	/**
+	 * Iterate over the triples of an RDF Set that match the specified pattern, and gives back the ID of the triple
+	 * (i.e. the index of the triple in the list of triples) .
+	 * null and empty strings act as a wildcard.
+	 * (e.g. search(null, null, null) iterates over all elements)
+	 *
+	 * @param subject
+	 *            The subject to search
+	 * @param predicate
+	 *            The predicate to search
+	 * @param object
+	 *            The object to search
+	 *
+	 * @return Iterator of TripleStrings
+	 * @throws NotFoundException when the triple cannot be found
+	 */
+	IteratorTripleString searchWithId(CharSequence subject, CharSequence predicate, CharSequence object) throws NotFoundException;
 }

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
@@ -28,6 +28,7 @@
 package org.rdfhdt.hdt.triples;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.rdfhdt.hdt.util.LongCompare;
 
@@ -43,7 +44,9 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 	private long subject;
 	private long predicate;
 	private long object;
-
+	private long index = -1;
+	// by default it's fault, we don't return the index
+	private boolean withIndex = false;
 	/**
 	 * Basic constructor
 	 */
@@ -68,19 +71,27 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 		this.object = object;
 	}
 
+
 	/**
 	 * Build a TripleID as a copy of another one.
-	 * @param other the triple ID to copy
+	 * @param other
 	 */
 	public TripleID(TripleID other) {
 		super();
 		this.subject = other.subject;
 		this.predicate = other.predicate;
 		this.object = other.object;
+		this.index = other.index;
+		this.withIndex = other.withIndex;
+	}
+
+
+	public long getIndex() {
+		return index;
 	}
 
 	/**
-	 * @return long the subject
+	 * @return the subject
 	 */
 	public long getSubject() {
 		return subject;
@@ -95,7 +106,7 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 	}
 
 	/**
-	 * @return long the object
+	 * @return the object
 	 */
 	public long getObject() {
 		return object;
@@ -110,7 +121,7 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 	}
 
 	/**
-	 * @return long the predicate
+	 * @return the predicate
 	 */
 	public long getPredicate() {
 		return predicate;
@@ -126,9 +137,9 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 
 	/**
 	 * Replace all components of a TripleID at once. Useful to reuse existing objects.
-	 * @param subject subject ID
-	 * @param predicate predicate ID
-	 * @param object object ID
+	 * @param subject
+	 * @param predicate
+	 * @param object
 	 */
 	public void setAll(long subject, long predicate, long object) {
 		this.subject = subject;
@@ -136,10 +147,18 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 		this.object = object;
 	}
 
+	public void setAllPlusIndex(long subject, long predicate, long object,long index) {
+		this.subject = subject;
+		this.predicate = predicate;
+		this.object = object;
+		this.index = index;
+	}
+
 	public void assign(TripleID replacement) {
 		subject = replacement.getSubject();
-        object = replacement.getObject();
-        predicate = replacement.getPredicate();
+		object = replacement.getObject();
+		predicate = replacement.getPredicate();
+		index = replacement.getIndex();
 	}
 
 	/**
@@ -159,24 +178,30 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 		return Long.toString(subject) + " " + predicate + " " + object;
 	}
 
+
+	public boolean equals(TripleID other) {
+		System.out.println(!( subject!=other.subject || predicate!=other.predicate || object!=other.object ));
+		return !( subject!=other.subject || predicate!=other.predicate || object!=other.object );
+	}
+
 	/**
 	 * Compare TripleID to another one using SPO Order.
-	 * To compare using other orders use @see org.rdfhdt.hdt.triples.TripleStringComparator
+	 * To compare using other orders use {@link TripleStringComparator}
 	 */
 	@Override
 	public int compareTo(TripleID other) {
-		 int result = LongCompare.compare(this.subject, other.subject);
+		int result = LongCompare.compare(this.subject, other.subject);
 
-         if(result==0) {
-                 result = LongCompare.compare(this.predicate,other.predicate);
-                 if(result==0) {
-                         return LongCompare.compare(this.object,other.object);
-                 } else {
-                         return result;
-                 }
-         } else {
-                 return result;
-         }
+		if(result==0) {
+			result = LongCompare.compare(this.predicate,other.predicate);
+			if(result==0) {
+				return LongCompare.compare(this.object,other.object);
+			} else {
+				return result;
+			}
+		} else {
+			return result;
+		}
 	}
 
 	/**
@@ -206,7 +231,7 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 
 	/**
 	 * Check whether all the components of the triple are empty (zero).
-	 * @return boolean
+	 * @return
 	 */
 	public boolean isEmpty() {
 		return !(subject != 0 || predicate != 0 || object != 0);
@@ -214,7 +239,7 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 
 	/**
 	 * Check whether none of the components of the triple are empty.
-	 * @return boolean
+	 * @return
 	 */
 	public boolean isValid() {
 		return subject>0 && predicate>0 && object>0;
@@ -222,7 +247,7 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 
 	/**
 	 * Checks whether any of the components of the triple are "no match" (-1).
-	 * @return boolean
+	 * @return
 	 */
 	public boolean isNoMatch() {
 		return subject == -1 || predicate == -1 || object == -1;
@@ -230,19 +255,16 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 
 	/**
 	 * Get the pattern of the triple as String, such as "SP?".
-	 * @return String
+	 * @return
 	 */
 	public String getPatternString() {
 		return "" +
-			(subject==0   ? '?' : 'S') +
-			(predicate==0 ? '?' : 'P') +
-			(object==0    ? '?' : 'O');
+				(subject==0   ? '?' : 'S') +
+				(predicate==0 ? '?' : 'P') +
+				(object==0    ? '?' : 'O');
 	}
 
-	/**
-	 * size of one TripleID in memory
-	 * @return int
-	 */
+	/** size of one TripleID in memory */
 	public static int size(){
 		return 48;
 	}
@@ -261,4 +283,13 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 	public int hashCode() {
 		return (int) (subject * 13 + predicate * 17 + object * 31);
 	}
+
+	public boolean isWithIndex() {
+		return withIndex;
+	}
+
+	public void setWithIndex(boolean withIndex) {
+		this.withIndex = withIndex;
+	}
+
 }

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleString.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleString.java
@@ -40,7 +40,7 @@ public class TripleString {
 	private CharSequence subject;
 	private CharSequence predicate;
 	private CharSequence object;
-
+	private long index;
 	public TripleString() {
 		this.subject = this.predicate = this.object = null;
 	}
@@ -61,9 +61,14 @@ public class TripleString {
 		this.object = object;
 	}
 
+	public TripleString(CharSequence subject, CharSequence predicate, CharSequence object,long index) {
+		this.subject = subject;
+		this.predicate = predicate;
+		this.object = object;
+		this.index = index;
+	}
 	/**
 	 * Copy constructor
-	 * @param other triple string to copy
 	 */
 	public TripleString(TripleString other) {
 		this.subject = other.subject;
@@ -72,7 +77,7 @@ public class TripleString {
 	}
 
 	/**
-	 * @return CharSequence the subject
+	 * @return the subject
 	 */
 	public CharSequence getSubject() {
 		return subject;
@@ -87,7 +92,7 @@ public class TripleString {
 	}
 
 	/**
-	 * @return CharSequence the predicate
+	 * @return the predicate
 	 */
 	public CharSequence getPredicate() {
 		return predicate;
@@ -118,9 +123,9 @@ public class TripleString {
 
 	/**
 	 * Sets all components at once. Useful to reuse existing object instead of creating new ones for performance.
-	 * @param subject subject
-	 * @param predicate predicate
-	 * @param object object
+	 * @param subject
+	 * @param predicate
+	 * @param object
 	 */
 	public void setAll(CharSequence subject, CharSequence predicate, CharSequence object) {
 		this.subject = subject;
@@ -128,38 +133,24 @@ public class TripleString {
 		this.object = object;
 	}
 
-	@Override
-	public boolean equals(Object other) {
-		if (other instanceof TripleString) {
-			TripleString ts = (TripleString) other;
-			return subject.equals(ts.subject) && predicate.equals(ts.predicate)
-					&& object.equals(ts.object);
-		}
-		return false;
-	}
-
-	@Override public int hashCode() {
-		// Same as Objects.hashCode(subject, predicate, object), with fewer calls
-		int s = subject   == null ? 0 : subject.hashCode();
-		int p = predicate == null ? 0 : predicate.hashCode();
-		int o = object    == null ? 0 : object.hashCode();
-		return 31 * (31 * (31 * s) + p) + o;
+	public boolean equals(TripleString other) {
+		return !( !subject.equals(other.subject) || !predicate.equals(other.predicate) || !object.equals(other.object) );
 	}
 
 	/**
 	 * Check whether this triple matches a pattern. A pattern is just a TripleString where each empty component means <em>any</em>.
-	 * @param pattern triple pattern to search
-	 * @return boolean
+	 * @param pattern
+	 * @return
 	 */
 	public boolean match(TripleString pattern) {
-        if (pattern.getSubject() == "" || pattern.getSubject().equals(this.subject)) {
-            if (pattern.getPredicate() == "" || pattern.getPredicate().equals(this.predicate)) {
-                if (pattern.getObject() == "" || pattern.getObject().equals(this.object)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+		if (pattern.getSubject() == "" || pattern.getSubject().equals(this.subject)) {
+			if (pattern.getPredicate() == "" || pattern.getPredicate().equals(this.predicate)) {
+				if (pattern.getObject() == "" || pattern.getObject().equals(this.object)) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -171,7 +162,7 @@ public class TripleString {
 
 	/**
 	 * Checks whether all components are empty.
-	 * @return boolean
+	 * @return
 	 */
 	public boolean isEmpty() {
 		return subject.length()==0 && predicate.length()==0 && object.length()==0;
@@ -179,7 +170,7 @@ public class TripleString {
 
 	/**
 	 * Checks whether any component is empty.
-	 * @return boolean
+	 * @return
 	 */
 	public boolean hasEmpty() {
 		return subject.length()==0 || predicate.length()==0 || object.length()==0;
@@ -187,8 +178,7 @@ public class TripleString {
 
 	/**
 	 * Read from a line, where each component is separated by space.
-	 * @param line line to read
-	 * @throws ParserException if the line is not RDF complient
+	 * @param line
 	 */
 	public void read(String line) throws ParserException {
 		int split, posa, posb;
@@ -243,11 +233,7 @@ public class TripleString {
 		return subject + " " + predicate + " " + object;
 	}
 
-	/**
-     * Convert TripleString to NTriple
-	 * @return CharSequence
-	 * @throws IOException when IOException occurs
-	 */
+	/** Convert TripleString to NTriple */
 	public CharSequence asNtriple() throws IOException {
 		StringBuilder str = new StringBuilder();
 		this.dumpNtriple(str);
@@ -278,5 +264,9 @@ public class TripleString {
 		} else {
 			out.append('<').append(object).append("> .\n");
 		}
+	}
+
+	public long getIndex() {
+		return index;
 	}
 }

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/Triples.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/Triples.java
@@ -53,6 +53,16 @@ public interface Triples extends Closeable {
 	IteratorTripleID search(TripleID pattern);
 
 	/**
+	 * Iterates over all triples that match the pattern, and their IDs (i.e. index in the triples list)
+	 *
+	 * @param pattern
+	 *            The pattern to match against
+	 * @return IteratorTripleID
+	 *
+	 */
+	IteratorTripleID searchWithId(TripleID pattern);
+
+	/**
 	 * Returns the total number of triples
 	 *
 	 * @return int
@@ -78,4 +88,10 @@ public interface Triples extends Closeable {
 	 * @return String
 	 */
 	String getType();
+
+	/**
+	 * Returns a triple of the given index
+	 * @param index
+	 */
+	TripleID find(long index);
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -386,6 +386,55 @@ public class HDTImpl implements HDTPrivate {
 			return new DictionaryTranslateIterator(triples.search(triple), dictionary, subject, predicate, object);
 		}
 	}
+	@Override
+	public IteratorTripleString searchWithId(CharSequence subject, CharSequence predicate, CharSequence object) throws NotFoundException {
+		if(isClosed) {
+			throw new IllegalStateException("Cannot search an already closed HDT");
+		}
+
+		// Conversion from TripleString to TripleID
+		TripleID triple = new TripleID(
+				dictionary.stringToId(subject, TripleComponentRole.SUBJECT),
+				dictionary.stringToId(predicate, TripleComponentRole.PREDICATE),
+				dictionary.stringToId(object, TripleComponentRole.OBJECT)
+		);
+
+		if(triple.isNoMatch()) {
+			//throw new NotFoundException("String not found in dictionary");
+			return new IteratorTripleString() {
+				@Override
+				public TripleString next() {
+					return null;
+				}
+				@Override
+				public boolean hasNext() {
+					return false;
+				}
+				@Override
+				public ResultEstimationType numResultEstimation() {
+					return ResultEstimationType.EXACT;
+				}
+				@Override
+				public void goToStart() {
+				}
+				@Override
+				public long estimatedNumResults() {
+					return 0;
+				}
+			};
+		}
+
+		if(isMapped) {
+			try {
+					return new DictionaryTranslateIteratorBuffer(triples.searchWithId(triple), (FourSectionDictionary) dictionary, subject, predicate, object);
+			}catch(NullPointerException e) {
+				e.printStackTrace();
+				return new DictionaryTranslateIterator(triples.searchWithId(triple), dictionary, subject, predicate, object);
+			}
+		} else {
+			return new DictionaryTranslateIterator(triples.searchWithId(triple), dictionary, subject, predicate, object);
+		}
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/header/PlainHeader.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/header/PlainHeader.java
@@ -156,6 +156,13 @@ public class PlainHeader implements HeaderPrivate, RDFCallback {
 		return new PlainHeaderIterator(this, pattern);
 	}
 
+	// not used
+	@Override
+	public IteratorTripleString searchWithId(CharSequence subject, CharSequence predicate, CharSequence object) {
+		return search(subject,predicate,object);
+	}
+
+
 	@Override
 	public void processTriple(TripleString triple, long pos) {
 		triples.add(new TripleString(triple));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/DictionaryTranslateIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/DictionaryTranslateIterator.java
@@ -121,8 +121,8 @@ public class DictionaryTranslateIterator implements IteratorTripleString {
 			lastOstr = dictionary.idToString(triple.getObject(), TripleComponentRole.OBJECT);
 			lastOid = triple.getObject();
 		}
-		
-		return new TripleString(lastSstr, lastPstr, lastOstr);
+
+		return new TripleString(lastSstr, lastPstr, lastOstr,triple.getIndex());
 //		return DictionaryUtil.tripleIDtoTripleString(dictionary, triple);
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/DictionaryTranslateIteratorBuffer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/DictionaryTranslateIteratorBuffer.java
@@ -186,8 +186,8 @@ public class DictionaryTranslateIteratorBuffer implements IteratorTripleString {
 			lastOid = triple.getObject();
 			lastOstr = mapObject.get(lastOid);
 		}
-		
-		return new TripleString(lastSstr, lastPstr, lastOstr);
+
+		return new TripleString(lastSstr, lastPstr, lastOstr,triple.getIndex());
 	}
 
 	/*

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIterator.java
@@ -52,6 +52,8 @@ public class BitmapTriplesIterator implements IteratorTripleID {
 		this.triples = triples;
 		this.returnTriple = new TripleID();
 		this.pattern = new TripleID();
+		if(pattern.isWithIndex())
+			this.pattern.setWithIndex(true);
 		newSearch(pattern);
 	}
 
@@ -88,6 +90,11 @@ public class BitmapTriplesIterator implements IteratorTripleID {
 
 	private void updateOutput() {
 		returnTriple.setAll(x, y, z);
+		if(pattern.isWithIndex())
+			returnTriple.setAllPlusIndex(x, y, z,posZ);
+		else
+			returnTriple.setAll(x,y,z);
+
 		TripleOrderConvert.swapComponentOrder(returnTriple, triples.order, TripleComponentOrder.SPO);
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorY.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorY.java
@@ -71,6 +71,11 @@ public class BitmapTriplesIteratorY implements IteratorTripleID {
 	
 	private void updateOutput() {
 		returnTriple.setAll(x, y, z);
+		if(pattern.isWithIndex())
+			returnTriple.setAllPlusIndex(x, y, z,posZ);
+		else
+			returnTriple.setAll(x,y,z);
+
 		TripleOrderConvert.swapComponentOrder(returnTriple, triples.order, TripleComponentOrder.SPO);
 	}
 	

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorYFOQ.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorYFOQ.java
@@ -77,6 +77,11 @@ public class BitmapTriplesIteratorYFOQ implements IteratorTripleID {
 		
 		private void updateOutput() {
 			returnTriple.setAll(x, y, z);
+			if(pattern.isWithIndex())
+				returnTriple.setAllPlusIndex(x, y, z,posZ);
+			else
+				returnTriple.setAll(x,y,z);
+
 			TripleOrderConvert.swapComponentOrder(returnTriple, triples.order, TripleComponentOrder.SPO);
 		}
 		

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorZ.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorZ.java
@@ -67,6 +67,11 @@ public class BitmapTriplesIteratorZ implements IteratorTripleID {
 	
 	private void updateOutput() {
 		returnTriple.setAll(x, y, z);
+		if(pattern.isWithIndex())
+			returnTriple.setAllPlusIndex(x, y, z,posZ+1);
+		else
+			returnTriple.setAll(x,y,z);
+
 		TripleOrderConvert.swapComponentOrder(returnTriple, triples.order, TripleComponentOrder.SPO);
 	}
 	
@@ -90,11 +95,12 @@ public class BitmapTriplesIteratorZ implements IteratorTripleID {
 		z = adjZ.get(posZ);
 		y = adjY.get(posY);
 		x = adjY.findListIndex(posY)+1;
-		
+
+		updateOutput();
+
 		// Go forward finding next appearance
 		posZ = adjZ.findNextAppearance(posZ+1, patZ);
-		
-		updateOutput();
+
 		
 		return returnTriple;
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorZFOQ.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorZFOQ.java
@@ -45,7 +45,8 @@ public class BitmapTriplesIteratorZFOQ implements IteratorTripleID {
 	AdjacencyList adjY, adjIndex;
 	long posIndex, minIndex, maxIndex;
 	long x, y, z;
-	
+
+	long posZ;
 	long patY;
     final long patZ;
 	
@@ -134,6 +135,11 @@ public class BitmapTriplesIteratorZFOQ implements IteratorTripleID {
 	
 	private void updateOutput() {
 		returnTriple.setAll(x, y, z);
+		if(pattern.isWithIndex())
+			returnTriple.setAllPlusIndex(x, y, z,posZ);
+		else
+			returnTriple.setAll(x,y,z);
+
 		TripleOrderConvert.swapComponentOrder(returnTriple, triples.order, TripleComponentOrder.SPO);
 	}
 	
@@ -150,16 +156,19 @@ public class BitmapTriplesIteratorZFOQ implements IteratorTripleID {
 	 */
 	@Override
 	public TripleID next() {
-	    long posY = adjIndex.get(posIndex);
+		long posY = adjIndex.get(posIndex);
 
-	    z = patZ!=0 ? patZ : adjIndex.findListIndex(posIndex)+1;
-	    y = patY!=0 ? patY : adjY.get(posY);
-	    x = adjY.findListIndex(posY)+1;
+		z = patZ!=0 ? patZ : adjIndex.findListIndex(posIndex)+1;
+		y = patY!=0 ? patY : adjY.get(posY);
+		x = adjY.findListIndex(posY)+1;
 
-	    posIndex++;
-
-	    updateOutput();
-	    return returnTriple;
+		if(this.pattern.isWithIndex()) {
+			// if the triple pattern is asking for the index as well
+			posZ = triples.adjZ.find(posY, z) + 1;
+		}
+		posIndex++;
+		updateOutput();
+		return returnTriple;
 	}
 
 	/* (non-Javadoc)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesList.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesList.java
@@ -113,6 +113,12 @@ public class TriplesList implements TempTriples {
 		}
 	}
 
+	@Override
+	public IteratorTripleID searchWithId(TripleID pattern) {
+		pattern.setWithIndex(true);
+		return search(pattern);
+	}
+
 	/* (non-Javadoc)
 	 * @see hdt.triples.Triples#searchAll()
 	 */
@@ -505,5 +511,8 @@ public class TriplesList implements TempTriples {
 				);
 		}
 	}
-
+	@Override
+	public TripleID find(long index) {
+		return null;
+	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesListLong.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesListLong.java
@@ -121,6 +121,11 @@ public class TriplesListLong implements TempTriples {
 			return new SequentialSearchIteratorTripleID(pattern, new TriplesListIterator(this));
 		}
 	}
+	@Override
+	public IteratorTripleID searchWithId(TripleID pattern) {
+		pattern.setWithIndex(true);
+		return search(pattern);
+	}
 
 	/* (non-Javadoc)
 	 * @see hdt.triples.Triples#searchAll()
@@ -514,6 +519,11 @@ public class TriplesListLong implements TempTriples {
 					mapObj.getNewID(triple.getObject()-1)
 				);
 		}
+	}
+	// function not used...
+	@Override
+	public TripleID find(long index) {
+		return null;
 	}
 
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorTest.java
@@ -1,12 +1,29 @@
 package org.rdfhdt.hdt.triples.impl;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.rdfhdt.hdt.enums.TripleComponentRole;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.options.HDTSpecification;
+import org.rdfhdt.hdt.rdf.parsers.RDFParserRAR;
+import org.rdfhdt.hdt.triples.IteratorTripleID;
+import org.rdfhdt.hdt.triples.IteratorTripleString;
+import org.rdfhdt.hdt.triples.TripleID;
+import org.rdfhdt.hdt.triples.TripleString;
+import org.rdfhdt.hdt.util.StopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.TestCase.assertEquals;
 
 public class BitmapTriplesIteratorTest {
-
+	private static final Logger log = LoggerFactory.getLogger(BitmapTriplesIteratorTest.class);
 	@Before
 	public void setUp() throws Exception {
 	}
@@ -21,6 +38,70 @@ public class BitmapTriplesIteratorTest {
 //		while(it.hasNext()) {
 //			System.out.println(it.next());
 //		}
+	}
+	@Test
+	public void testFindByIndex() throws IOException {
+		ClassLoader classLoader = getClass().getClassLoader();
+		String file = Objects.requireNonNull(classLoader.getResource("dbpedia.hdt")).getFile();
+		try {
+			HDT hdt = HDTManager.mapHDT(new File(file).getAbsolutePath());
+			IteratorTripleID it = hdt.getTriples().searchAll();
+			int count = 1;
+			while(it.hasNext()) {
+				TripleID triple = it.next();
+				assertEquals(triple,hdt.getTriples().find(count));
+				count++;
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	@Test
+	public void testIteratorsWithIndex() throws IOException {
+		ClassLoader classLoader = getClass().getClassLoader();
+		String file = Objects.requireNonNull(classLoader.getResource("dbpedia.hdt")).getFile();
+		try {
+			HDT hdt = HDTManager.mapHDT(new File(file).getAbsolutePath());
+			System.out.println("Testing iterator with index, for patterns like ?P? ");
+			// iterator for ? P ?
+			IteratorTripleString it = hdt.searchWithId("","http://www.w3.org/1999/02/22-rdf-syntax-ns#type","");
+			int count = 1;
+			checkIteratorMatching(it,hdt);
+			System.out.println("Testing iterator with index, for patterns like ?PO ");
+			// iterator for ? P O
+			it = hdt.searchWithId("","http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+					"http://dbpedia.org/ontology/Image");
+			checkIteratorMatching(it,hdt);
+			System.out.println("Testing iterator with index, for patterns like S?? or SP? or SPO");
+			// iterator for S??
+			it = hdt.searchWithId("http://commons.wikimedia.org/wiki/Special:FilePath/96ST1AVE.JPG",
+					"", "");
+			checkIteratorMatching(it,hdt);
+			System.out.println("Testing iterator with extra objects index, for patterns like ?PO or ??O");
+			// iterator for ?PO
+			hdt = HDTManager.mapIndexedHDT(new File(file).getAbsolutePath());
+			it = hdt.searchWithId("","http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+					"http://dbpedia.org/ontology/Image");
+			checkIteratorMatching(it,hdt);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	private void checkIteratorMatching(Iterator<TripleString> it,HDT hdt){
+		while(it.hasNext()) {
+			TripleString triple = it.next();
+			// find the triple with the given index from the triple
+			TripleID tripleID = hdt.getTriples().find(triple.getIndex());
+			// compare the IDs of the triple found and the one coming from the iterator
+			long subId = hdt.getDictionary().stringToId(triple.getSubject(), TripleComponentRole.SUBJECT);
+			assertEquals(tripleID.getSubject(),subId);
+
+			long predId = hdt.getDictionary().stringToId(triple.getPredicate(), TripleComponentRole.PREDICATE);
+			assertEquals(tripleID.getPredicate(),predId);
+
+			long objId = hdt.getDictionary().stringToId(triple.getObject(), TripleComponentRole.OBJECT);
+			assertEquals(tripleID.getObject(),objId);
+		}
 	}
 
 }


### PR DESCRIPTION
We introduce a new feature to be able to search over the triples and get an ID of the found list or one hit of triples,  as well we provide a function **find(long id)** over the triples which basically takes an index or ID in the list of triples and looks up in the trees in a bottom up fashion to find the given tripleID. 

This code doesn't change the original hdt-api but adds two extra functions:
- searchWithId(TripleID pattern): Iterates over all triples that match the pattern, and their IDs (i.e. index in the triples list)
- find(long index): Returns a tripleID of the given index.

For the search with ID method all the modifications are over the bitmap triples iterators of the different query patterns, all of the modifications doesn't cost any performance issue because we take into account the indexes used to find the matching triple patterns and we use the index of Z (the object in this case) as an identifier of the triple or the index in the list. 

P.S: There is only one case when we use BitmapTriplesIteratorZFOQ to search over a fixed object we need to do a binary search over the extra object list in order to find the position of the given object z. 


Regarding the find triple by ID, we go up in the tree using the indexes and rank1 operations over the bitmaps:

1) First we use the given ID or index of the triple and find the corresponding object ID from the sequence of objects.
2) Get the position of the predicate by doing a rank1 operation over the bitmapZ using the object's position. (basically count the ones up to the given position)
3) Find the predicate ID from the inferred predicate position using the sequence of predicates.
4) Use the position of the predicate to get the position of the subject exactly by doing the same rank1 but over bitmapY
5) Get the subject from the subjects sequence using the position got in (4)
<img width="300" alt="Screenshot 2022-01-13 at 16 02 58" src="https://user-images.githubusercontent.com/43681203/149354717-45190998-e3a9-48b2-9f36-5b4d59a5b058.png">

example: find(3) in the above figure.
triples list:
1 4 5, pos = 1
2 2 1, pos = 2
2 3 3, pos = 3
2 3 4, pos = 4
2 5 2, pos = 5
3 1 1, pos = 6
4 1 1, pos = 7
solution: z = seqZ.get(3-1) = 3 ( id at position 2), posY = bitmapZ.rank1(3 -1) = 2, y = seqY.get(posY) = 3, 
posX = bitmapY.rank1(2 - 1) = 1, x = seqX.get(posX) = 2,  then => x = 2, y =3, z =3 

Triple (2 3 3) is at position 3 in the list. 

All those operations must be done in constant time because we just use some binary operations to access and find the positions of the triple.

