### PR TITLE
Bug fixes to avoid overflow problems

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
@@ -153,19 +153,20 @@ public class SequenceLog64Big implements DynamicSequence {
 			data.set(i+1 , (data.get(i+1) & mask) | value >>> (W-j));
 		}
 	}
-	
+
 	private void resizeArray(long size) {
-		//data = Arrays.copyOf(data, size);	
-		
-		LongLargeArray a = new LongLargeArray(size);
-		if (size < data.length()) {
-			LargeArrayUtils.arraycopy(data, 0, a, 0, size);
+		//data = Arrays.copyOf(data, size);
+		if(size > 0) {
+			LongLargeArray a = new LongLargeArray(size);
+			if (size < data.length()) {
+				LargeArrayUtils.arraycopy(data, 0, a, 0, size);
+			} else {
+				LargeArrayUtils.arraycopy(data, 0, a, 0, data.length());
 			}
-			else {
-		    LargeArrayUtils.arraycopy(data, 0, a, 0, data.length());
-			}
-		data = a;
-		
+			data = a;
+		}else{
+			this.numentries = 0;
+		}
 	}
 	
 	
@@ -289,7 +290,7 @@ public class SequenceLog64Big implements DynamicSequence {
 			long totalSize = numWordsFor(numbits, numentries);
 			
 			if (totalSize!=data.length()){
-				resizeArray((int)totalSize);
+				resizeArray(totalSize);
 			}
 		}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64BigDisk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64BigDisk.java
@@ -208,7 +208,7 @@ public class SequenceLog64BigDisk implements DynamicSequence, Closeable {
             long totalSize = numWordsFor(numbits, numentries);
 
             if (totalSize!=data.length()){
-                resizeArray((int)totalSize);
+                resizeArray(totalSize);
             }
         }
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionBig.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionBig.java
@@ -175,8 +175,15 @@ public class PFCDictionarySectionBig implements DictionarySectionPrivate {
 			long bytePos = 0;
 			long numBlocks = blocks.getNumberOfElements();
 			//System.out.println("numblocks:"+numBlocks);
-			
-			long numBuffers = 1+numBlocks/BLOCK_PER_BUFFER;
+
+			long numBuffers = -1;
+			if(numBlocks > 0){
+				// non empty section
+				numBuffers = 1+numBlocks/BLOCK_PER_BUFFER;
+			}else{
+				// else empty section then it's zero
+				numBuffers = 0;
+			}
 			data = new byte[(int)numBuffers][];
 			posFirst = new long[(int)numBuffers];
 			

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
@@ -41,9 +41,7 @@ import org.rdfhdt.hdt.compact.bitmap.Bitmap;
 import org.rdfhdt.hdt.compact.bitmap.Bitmap375;
 import org.rdfhdt.hdt.compact.bitmap.BitmapFactory;
 import org.rdfhdt.hdt.compact.bitmap.ModifiableBitmap;
-import org.rdfhdt.hdt.compact.sequence.Sequence;
-import org.rdfhdt.hdt.compact.sequence.SequenceFactory;
-import org.rdfhdt.hdt.compact.sequence.SequenceLog64;
+import org.rdfhdt.hdt.compact.sequence.*;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
 import org.rdfhdt.hdt.exceptions.IllegalFormatException;
 import org.rdfhdt.hdt.hdt.HDTVocabulary;
@@ -396,7 +394,7 @@ public class BitmapTriples implements TriplesPrivate {
 		
 		isClosed=false;
 	}
-	
+
 
 
 	private void createIndexObjectMemoryEfficient() {
@@ -408,14 +406,14 @@ public class BitmapTriples implements TriplesPrivate {
 		long numDifferentObjects = 0;
 		long numReservedObjects = 8192;
 		@SuppressWarnings("resource")
-		SequenceLog64 objectCount = new SequenceLog64(BitUtil.log2(seqZ.getNumberOfElements()), numReservedObjects, true);
+		SequenceLog64Big objectCount = new SequenceLog64Big(BitUtil.log2(seqZ.getNumberOfElements()), numReservedObjects, true);
 		for(long i=0;i<seqZ.getNumberOfElements(); i++) {
 			long val = seqZ.get(i);
 			if(val==0) {
 				throw new RuntimeException("ERROR: There is a zero value in the Z level.");
 			}
 			if(numReservedObjects<val) {
-				while(numReservedObjects<val) {					
+				while(numReservedObjects<val) {
 					numReservedObjects <<=1;
 				}
 				objectCount.resize(numReservedObjects);
@@ -423,7 +421,7 @@ public class BitmapTriples implements TriplesPrivate {
 			if(numDifferentObjects<val) {
 				numDifferentObjects=val;
 			}
-			
+
 			long count = objectCount.get(val-1)+1;
 			maxCount = count>maxCount ? count : maxCount;
 			objectCount.set(val-1, count);
@@ -445,28 +443,35 @@ public class BitmapTriples implements TriplesPrivate {
 		st.reset();
 
 		// Copy each object reference to its position
-		SequenceLog64 objectInsertedCount = new SequenceLog64(BitUtil.log2(maxCount), numDifferentObjects);
+		SequenceLog64Big objectInsertedCount = new SequenceLog64Big(BitUtil.log2(maxCount), numDifferentObjects);
 		objectInsertedCount.resize(numDifferentObjects);
+		File file = null;
+		try {
+			file = File.createTempFile("objectsArray", ".tmp");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 
-		SequenceLog64 objectArray = new SequenceLog64(BitUtil.log2(seqY.getNumberOfElements()), seqZ.getNumberOfElements());
+		SequenceLog64BigDisk objectArray = new SequenceLog64BigDisk(file.getAbsolutePath(),
+				BitUtil.log2(seqY.getNumberOfElements()), seqZ.getNumberOfElements());
 		objectArray.resize(seqZ.getNumberOfElements());
 
 		for(long i=0;i<seqZ.getNumberOfElements(); i++) {
-				long objectValue = seqZ.get(i);
-				long posY = i>0 ?  bitmapZ.rank1(i-1) : 0;
+			long objectValue = seqZ.get(i);
+			long posY = i>0 ?  bitmapZ.rank1(i-1) : 0;
 
-				long insertBase = objectValue==1 ? 0 : bitmapIndex.select1(objectValue-1)+1;
-				long insertOffset = objectInsertedCount.get(objectValue-1);
-				objectInsertedCount.set(objectValue-1, insertOffset+1);
+			long insertBase = objectValue==1 ? 0 : bitmapIndex.select1(objectValue-1)+1;
+			long insertOffset = objectInsertedCount.get(objectValue-1);
+			objectInsertedCount.set(objectValue-1, insertOffset+1);
 
-				objectArray.set(insertBase+insertOffset, posY);
+			objectArray.set(insertBase+insertOffset, posY);
 		}
 		log.info("Object references in {}", st.stopAndShow());
 		IOUtil.closeQuietly(objectInsertedCount);
 		objectInsertedCount=null;
 		st.reset();
 
-		
+
 		long object=1;
 		long first = 0;
 		long last = bitmapIndex.selectNext1(first)+1;
@@ -487,30 +492,30 @@ public class BitmapTriples implements TriplesPrivate {
 				}
 			} else if(listLen>2) {
 				class Pair {
-					int valueY;
-					int positionY;
+					Long valueY;
+					Long positionY;
 					@Override public String toString() { return String.format("%d %d", valueY,positionY); }
 				};
-				
+
 				// FIXME: Sort directly without copying?
 				ArrayList<Pair> list=new ArrayList<Pair>((int)listLen);
 
 				// Create temporary list of (position, predicate)
 				for(long i=first; i<last;i++) {
 					Pair p = new Pair();
-					p.positionY=(int)objectArray.get(i);
-					p.valueY=(int)seqY.get(p.positionY);
+					p.positionY = objectArray.get(i);
+					p.valueY = seqY.get(p.positionY);
 					list.add(p);
 				}
 
 				// Sort
-				Collections.sort(list, (Pair o1, Pair o2)->{
-						if(o1.valueY==o2.valueY) {
-							return o1.positionY-o2.positionY;
-						}
-						return o1.valueY-o2.valueY;
-					});
-				
+				list.sort((Pair o1, Pair o2) -> {
+					if (o1.valueY.equals(o2.valueY)) {
+						return o1.positionY.compareTo(o2.positionY);
+					}
+					return o1.valueY.compareTo(o2.valueY);
+				});
+
 				// Copy back
 				for(long i=first; i<last;i++) {
 					Pair pair = list.get((int)(i-first));
@@ -527,7 +532,7 @@ public class BitmapTriples implements TriplesPrivate {
 		st.reset();
 
 		// Count predicates
-		SequenceLog64 predCount = new SequenceLog64(BitUtil.log2(seqY.getNumberOfElements()));
+		SequenceLog64Big predCount = new SequenceLog64Big(BitUtil.log2(seqY.getNumberOfElements()));
 		for(long i=0;i<seqY.getNumberOfElements(); i++) {
 			// Read value
 			long val = seqY.get(i);
@@ -549,7 +554,7 @@ public class BitmapTriples implements TriplesPrivate {
 		this.indexZ = objectArray;
 		this.bitmapIndexZ = bitmapIndex;
 		this.adjIndex = new AdjacencyList(this.indexZ, this.bitmapIndexZ);
-		
+
 		log.info("Index generated in {}", global.stopAndShow());
 	}
 	

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
@@ -8,10 +8,7 @@ import java.io.OutputStream;
 import org.rdfhdt.hdt.compact.bitmap.Bitmap;
 import org.rdfhdt.hdt.compact.bitmap.Bitmap375;
 import org.rdfhdt.hdt.compact.bitmap.BitmapFactory;
-import org.rdfhdt.hdt.compact.sequence.Sequence;
-import org.rdfhdt.hdt.compact.sequence.SequenceFactory;
-import org.rdfhdt.hdt.compact.sequence.SequenceLog64;
-import org.rdfhdt.hdt.compact.sequence.SequenceLog64Map;
+import org.rdfhdt.hdt.compact.sequence.*;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.util.BitUtil;
 import org.rdfhdt.hdt.util.StopWatch;
@@ -71,7 +68,7 @@ class PredicateIndexArray implements PredicateIndex {
 		IntermediateListener iListener = new IntermediateListener(listener);
 		StopWatch st = new StopWatch();
 		@SuppressWarnings("resource")
-		SequenceLog64 predCount = new SequenceLog64(BitUtil.log2(triples.getSeqY().getNumberOfElements()));
+		SequenceLog64Big predCount = new SequenceLog64Big(BitUtil.log2(triples.getSeqY().getNumberOfElements()));
 
 	    long maxCount = 0;
 	    for(long i=0;i<triples.getSeqY().getNumberOfElements(); i++) {
@@ -108,10 +105,10 @@ class PredicateIndexArray implements PredicateIndex {
 
 
 	    // Create predicate index
-	    SequenceLog64 array = new SequenceLog64(BitUtil.log2(triples.getSeqY().getNumberOfElements()), triples.getSeqY().getNumberOfElements());
+		SequenceLog64Big array = new SequenceLog64Big(BitUtil.log2(triples.getSeqY().getNumberOfElements()), triples.getSeqY().getNumberOfElements());
 	    array.resize(triples.getSeqY().getNumberOfElements());
 
-	    SequenceLog64 insertArray = new SequenceLog64(BitUtil.log2(triples.getSeqY().getNumberOfElements()), bitmap.countOnes());
+		SequenceLog64Big insertArray = new SequenceLog64Big(BitUtil.log2(triples.getSeqY().getNumberOfElements()), bitmap.countOnes());
 	    insertArray.resize(bitmap.countOnes());
 
 	    for(long i=0;i<triples.getSeqY().getNumberOfElements(); i++) {


### PR DESCRIPTION
We are adding some bug fixes to use longs and SeqLog64Big in order to avoid overflow problems when dealing with very large files where integers don't suffice anymore.

There is a as well some edge cases when a section is empty and using PFCSectionDictionaryBig class, it throws an exception so we handle this as well.

Some casts to int in resize methods as well are changed to just use long instead to avoid IndexOutOfBoundException when we have an overflow and get a negative value when the arrays are so big.