### PR TITLE
Fix TripleString match and equals methods if the CharSequences don't have equals() implemented

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleString.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleString.java
@@ -128,12 +128,25 @@ public class TripleString {
 		this.object = object;
 	}
 
+	private boolean equalsCharSequence(CharSequence cs1, CharSequence cs2) {
+		if (cs1 instanceof String && cs2 instanceof String)
+			return cs1.equals(cs2); // use string method if we can
+
+		if (cs1.length() != cs2.length())
+			return false;
+
+		for (int i = 0; i < cs1.length(); i++)
+			if (cs1.charAt(i) != cs2.charAt(i))
+				return false;
+		return true;
+	}
+
 	@Override
 	public boolean equals(Object other) {
 		if (other instanceof TripleString) {
 			TripleString ts = (TripleString) other;
-			return subject.equals(ts.subject) && predicate.equals(ts.predicate)
-					&& object.equals(ts.object);
+			return equalsCharSequence(subject, ts.subject) && equalsCharSequence(predicate, ts.predicate)
+					&& equalsCharSequence(object, ts.object);
 		}
 		return false;
 	}
@@ -152,9 +165,9 @@ public class TripleString {
 	 * @return boolean
 	 */
 	public boolean match(TripleString pattern) {
-        if (pattern.getSubject() == "" || pattern.getSubject().equals(this.subject)) {
-            if (pattern.getPredicate() == "" || pattern.getPredicate().equals(this.predicate)) {
-                if (pattern.getObject() == "" || pattern.getObject().equals(this.object)) {
+        if (pattern.getSubject().length() == 0 || equalsCharSequence(pattern.getSubject(), this.subject)) {
+            if (pattern.getPredicate().length() == 0 || equalsCharSequence(pattern.getPredicate(), this.predicate)) {
+                if (pattern.getObject().length() == 0 || equalsCharSequence(pattern.getObject(), this.object)) {
                     return true;
                 }
             }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/TripleStringTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/TripleStringTest.java
@@ -1,0 +1,85 @@
+package org.rdfhdt.hdt.triples;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TripleStringTest {
+    private static class CustomCharSequence implements CharSequence {
+
+        private final String str;
+
+        CustomCharSequence(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public int length() {
+            return str.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            return str.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new CustomCharSequence(str.substring(start, end));
+        }
+    }
+
+    private TripleString customTripleStr(String s, String p, String o) {
+        return new TripleString(
+                new CustomCharSequence(s),
+                new CustomCharSequence(p),
+                new CustomCharSequence(o)
+        );
+    }
+
+    @Test
+    public void tripleStringEqualsTest() {
+        String baseUri = "http://example.org/";
+
+        String s = baseUri + "subject";
+        String p = baseUri + "predicate";
+        String o = baseUri + "object";
+        String s2 = baseUri + "subject2";
+        String p2 = baseUri + "predicate2";
+        String o2 = baseUri + "object2";
+
+        TripleString ts1 = customTripleStr(s, p, o);
+        TripleString ts2 = customTripleStr(s, p, o);
+        TripleString ts3 = customTripleStr(s2, p2, o2);
+
+        Assert.assertEquals("ts1=ts1", ts1, ts1);
+        Assert.assertEquals("ts2=ts2", ts2, ts2);
+        Assert.assertEquals("ts1=ts2", ts1, ts2);
+        Assert.assertNotEquals("ts1!=ts3", ts1, ts3);
+    }
+
+    @Test
+    public void tripleStringMatchTest() {
+        String baseUri = "http://example.org/";
+
+        String s = baseUri + "subject";
+        String p = baseUri + "predicate";
+        String o = baseUri + "object";
+        String s2 = baseUri + "subject2";
+        String p2 = baseUri + "predicate2";
+        String o2 = baseUri + "object2";
+
+        TripleString ts1 = customTripleStr(s, p, o);
+        Assert.assertTrue("ts1 match itself", ts1.match(ts1));
+        Assert.assertTrue("ts1 match itself", ts1.match(customTripleStr(s, p, o)));
+        Assert.assertTrue("ts1 match sp?", ts1.match(customTripleStr(s, p, "")));
+        Assert.assertTrue("ts1 match ?p?", ts1.match(customTripleStr("", p, "")));
+        Assert.assertTrue("ts1 match s??", ts1.match(customTripleStr(s, "", "")));
+        Assert.assertTrue("ts1 match ???", ts1.match(customTripleStr("", "", "")));
+
+        Assert.assertFalse("ts1 not match itself", ts1.match(customTripleStr(s2, p2, o)));
+        Assert.assertFalse("ts1 not match 2 sp?", ts1.match(customTripleStr(s2, p2, "")));
+        Assert.assertFalse("ts1 not match 2 ?p?", ts1.match(customTripleStr("", p2, "")));
+        Assert.assertFalse("ts1 not match 2 s??", ts1.match(customTripleStr(s2, "", "")));
+    }
+
+}


### PR DESCRIPTION
## Issue

I was facing a bug where I was doing an the equals of 2 TripleString from 2 different searches, the value should have been true, but it wasn't [(This line)](https://github.com/ate47/hdt-java/blob/tripleposition-next/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/utils/HDTSortedUtils.java#L65).

In the Javadoc of [CharSquence](https://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html), we can read:

> interface does not refine the general contracts of the [equals](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#equals-java.lang.Object-) and [hashCode](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#hashCode--) methods. The result of comparing two objects that implement CharSequence is therefore, in general, undefined

So we need to check all the CharSequence usage in RDF-HDT, my PR is only fixing it in TripleString. (the main usage location) 

## PR Changes

In this PR I've added into the equals and match method of TripleString a custom equals if the type of the triple isn't a String.

## Tests

Because the API doesn't have a test module, I've put the test inside the CORE module (this should be changed if future test are required)