### PR TITLE
Fix #126 "Make sure bytebuffer never exceeds Integer.MAX_VALUE"

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 import org.rdfhdt.hdt.util.Mutable;
+import org.rdfhdt.hdt.util.io.BigMappedByteBuffer;
 
 /**
  * Typical implementation of Variable-Byte encoding for integers.
@@ -81,23 +82,45 @@ public class VByte {
 		out |= (readbyte & 127) << shift;
 		return out;
 	}
-	
+
 	public static long decode(ByteBuffer in) throws IOException {
 		long out = 0;
 		int shift=0;
 		if(!in.hasRemaining()) throw new EOFException();
 		byte readbyte = in.get();
-		
+
 		while( (readbyte & 0x80)==0) {
 			if(shift>=50) { // We read more bytes than required to load the max long
 				throw new IllegalArgumentException();
 			}
-			
+
 			out |= (readbyte & 127) << shift;
-			
+
 			if(!in.hasRemaining()) throw new EOFException();
 			readbyte = in.get();
-			
+
+			shift+=7;
+		}
+		out |= (readbyte & 127) << shift;
+		return out;
+	}
+
+	public static long decode(BigMappedByteBuffer in) throws IOException {
+		long out = 0;
+		int shift=0;
+		if(!in.hasRemaining()) throw new EOFException();
+		byte readbyte = in.get();
+
+		while( (readbyte & 0x80)==0) {
+			if(shift>=50) { // We read more bytes than required to load the max long
+				throw new IllegalArgumentException();
+			}
+
+			out |= (readbyte & 127) << shift;
+
+			if(!in.hasRemaining()) throw new EOFException();
+			readbyte = in.get();
+
 			shift+=7;
 		}
 		out |= (readbyte & 127) << shift;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCOptimizedExtractor.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCOptimizedExtractor.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 
 import org.rdfhdt.hdt.compact.integer.VByte;
 import org.rdfhdt.hdt.compact.sequence.Sequence;
+import org.rdfhdt.hdt.util.io.BigMappedByteBuffer;
 import org.rdfhdt.hdt.util.string.CompactString;
 import org.rdfhdt.hdt.util.string.ReplazableString;
 
@@ -21,8 +22,8 @@ public class PFCOptimizedExtractor {
 	PFCDictionarySectionMap pfc;
 	long numstrings;
 	int blocksize;
-	ByteBuffer [] buffers;
-	ByteBuffer buffer;
+	BigMappedByteBuffer[] buffers;
+	BigMappedByteBuffer buffer;
 	long [] posFirst;
 	Sequence blocks;
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/BigMappedByteBuffer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/BigMappedByteBuffer.java
@@ -1,0 +1,177 @@
+package org.rdfhdt.hdt.util.io;
+
+import java.io.IOException;
+import java.nio.*;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class BigMappedByteBuffer {
+    static long maxBufferSize = Integer.MAX_VALUE;
+
+    /**
+     * create a BigMappedByteBuffer of multiple {@link FileChannel#map(FileChannel.MapMode, long, long)} call
+     * @param ch the File channel
+     * @param mode the mode
+     * @param position the position in the file
+     * @param size the size of the buffer, can be higher than {@link Integer#MAX_VALUE}
+     * @return BigMappedByteBuffer
+     * @throws IOException if we can't call {@link FileChannel#map(FileChannel.MapMode, long, long)}
+     */
+    public static BigMappedByteBuffer ofFileChannel(FileChannel ch, FileChannel.MapMode mode, long position, long size) throws IOException {
+        int bufferCount = (int) ((size - 1) / maxBufferSize) + 1;
+        BigMappedByteBuffer buffer = new BigMappedByteBuffer(new ArrayList<>());
+        for (int i = 0; i < bufferCount; i++) {
+            long mapSize;
+
+            if (i == bufferCount - 1 && size % maxBufferSize != 0) {
+                mapSize = size % maxBufferSize;
+            } else {
+                mapSize = maxBufferSize;
+            }
+            buffer.buffers.add(ch.map(mode, position + (long) i * maxBufferSize, mapSize));
+        }
+        return buffer;
+    }
+
+    private final List<ByteBuffer> buffers;
+
+    /**
+     * cat multiple buffers
+     * @param buffers the buffers
+     */
+    private BigMappedByteBuffer(List<ByteBuffer> buffers) {
+        this.buffers = buffers;
+    }
+
+    private BigMappedByteBuffer(BigMappedByteBuffer other, Function<ByteBuffer, ByteBuffer> map) {
+        this(other.buffers.stream().map(map).collect(Collectors.toList()));
+    }
+
+    List<ByteBuffer> getBuffers() {
+        return buffers;
+    }
+
+    /**
+     * set the byte order of the buffer
+     * @param order the order
+     */
+    public void order(ByteOrder order) {
+        buffers.forEach(b -> b.order(order));
+    }
+
+    /**
+     * @return the capacity of the big buffer
+     */
+    public long capacity() {
+        return buffers.stream().mapToLong(ByteBuffer::capacity).sum();
+    }
+
+    private int getBufferOffset(long index) {
+        return (int) (index % maxBufferSize);
+    }
+
+    private int getBufferIndex(long index) {
+        return (int) (index / maxBufferSize);
+    }
+
+    /**
+     * get a byte at a particular index
+     * @param index the byte index
+     * @return byte
+     */
+    public byte get(long index) {
+        int buffer = getBufferIndex(index);
+        int inBufferIndex = getBufferOffset(index);
+
+        if (buffer < 0 || buffer >= buffers.size())
+            throw new IndexOutOfBoundsException();
+
+        return buffers.get(buffer).get(inBufferIndex);
+    }
+
+    /**
+     * set the position of the buffer
+     * @param position the position
+     */
+    public void position(long position) {
+        int mid = getBufferIndex(position);
+        for (int i = 0; i < mid; i++) {
+            buffers.get(i).position((int) maxBufferSize);
+        }
+        buffers.get(mid).position(getBufferOffset(position));
+        for (int i = mid + 1; i < buffers.size(); i++) {
+            buffers.get(i).position(0);
+        }
+    }
+
+    /**
+     * @return the position
+     */
+    public long position() {
+        long pos = 0;
+        for (ByteBuffer b : buffers) {
+            pos += b.position();
+            if (b.hasRemaining())
+                break;
+        }
+        return pos;
+    }
+
+    /**
+     * @return duplicate the buffer
+     */
+    public BigMappedByteBuffer duplicate() {
+        return new BigMappedByteBuffer(this, ByteBuffer::duplicate);
+    }
+
+    /**
+     * @return if we have remaining byte(s) to read
+     */
+    public boolean hasRemaining() {
+        return position() < capacity();
+    }
+
+    /**
+     * @return a byte, update the position
+     */
+    public byte get() {
+        return buffers.get(getBufferIndex(position())).get();
+    }
+
+    /**
+     * rewind the buffer
+     */
+    public void rewind() {
+        buffers.forEach(ByteBuffer::rewind);
+    }
+
+    /**
+     * read a particular number of bytes in the buffer
+     * @param dst the destination array
+     * @param offset the offset in the offset
+     * @param length the length to read
+     */
+    public void get(byte[] dst, int offset, int length) {
+        final long position = position();
+        int buffer1 = getBufferIndex(position);
+        int buffer2 = getBufferIndex(position + length - 1);
+
+        if (buffer1 == buffer2) {
+            // all the bytes are in the same buffer
+            ByteBuffer b = buffers.get(buffer1);
+            b.get(dst, offset, length);
+        } else {
+            // we are using 2 buffers
+            ByteBuffer b1 = buffers.get(buffer1);
+            ByteBuffer b2 = buffers.get(buffer2);
+
+            int toRead = b1.capacity() - getBufferOffset(position);
+
+            b1.get(dst, offset, toRead);
+            b2.get(dst, offset + toRead, length - toRead);
+        }
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
+import org.rdfhdt.hdt.util.io.BigMappedByteBuffer;
 
 
 /**
@@ -94,8 +95,14 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 		in.read(buffer, pos, len);
 		used = pos+len;
 	}
-	
+
 	public void replace(ByteBuffer in, int pos, int len) throws IOException {
+		ensureSize(pos+len);
+		in.get(buffer, pos, len);
+		used = pos+len;
+	}
+
+	public void replace(BigMappedByteBuffer in, int pos, int len) throws IOException {
 		ensureSize(pos+len);
 		in.get(buffer, pos, len);
 		used = pos+len;
@@ -154,10 +161,10 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 			used+=numread;
 		}
 	}
-	
+
 	public void replace(ByteBuffer in, int pos) throws IOException {
 		used = pos;
-		
+
 		int n = in.capacity()-in.position();
 		while(n-- != 0) {
 			byte value = in.get();
@@ -169,7 +176,23 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 			}
 			buffer[used++] = value;
 		}
-		throw new IllegalArgumentException("Was reading a string but stream ended before finding the null terminator");				
+		throw new IllegalArgumentException("Was reading a string but stream ended before finding the null terminator");
+	}
+	public void replace(BigMappedByteBuffer in, int pos) throws IOException {
+		used = pos;
+
+		long n = in.capacity()-in.position();
+		while(n-- != 0) {
+			byte value = in.get();
+			if(value==0) {
+				return;
+			}
+			if(used>=buffer.length) {
+				buffer = Arrays.copyOf(buffer, buffer.length*2);
+			}
+			buffer[used++] = value;
+		}
+		throw new IllegalArgumentException("Was reading a string but stream ended before finding the null terminator");
 	}
 	
 	/* (non-Javadoc)

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionMapTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionMapTest.java
@@ -1,8 +1,16 @@
 package org.rdfhdt.hdt.dictionary.impl.section;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.rdfhdt.hdt.exceptions.NotFoundException;
 import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.triples.IteratorTripleString;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
 
 public class PFCDictionarySectionMapTest {
 

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/BigMappedByteBufferTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/BigMappedByteBufferTest.java
@@ -1,0 +1,126 @@
+package org.rdfhdt.hdt.util.io;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.rdfhdt.hdt.exceptions.NotFoundException;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+public class BigMappedByteBufferTest {
+
+    private long normalBufferSize;
+    private BigMappedByteBuffer buffer;
+    private long size;
+    private FileChannel ch;
+
+    @Before
+    public void setup() throws IOException {
+        normalBufferSize = BigMappedByteBuffer.maxBufferSize;
+
+        final String rawFileName = Objects.requireNonNull(getClass().getClassLoader().getResource("dbpedia.hdt"), "can't find dbpedia hdt").getFile();
+
+        Path path = Paths.get(rawFileName);
+
+        size = Files.size(path);
+
+        BigMappedByteBuffer.maxBufferSize = size / 5; // test with huge split
+
+        ch = FileChannel.open(path);
+        buffer = BigMappedByteBuffer.ofFileChannel(ch, FileChannel.MapMode.READ_ONLY, 0, size);
+    }
+
+    @After
+    public void unSetup() throws IOException {
+        ch.close();
+        BigMappedByteBuffer.maxBufferSize = normalBufferSize;
+    }
+
+    @Test
+    public void capacityBuffer() {
+        List<ByteBuffer> buffers = buffer.getBuffers();
+
+        for (int i = 0; i < buffers.size() - 1; i++) {
+            int c = buffers.get(i).capacity();
+            Assert.assertEquals("Buffer size #" + i, BigMappedByteBuffer.maxBufferSize, c);
+        }
+
+        int c = buffers.get(buffers.size() - 1).capacity();
+
+        if (size % BigMappedByteBuffer.maxBufferSize == 0) {
+            Assert.assertEquals("Buffer size #" + (buffers.size() - 1), BigMappedByteBuffer.maxBufferSize, c);
+        } else {
+            Assert.assertEquals("Buffer size #" + (buffers.size() - 1), size % BigMappedByteBuffer.maxBufferSize, c);
+        }
+
+    }
+    @Test
+    public void capacity() {
+        Assert.assertEquals("Buffer size", size, buffer.capacity());
+    }
+
+    @Test
+    public void get() throws IOException {
+        BigMappedByteBuffer buffer1 = buffer.duplicate();
+        MappedByteBuffer buffer2 = ch.map(FileChannel.MapMode.READ_ONLY, 0, size);
+
+        while (buffer2.hasRemaining() && buffer1.hasRemaining()) {
+            Assert.assertEquals("position", buffer1.position(), buffer2.position());
+            Assert.assertEquals("byte op", buffer1.get(), buffer2.get());
+        }
+
+        Assert.assertFalse("Buffer 1 empty", buffer1.hasRemaining());
+        Assert.assertFalse("Buffer 2 empty", buffer2.hasRemaining());
+    }
+
+    @Test
+    public void position() throws IOException {
+        BigMappedByteBuffer test = buffer.duplicate();
+
+        for (long i = 0; i < size; i++) {
+            test.position(i);
+            Assert.assertEquals("position", i, test.position());
+        }
+    }
+
+    @Test
+    public void getBuff() throws IOException {
+        BigMappedByteBuffer buffer1 = buffer.duplicate();
+        MappedByteBuffer buffer2 = ch.map(FileChannel.MapMode.READ_ONLY, 0, size);
+
+        // add +2 to assure the cross-buffer reading
+        byte[] bytes1 = new byte[(int)(BigMappedByteBuffer.maxBufferSize / 2 + 2)];
+        byte[] bytes2 = new byte[bytes1.length];
+
+        while (buffer2.hasRemaining() && buffer1.hasRemaining()) {
+            int toRead = (int) Math.min(bytes1.length, buffer1.capacity() - buffer2.position());
+            buffer1.get(bytes1, 0, toRead);
+            buffer2.get(bytes2, 0, toRead);
+            Assert.assertArrayEquals("byte op", bytes1, bytes2);
+        }
+
+        Assert.assertFalse("Buffer 1 empty", buffer1.hasRemaining());
+        Assert.assertFalse("Buffer 2 empty", buffer2.hasRemaining());
+    }
+
+
+    @Test
+    @Ignore("HDT git ignored")
+    public void largeTest() throws IOException, NotFoundException {
+        // see https://github.com/rdfhdt/hdt-java/issues/126#issuecomment-1036228969
+        HDT hdt = HDTManager.mapHDT("/Users/ate/Downloads/archive/dbpedia2016-10.hdt");
+
+        System.out.println(hdt.getTriples().getNumberOfElements());
+    }
+}


### PR DESCRIPTION
I've made this little fix for #126, it's using multiple MappedByteBuffer instead of one if the size of the bytebuffer is too big (the max size is set to Integer.MAX_VALUE)

Because the ByteBuffer classes constructors of the nio package are package-private, I wasn't able to create a children of the ByteBuffer class, so I cloned the methods using the ByteBuffer to use my new class, BigMappedByteBuffer.

## Tests

I've tried all the methods reimplemented to see if it was working across multiple mapped buffers. So 5 new tests were added + 1 ignored because it was using the test HDT ``dbpedia2016-10.hdt``. (36GB+)

