### PR TITLE
Fix "IllegalFormatException or IllegalArgumentException while reading RDF with B-Nodes in two-pass mode" #158

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/rdf/RDFParserCallback.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/rdf/RDFParserCallback.java
@@ -44,6 +44,6 @@ public interface RDFParserCallback {
 		void processTriple(TripleString triple, long pos);
 	}
 	
-	void doParse(String fileName, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException;
-	void doParse(InputStream in, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException;
+	void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException;
+	void doParse(InputStream in, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException;
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterOnePass.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterOnePass.java
@@ -27,9 +27,6 @@
 
 package org.rdfhdt.hdt.hdt.impl;
 
-import java.io.IOException;
-import java.util.Iterator;
-
 import org.rdfhdt.hdt.dictionary.TempDictionary;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.enums.TripleComponentRole;
@@ -46,9 +43,11 @@ import org.rdfhdt.hdt.triples.TempTriples;
 import org.rdfhdt.hdt.triples.TripleString;
 import org.rdfhdt.hdt.util.listener.ListenerUtil;
 
+import java.util.Iterator;
+
 public class TempHDTImporterOnePass implements TempHDTImporter {
 
-	class TripleAppender implements RDFCallback {
+	static class TripleAppender implements RDFCallback {
 		final TempDictionary dict;
 		final TempTriples triples;
 		final ProgressListener listener;
@@ -76,10 +75,10 @@ public class TempHDTImporterOnePass implements TempHDTImporter {
 
 	@Override
 	public TempHDT loadFromRDF(HDTOptions specs, String filename, String baseUri, RDFNotation notation, ProgressListener listener)
-			throws IOException, ParserException {
+			throws ParserException {
 		
 		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation);
-		
+
 		// Create Modifiable Instance
 		TempHDT modHDT = new TempHDTImpl(specs, baseUri, ModeOfLoading.ONE_PASS);
 		TempDictionary dictionary = modHDT.getDictionary();
@@ -88,7 +87,7 @@ public class TempHDTImporterOnePass implements TempHDTImporter {
 
         // Load RDF in the dictionary and generate triples
         dictionary.startProcessing();
-        parser.doParse(filename, baseUri, notation, appender);
+        parser.doParse(filename, baseUri, notation, true, appender);
         dictionary.endProcessing();
 		
 		// Reorganize both the dictionary and the triples
@@ -100,8 +99,7 @@ public class TempHDTImporterOnePass implements TempHDTImporter {
 		return modHDT; 
 	}
 	
-	public TempHDT loadFromTriples(HDTOptions specs, Iterator<TripleString> iterator, String baseUri, ProgressListener listener)
-			throws IOException {
+	public TempHDT loadFromTriples(HDTOptions specs, Iterator<TripleString> iterator, String baseUri, ProgressListener listener) {
 			
 		// Create Modifiable Instance
 		TempHDT modHDT = new TempHDTImpl(specs, baseUri, ModeOfLoading.ONE_PASS);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterTwoPass.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterTwoPass.java
@@ -27,8 +27,6 @@
 
 package org.rdfhdt.hdt.hdt.impl;
 
-import java.io.IOException;
-
 import org.rdfhdt.hdt.dictionary.TempDictionary;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.enums.TripleComponentRole;
@@ -46,7 +44,7 @@ import org.rdfhdt.hdt.util.listener.ListenerUtil;
 
 public class TempHDTImporterTwoPass implements TempHDTImporter {
 
-	class DictionaryAppender implements RDFCallback {
+	static class DictionaryAppender implements RDFCallback {
 
 		final TempDictionary dict;
 		final ProgressListener listener;
@@ -77,7 +75,7 @@ public class TempHDTImporterTwoPass implements TempHDTImporter {
 	 * @author mario.arias
 	 *
 	 */
-	class TripleAppender2 implements RDFCallback {
+	static class TripleAppender2 implements RDFCallback {
 		final TempDictionary dict;
 		final TempTriples triples;
 		final ProgressListener listener;
@@ -103,7 +101,7 @@ public class TempHDTImporterTwoPass implements TempHDTImporter {
 
     @Override
 	public TempHDT loadFromRDF(HDTOptions specs, String filename, String baseUri, RDFNotation notation, ProgressListener listener)
-			throws IOException, ParserException {
+			throws ParserException {
 		
 		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation);
 
@@ -114,14 +112,15 @@ public class TempHDTImporterTwoPass implements TempHDTImporter {
 
 		// Load RDF in the dictionary
 		dictionary.startProcessing();
-		parser.doParse(filename, baseUri, notation, new DictionaryAppender(dictionary, listener));
+		parser.doParse(filename, baseUri, notation, true, new DictionaryAppender(dictionary, listener));
 		dictionary.endProcessing();
+
 
 		// Reorganize IDs before loading triples
 		modHDT.reorganizeDictionary(listener);
 
 		// Load triples (second pass)
-		parser.doParse(filename, baseUri, notation, new TripleAppender2(dictionary, triples, listener));
+		parser.doParse(filename, baseUri, notation, true, new TripleAppender2(dictionary, triples, listener));
 
 		//reorganize HDT
 		modHDT.reorganizeTriples(listener);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/header/PlainHeader.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/header/PlainHeader.java
@@ -132,7 +132,7 @@ public class PlainHeader implements HeaderPrivate, RDFCallback {
 		
 		try {
 			RDFParserSimple parser = new RDFParserSimple();
-			parser.doParse(new ByteArrayInputStream(headerData), "http://www.rdfhdt.org", RDFNotation.NTRIPLES, this);
+			parser.doParse(new ByteArrayInputStream(headerData), "http://www.rdfhdt.org", RDFNotation.NTRIPLES, true, this);
 		} catch (ParserException e) {
 			log.error("Unexpected exception.", e);
 			throw new IllegalFormatException("Error parsing header");

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserList.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserList.java
@@ -50,7 +50,7 @@ public class RDFParserList implements RDFParserCallback {
 	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String, java.lang.String, hdt.enums.RDFNotation, hdt.rdf.RDFParserCallback.RDFCallback)
 	 */
 	@Override
-	public void doParse(String fileName, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		BufferedReader reader;
 		try {
 			reader = IOUtil.getFileReader(fileName);
@@ -59,17 +59,17 @@ public class RDFParserList implements RDFParserCallback {
 			throw new ParserException(e);
 		}
 		try {
-			doParse(reader, baseUri, notation, callback);
+			doParse(reader, baseUri, notation, keepBNode, callback);
 		} finally {
 			IOUtil.closeQuietly(reader);
 		}
 	}
 
 	@Override
-    public void doParse(InputStream input, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+    public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(input));
 		try {
-			doParse(reader, baseUri, notation, callback);
+			doParse(reader, baseUri, notation, keepBNode, callback);
 		} finally {
 			try {
 				reader.close();
@@ -78,7 +78,7 @@ public class RDFParserList implements RDFParserCallback {
 		}
 	}
 
-	private void doParse(BufferedReader reader, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	private void doParse(BufferedReader reader, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 			String line;
 			while((line=reader.readLine())!=null) {
@@ -90,7 +90,7 @@ public class RDFParserList implements RDFParserCallback {
 					System.out.println("Parse from list: "+line+" as "+guessnot);
 					RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot);
 
-					parser.doParse(line, baseUri, guessnot, callback);
+					parser.doParse(line, baseUri, guessnot, keepBNode, callback);
 				}
 			}
 			reader.close();

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRAR.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRAR.java
@@ -60,7 +60,7 @@ public class RDFParserRAR implements RDFParserCallback {
 	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String, java.lang.String, hdt.enums.RDFNotation, hdt.rdf.RDFParserCallback.Callback)
 	 */
 	@Override
-	public void doParse(String rarFile, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(String rarFile, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 			
 			String [] cmdList1 = Arrays.copyOf(cmdList, cmdList.length);
@@ -90,7 +90,7 @@ public class RDFParserRAR implements RDFParserCallback {
 					Process processExtract = extractProcessBuilder.start();
 
 					InputStream in = processExtract.getInputStream();
-					parser.doParse(in, baseUri, guessnot, callback);
+					parser.doParse(in, baseUri, guessnot, keepBNode, callback);
 					
 					in.close();
 					processExtract.waitFor();
@@ -109,7 +109,7 @@ public class RDFParserRAR implements RDFParserCallback {
 	}
 
 	@Override
-	public void doParse(InputStream input, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		throw new NotImplementedException();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserSimple.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserSimple.java
@@ -51,7 +51,7 @@ public class RDFParserSimple implements RDFParserCallback {
 	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String, java.lang.String, hdt.enums.RDFNotation, hdt.rdf.RDFParserCallback.RDFCallback)
 	 */
 	@Override
-	public void doParse(String fileName, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		BufferedReader reader;
 		try {
 			reader = IOUtil.getFileReader(fileName);
@@ -60,17 +60,17 @@ public class RDFParserSimple implements RDFParserCallback {
 			throw new ParserException(e);
 		}
 		try {
-			doParse(reader, baseUri, notation, callback);
+			doParse(reader, baseUri, notation, keepBNode, callback);
 		} finally {
 			IOUtil.closeQuietly(reader);
 		}
 	}
 
 	@Override
-    public void doParse(InputStream input, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+    public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(input));
 		try {
-			doParse(reader, baseUri, notation, callback);
+			doParse(reader, baseUri, notation, keepBNode, callback);
 		} finally {
 			try {
 				reader.close();
@@ -79,7 +79,7 @@ public class RDFParserSimple implements RDFParserCallback {
 		}
 	}
 
-	private void doParse(BufferedReader reader, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	private void doParse(BufferedReader reader, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 			String line;
 			long numLine = 1;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserTar.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserTar.java
@@ -33,10 +33,10 @@ public class RDFParserTar implements RDFParserCallback {
 	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String, java.lang.String, hdt.enums.RDFNotation, hdt.rdf.RDFParserCallback.Callback)
 	 */
 	@Override
-	public void doParse(String fileName, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 			InputStream input = IOUtil.getFileInputStream(fileName);
-			this.doParse(input, baseUri, notation, callback);
+			this.doParse(input, baseUri, notation, keepBNode, callback);
 			input.close();
 		} catch (Exception e) {
 			log.error("Unexpected exception parsing file: {}", fileName, e);
@@ -45,7 +45,7 @@ public class RDFParserTar implements RDFParserCallback {
 	}
 
 	@Override
-	public void doParse(InputStream input, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 
 			final TarArchiveInputStream debInputStream = (TarArchiveInputStream) new ArchiveStreamFactory().createArchiveInputStream("tar", input);
@@ -62,7 +62,7 @@ public class RDFParserTar implements RDFParserCallback {
 						log.info("Parse from tar: {} as {}", entry.getName(), guessnot);
 						RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot);
 
-						parser.doParse(nonCloseIn, baseUri, guessnot, callback);
+						parser.doParse(nonCloseIn, baseUri, guessnot, keepBNode, callback);
 					}catch (IllegalArgumentException | ParserException e1) {
 						log.error("Unexpected exception.", e1);
 					}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserZip.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserZip.java
@@ -29,10 +29,10 @@ public class RDFParserZip implements RDFParserCallback {
 	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String, java.lang.String, hdt.enums.RDFNotation, hdt.rdf.RDFParserCallback.Callback)
 	 */
 	@Override
-	public void doParse(String fileName, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 			InputStream input = IOUtil.getFileInputStream(fileName);
-			this.doParse(input, baseUri, notation, callback);
+			this.doParse(input, baseUri, notation, keepBNode, callback);
 			input.close();
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -41,7 +41,7 @@ public class RDFParserZip implements RDFParserCallback {
 	}
 
 	@Override
-	public void doParse(InputStream input, String baseUri, RDFNotation notation, RDFCallback callback) throws ParserException {
+	public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		try {
 			ZipInputStream zin = new ZipInputStream(input);
 			
@@ -56,7 +56,7 @@ public class RDFParserZip implements RDFParserCallback {
 						System.out.println("Parse from zip: "+zipEntry.getName()+" as "+guessnot);
 						RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot);
 
-						parser.doParse(nonCloseIn, baseUri, guessnot, callback);
+						parser.doParse(nonCloseIn, baseUri, guessnot, keepBNode, callback);
 					}catch (IllegalArgumentException e1) {
 						e1.printStackTrace();
 					}catch (ParserException e1) {

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterTest.java
@@ -1,0 +1,85 @@
+package org.rdfhdt.hdt.hdt.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.rdfhdt.hdt.enums.RDFNotation;
+import org.rdfhdt.hdt.exceptions.NotFoundException;
+import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.options.HDTSpecification;
+import org.rdfhdt.hdt.rdf.RDFParserCallback;
+import org.rdfhdt.hdt.rdf.RDFParserFactory;
+import org.rdfhdt.hdt.triples.TripleString;
+import org.rdfhdt.hdt.triples.impl.utils.HDTTestUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+@RunWith(Parameterized.class)
+public class TempHDTImporterTest {
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object> setup() {
+		return Arrays.asList("one-pass", "two-pass");
+	}
+	private final HDTSpecification spec;
+
+	public TempHDTImporterTest(String mode) {
+		spec = new HDTSpecification();
+		spec.set("loader.type", mode);
+		spec.set("loader.bnode.seed", "1234567");
+	}
+
+	private String getFile(String f) {
+		return Objects.requireNonNull(getClass().getClassLoader().getResource(f), "Can't find " + f).getFile();
+	}
+	@Test
+	public void bNodeXTest() throws ParserException, IOException, NotFoundException {
+		HDT hdt = HDTManager.generateHDT(getFile("importer/bnode_x.nt"), HDTTestUtils.BASE_URI, RDFNotation.NTRIPLES, spec, null);
+		hdt.search("", "", "").forEachRemaining(System.out::println);
+		hdt.close();
+	}
+	@Test
+	public void bNodeZTest() throws ParserException, IOException, NotFoundException {
+		HDT hdt = HDTManager.generateHDT(getFile("importer/bnode_z.nt"), HDTTestUtils.BASE_URI, RDFNotation.NTRIPLES, spec, null);
+		hdt.search("", "", "").forEachRemaining(System.out::println);
+		hdt.close();
+	}
+
+	private Iterator<TripleString> asIt(String file) throws ParserException {
+		List<TripleString> triples = new ArrayList<>();
+		RDFNotation notation = RDFNotation.guess(file);
+		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation);
+		parser.doParse(file, HDTTestUtils.BASE_URI, notation, true, new RDFParserCallback.RDFCallback() {
+			@Override
+			public void processTriple(TripleString triple, long pos) {
+				// force duplication of the triple string data
+				triples.add(new TripleString(
+						triple.getSubject().toString(),
+						triple.getPredicate().toString(),
+						triple.getObject().toString()
+				));
+			}
+		});
+		return triples.iterator();
+	}
+
+	@Test
+	public void bNodeXStreamTest() throws ParserException, IOException, NotFoundException {
+		HDT hdt = HDTManager.generateHDT(asIt(getFile("importer/bnode_x.nt")), HDTTestUtils.BASE_URI, spec, null);
+		hdt.search("", "", "").forEachRemaining(System.out::println);
+		hdt.close();
+	}
+	@Test
+	public void bNodeZStreamTest() throws ParserException, IOException, NotFoundException {
+		HDT hdt = HDTManager.generateHDT(asIt(getFile("importer/bnode_z.nt")), HDTTestUtils.BASE_URI, spec, null);
+		hdt.search("", "", "").forEachRemaining(System.out::println);
+		hdt.close();
+	}
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/writer/TripleWritterHDTTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/writer/TripleWritterHDTTest.java
@@ -31,7 +31,7 @@ public class TripleWritterHDTTest {
 			final TripleWriterHDT wr = new TripleWriterHDT("http://example.org", new HDTSpecification(), file.toString(), false);
 			
 			RDFParserCallback pars = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES);
-			pars.doParse("data/test.nt", "http://example.org", RDFNotation.NTRIPLES, new RDFParserCallback.RDFCallback() {	
+			pars.doParse("data/test.nt", "http://example.org", RDFNotation.NTRIPLES, false, new RDFParserCallback.RDFCallback() {
 				@Override
 				public void processTriple(TripleString triple, long pos) {				
 					try {

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/AbstractNTriplesParserTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/AbstractNTriplesParserTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractNTriplesParserTest {
         InputStream in = new ByteArrayInputStream(ntriples.getBytes(UTF_8));
 
         final List<TripleString> triples = new ArrayList<>();
-        createParser().doParse(in, "http://example.com#", RDFNotation.NTRIPLES,
+        createParser().doParse(in, "http://example.com#", RDFNotation.NTRIPLES, false,
                 new RDFParserCallback.RDFCallback() {
                     @Override
                     public void processTriple(TripleString triple, long pos) {

--- a/hdt-java-core/src/test/resources/importer/bnode_x.nt
+++ b/hdt-java-core/src/test/resources/importer/bnode_x.nt
@@ -1,0 +1,2 @@
+_:mysupernode <p> <o> .
+<s> <p> <o> .

--- a/hdt-java-core/src/test/resources/importer/bnode_z.nt
+++ b/hdt-java-core/src/test/resources/importer/bnode_z.nt
@@ -1,0 +1,2 @@
+<s> <p> _:mysupernode .
+<s> <p> <o> .


### PR DESCRIPTION
~~In this pull request, I've fixed the issue #158, it add a new class ``MultiPassBNodeParser `` to clear a ``RDFParserCallback.RDFCallback`` and return the same BNodes id at each parse, the bnodes names are still random, but we can now control the random seed with the HDTOptions "loader.bnode.seed" (0 = random).~~

~~It also impact the One-Pass parser, so if we set a seed, we will get the same bnode names with a Two or One pass parser, removing the randomness if needed.~~

Edit:

In this pull request, I added to the API in the RDF parser an option to ask to keep blank nodes or node while parsing, this feature is then used to fix the issue #158  with the 2-pass parsing.