### PR TITLE
fix IndexOutOfBound for loaded HDT BigByteBuffer of size > 2^31

### DIFF
--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
@@ -95,14 +95,14 @@ public class VByte {
 				throw new IllegalArgumentException();
 			}
 
-			out |= (readbyte & 127) << shift;
+			out |= (readbyte & 127L) << shift;
 
 			if(!in.hasRemaining()) throw new EOFException();
 			readbyte = in.get();
 
 			shift+=7;
 		}
-		out |= (readbyte & 127) << shift;
+		out |= (readbyte & 127L) << shift;
 		return out;
 	}
 
@@ -117,14 +117,14 @@ public class VByte {
 				throw new IllegalArgumentException();
 			}
 
-			out |= (readbyte & 127) << shift;
+			out |= (readbyte & 127L) << shift;
 
 			if(!in.hasRemaining()) throw new EOFException();
 			readbyte = in.get();
 
 			shift+=7;
 		}
-		out |= (readbyte & 127) << shift;
+		out |= (readbyte & 127L) << shift;
 		return out;
 	}
 	
@@ -149,11 +149,11 @@ public class VByte {
 		int i=0;
 		int shift=0;
 		while( (0x80 & data[offset+i])==0) {
-			out |= (data[offset+i] & 127) << shift;
+			out |= (data[offset+i] & 127L) << shift;
 			i++;
 			shift+=7;
 		}
-		out |= (data[offset+i] & 127) << shift;
+		out |= (data[offset+i] & 127L) << shift;
 		i++;
 		value.setValue(out);
 		return i;
@@ -164,11 +164,11 @@ public class VByte {
 		int i = 0;
 		int shift=0;
 		while( (0x80 & data.get(offset+i))==0) {
-			out |= (data.get(offset+i) & 127) << shift;
+			out |= (data.get(offset+i) & 127L) << shift;
 			i++;
 			shift+=7;
 		}
-		out |= (data.get(offset+i) & 127) << shift;
+		out |= (data.get(offset+i) & 127L) << shift;
 		i++;
 		value.setValue(out);
 		return i;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ByteStringUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ByteStringUtil.java
@@ -143,11 +143,7 @@ public class ByteStringUtil {
 				return a-b;
 			}
 			if(a==0) {
-				if(b==0) {
-					return 0;
-				} else {
-					return -1;
-				}
+				return 0;
 			}
 		}
 
@@ -164,7 +160,7 @@ public class ByteStringUtil {
 	public static int strcmp(CharSequence str, BigByteBuffer buff2, long off2) {
 		byte [] buff1;
 		int off1;
-		int len1;
+		long len1;
 		long len2=buff2.size();
 
 		if(str instanceof CompactString) {
@@ -183,7 +179,7 @@ public class ByteStringUtil {
 			throw new NotImplementedException();
 		}
 
-		int n = Math.min(len1-off1, (int) (len2-off2));
+		int n = (int) Math.min(len1-off1, len2-off2);
 
 		int p1 = off1;
 		long p2 = off2;
@@ -194,11 +190,7 @@ public class ByteStringUtil {
 				return a-b;
 			}
 			if(a==0) {
-				if(b==0) {
-					return 0;
-				} else {
-					return -1;
-				}
+				return 0;
 			}
 		}
 
@@ -235,7 +227,7 @@ public class ByteStringUtil {
 
 		// Compare
 		int i=0;
-		int n = Math.min(len, buffer.capacity()-offset);
+		long n = Math.min(len, buffer.capacity()-offset);
 		while(i<n) {
 			int v1 = buf[i] & 0xFF;
 			int v2 = buffer.get(offset+i) & 0xFF;


### PR DESCRIPTION
In the pull request #104, I forgot to cast to long a value, it was throwing an exception for big enough hdt, example:

```
java.lang.ArrayIndexOutOfBoundsException: Index 74 out of bounds for length 74
        at org.rdfhdt.hdt.util.string.ByteStringUtil.strcmp(ByteStringUtil.java:193) ~[hdt-java-core-3.0.2.jar!/:na]
        at org.rdfhdt.hdt.dictionary.impl.section.PFCDictionarySectionBig.locateBlock(PFCDictionarySectionBig.java:242) ~[hdt-java-core-3.0.2.jar!/:na]
        at org.rdfhdt.hdt.dictionary.impl.section.PFCDictionarySectionBig.locate(PFCDictionarySectionBig.java:263) ~[hdt-java-core-3.0.2.jar!/:na]
        at org.rdfhdt.hdt.dictionary.impl.BaseDictionary.stringToId(BaseDictionary.java:136) ~[hdt-java-core-3.0.2.jar!/:na]
```

This pull request contains the fix for this error.