### PR TITLE
Fix non closed files 

### DIFF
--- a/.github/workflows/mvn-windows.yaml
+++ b/.github/workflows/mvn-windows.yaml
@@ -1,0 +1,21 @@
+name: Java CI (Windows)
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 15
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Run tests
+        run:  mvn test

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTManager.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTManager.java
@@ -254,9 +254,10 @@ public abstract class HDTManager {
 	 * Return an indexed HDT that is efficient for all kind of queries, given a not indexed HDT.
 	 * @param hdt file path to index
 	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
 	 * @return HDT
 	 */
-	public static HDT indexedHDT(HDT hdt, ProgressListener listener) {
+	public static HDT indexedHDT(HDT hdt, ProgressListener listener) throws IOException {
 		return HDTManager.getInstance().doIndexedHDT(hdt, listener);
 	}
 
@@ -346,7 +347,7 @@ public abstract class HDTManager {
 	protected abstract HDT doLoadIndexedHDT(String hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException;
 	protected abstract HDT doLoadIndexedHDT(InputStream hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException;
 	protected abstract HDT doMapIndexedHDT(String hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException;
-	protected abstract HDT doIndexedHDT(HDT hdt, ProgressListener listener);
+	protected abstract HDT doIndexedHDT(HDT hdt, ProgressListener listener) throws IOException;
 	protected abstract HDT doGenerateHDT(String rdfFileName, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException;
 	protected abstract HDT doGenerateHDT(Iterator<TripleString> iterator, String baseURI,	HDTOptions hdtFormat, ProgressListener listener) throws IOException;
 	protected abstract TripleWriter doGetHDTWriter(OutputStream out, String baseURI, HDTOptions hdtFormat) throws IOException;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64Disk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64Disk.java
@@ -29,6 +29,7 @@ import org.rdfhdt.hdt.util.crc.CRCOutputStream;
 import org.rdfhdt.hdt.util.disk.LongArrayDisk;
 import org.rdfhdt.hdt.util.io.IOUtil;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,7 +37,7 @@ import java.io.OutputStream;
 /**
  * Version of Bitmap64 which is backed up on disk
  */
-public class Bitmap64Disk {
+public class Bitmap64Disk implements Closeable {
 
     // Constants
     protected final static int LOGW = 6;
@@ -204,5 +205,10 @@ public class Bitmap64Disk {
 
     public long getRealSizeBytes() {
         return words.length()*8;
+    }
+
+    @Override
+    public void close() throws IOException {
+        words.close();
     }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryCat.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryCat.java
@@ -4,10 +4,11 @@ import org.rdfhdt.hdt.dictionary.impl.utilCat.CatMapping;
 import org.rdfhdt.hdt.dictionary.impl.utilCat.CatMappingBack;
 import org.rdfhdt.hdt.listener.ProgressListener;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 
-public interface DictionaryCat {
+public interface DictionaryCat extends Closeable {
     void cat(Dictionary dictionary1, Dictionary dictionary2, ProgressListener listener) throws IOException;
     CatMappingBack getMappingS();
     long getNumShared();

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryDiff.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryDiff.java
@@ -4,11 +4,12 @@ import org.rdfhdt.hdt.compact.bitmap.ModifiableBitmap;
 import org.rdfhdt.hdt.dictionary.impl.utilCat.CatMapping;
 import org.rdfhdt.hdt.listener.ProgressListener;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public interface DictionaryDiff {
+public interface DictionaryDiff extends Closeable {
     /**
      * compute the diff of the previous dictionary
      * @param dictionary previous dictionary

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/BaseDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/BaseDictionary.java
@@ -222,30 +222,15 @@ public abstract class BaseDictionary implements DictionaryPrivate {
 	}
 	@Override
 	public String dataTypeOfId(long id) {
-		try {
-			throw new IllegalAccessException("Method is not applicable on this dictionary");
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		}
-		return "";
+		throw new IllegalArgumentException("Method is not applicable on this dictionary");
 	}
 	@Override
 	public TreeMap<String, DictionarySection> getAllObjects() {
-		try {
-			throw new IllegalAccessException("Method is not applicable on this dictionary");
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		}
-		return null;
+		throw new IllegalArgumentException("Method is not applicable on this dictionary");
 	}
 	@Override
 	public long getNAllObjects() {
-		try {
-			throw new IllegalAccessException("Method is not applicable on this dictionary");
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		}
-		return 0;
+		throw new IllegalArgumentException("Method is not applicable on this dictionary");
 	}
 	
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionary.java
@@ -45,6 +45,7 @@ import org.rdfhdt.hdt.options.ControlInfo.Type;
 import org.rdfhdt.hdt.options.ControlInformation;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.util.io.CountInputStream;
+import org.rdfhdt.hdt.util.io.IOUtil;
 import org.rdfhdt.hdt.util.listener.IntermediateListener;
 
 
@@ -164,9 +165,11 @@ public class FourSectionDictionary extends BaseDictionary {
 
 	@Override
 	public void close() throws IOException {
-		shared.close();
-		subjects.close();
-		predicates.close();
-		objects.close();
+		IOUtil.closeAll(
+				shared,
+				subjects,
+				predicates,
+				objects
+		);
 	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/MultipleBaseDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/MultipleBaseDictionary.java
@@ -7,6 +7,7 @@ import org.rdfhdt.hdt.dictionary.DictionarySectionPrivate;
 import org.rdfhdt.hdt.dictionary.impl.section.PFCOptimizedExtractor;
 import org.rdfhdt.hdt.enums.DictionarySectionRole;
 import org.rdfhdt.hdt.enums.TripleComponentRole;
+import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.util.LiteralsUtils;
 import org.rdfhdt.hdt.util.string.CompactString;
@@ -212,7 +213,7 @@ public abstract class MultipleBaseDictionary implements DictionaryPrivate {
 
     @Override
     public DictionarySection getObjects() {
-        return null;
+        throw new NotImplementedException();
     }
 
     @Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/MultipleSectionDictionaryBig.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/MultipleSectionDictionaryBig.java
@@ -34,7 +34,7 @@ MultipleSectionDictionaryBig extends MultipleBaseDictionary {
         // FIXME: Read type from spec.
         subjects = new PFCDictionarySectionBig(spec);
         predicates = new PFCDictionarySectionBig(spec);
-        objects = new TreeMap<String, DictionarySectionPrivate>();
+        objects = new TreeMap<>();
         shared = new PFCDictionarySectionBig(spec);
     }
 
@@ -46,7 +46,7 @@ MultipleSectionDictionaryBig extends MultipleBaseDictionary {
         IntermediateListener iListener = new IntermediateListener(listener);
         subjects.load(other.getSubjects(), iListener);
         predicates.load(other.getPredicates(), iListener);
-        Iterator iter = other.getObjects().getEntries();
+        Iterator<? extends CharSequence> iter = other.getObjects().getEntries();
 
         HashMap<String,Long> literalsCounts = ((HashDictionarySection)other.getObjects()).getLiteralsCounts();
         if(literalsCounts.containsKey("NO_DATATYPE"))

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/MultipleSectionDictionaryDiff.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/MultipleSectionDictionaryDiff.java
@@ -39,6 +39,15 @@ public class MultipleSectionDictionaryDiff implements DictionaryDiff {
     }
 
     @Override
+    public void close() throws IOException {
+        // iterate over all mappings and close them
+        try {
+            IOUtil.closeAll(allMappings.values());
+        } finally {
+            IOUtil.closeAll(mappingBack);
+        }
+    }
+    @Override
     public void diff(Dictionary dictionary, Map<String, ModifiableBitmap> bitmaps, ProgressListener listener) throws IOException {
         allMappings.put("predicate",new CatMapping(location,"predicate",dictionary.getPredicates().getNumberOfElements()));
         allMappings.put("subject",new CatMapping(location,"subject",dictionary.getSubjects().getNumberOfElements()));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/DictionarySectionFactory.java
@@ -80,10 +80,8 @@ public class DictionarySectionFactory {
 		
 		switch(dictType) {
 		case PFCDictionarySection.TYPE_INDEX:
-				// First try load using the standard PFC 
-			DictionarySectionPrivate section= new PFCDictionarySectionMap(input, f);
-
-			return section;
+				// First try load using the standard PFC
+			return new PFCDictionarySectionMap(input, f);
 		default:
 			throw new IOException("DictionarySection implementation not available for id "+dictType);
 		}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionMap.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCDictionarySectionMap.java
@@ -38,6 +38,7 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -127,7 +128,7 @@ public class PFCDictionarySectionMap implements DictionarySectionPrivate,Closeab
 			long nextBlock = Math.min(numBlocks-1, block+BLOCKS_PER_BYTEBUFFER);
 			long nextBytePos = blocks.get(nextBlock);
 
-			buffers[buffer] = BigMappedByteBuffer.ofFileChannel(ch, MapMode.READ_ONLY, base+bytePos, nextBytePos-bytePos);
+			buffers[buffer] = BigMappedByteBuffer.ofFileChannel(f.getAbsolutePath(), ch, MapMode.READ_ONLY, base+bytePos, nextBytePos-bytePos);
 			buffers[buffer].order(ByteOrder.LITTLE_ENDIAN);
 			
 			posFirst[buffer] = bytePos;
@@ -354,7 +355,14 @@ public class PFCDictionarySectionMap implements DictionarySectionPrivate,Closeab
 	@Override
 	public void close() throws IOException {
 		blocks.close();
-		buffers = null;
+		if (buffers != null) {
+			for (BigMappedByteBuffer buffer: buffers) {
+				if (buffer != null) {
+					buffer.clean();
+				}
+			}
+			buffers = null;
+		}
 		ch.close();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCOptimizedExtractor.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/PFCOptimizedExtractor.java
@@ -106,8 +106,7 @@ public class PFCOptimizedExtractor {
 				}
 				return new CompactString(tempString).getDelayed();
 			} catch (IOException e) {
-				e.printStackTrace();
-				return null;
+				throw new RuntimeException(e);
 			}
 		}
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/utilCat/CatIntersection.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/utilCat/CatIntersection.java
@@ -19,6 +19,7 @@
 
 package org.rdfhdt.hdt.dictionary.impl.utilCat;
 
+import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.util.string.CompactString;
 
 import java.util.ArrayList;
@@ -27,8 +28,8 @@ import java.util.Iterator;
 
 public class CatIntersection implements Iterator<CatElement> {
     ArrayList<IteratorPlusElement> list;
-    private Iterator<CatElement> it1;
-    private Iterator<CatElement> it2;
+    private final Iterator<CatElement> it1;
+    private final Iterator<CatElement> it2;
 
     boolean hasNext = false;
     CatElement next;
@@ -61,7 +62,7 @@ public class CatIntersection implements Iterator<CatElement> {
 
     private void helpNext(){
         while (list.size() != 0) {
-            Collections.sort(list, new IteratorPlusElementComparator());
+            list.sort(new IteratorPlusElementComparator());
             if (list.size() == 2) {
 
 
@@ -110,10 +111,6 @@ public class CatIntersection implements Iterator<CatElement> {
 
     @Override
     public void remove() {
-        try {
-            throw new Exception("Not implemented");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        throw new NotImplementedException();
     }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/utilCat/CatMapping.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/utilCat/CatMapping.java
@@ -21,14 +21,15 @@
 package org.rdfhdt.hdt.dictionary.impl.utilCat;
 
 import org.rdfhdt.hdt.util.disk.LongArrayDisk;
+import org.rdfhdt.hdt.util.io.IOUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
 
 public class CatMapping implements Closeable {
-    private LongArrayDisk mapping = null;
-    private LongArrayDisk mappingType = null;
-    private long size;
+    private final LongArrayDisk mapping;
+    private final LongArrayDisk mappingType;
+    private final long size;
 
     public CatMapping(String location, String section, long size){
         this.size = size;
@@ -54,11 +55,6 @@ public class CatMapping implements Closeable {
     }
 
     public void close() throws IOException {
-        if (mapping != null) {
-            mapping.close();
-        }
-        if (mappingType != null) {
-            mappingType.close();
-        }
+        IOUtil.closeAll(mapping, mappingType);
     }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/utilCat/SectionUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/utilCat/SectionUtil.java
@@ -12,6 +12,7 @@ import org.rdfhdt.hdt.util.string.ByteStringUtil;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
@@ -124,13 +125,7 @@ public class SectionUtil {
             blocks.save(out, null);    // Write blocks directly to output, they have their own CRC check.
             blocks.close();
             //write out_buffer
-            byte[] buf = new byte[100000];
-            InputStream in = new FileInputStream(location + "section_buffer_" + type);
-            int b;
-            while ((b = in.read(buf)) >= 0) {
-                out.write(buf, 0, b);
-                out.flush();
-            }
+            Files.copy(Path.of(location + "section_buffer_" + type), out);
         }
 
         Files.deleteIfExists(Paths.get(location + "section_buffer_" + type));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTPrivate.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTPrivate.java
@@ -36,7 +36,7 @@ public interface HDTPrivate extends HDT {
 	 * 
 	 * @param listener A listener to be notified of the progress.
 	 */
-	void loadOrCreateIndex(ProgressListener listener);
+	void loadOrCreateIndex(ProgressListener listener) throws IOException;
 	
 	void populateHeaderStructure(String baseUri);
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesPrivate.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesPrivate.java
@@ -44,7 +44,7 @@ public interface TriplesPrivate extends Triples {
 	 * Generates the associated Index
 	 * @param listener
 	 */
-	void generateIndex(ProgressListener listener);
+	void generateIndex(ProgressListener listener) throws IOException;
 	
 	/**
 	 * Loads the associated Index from an InputStream

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
@@ -83,7 +83,7 @@ public class BitmapTriples implements TriplesPrivate {
 	// Index for Y
 	public PredicateIndex predicateIndex;
 	
-	private boolean isClosed=false;
+	private boolean isClosed;
 
 	public BitmapTriples() {
 		this(new HDTSpecification());
@@ -129,10 +129,7 @@ public class BitmapTriples implements TriplesPrivate {
 
 		long number = it.estimatedNumResults();
 		
-		@SuppressWarnings("resource")
 		SequenceLog64 vectorY = new SequenceLog64(BitUtil.log2(number), number);
-		
-		@SuppressWarnings("resource")
 		SequenceLog64 vectorZ = new SequenceLog64(BitUtil.log2(number), number);
 		
 		ModifiableBitmap bitY = new Bitmap375(number);
@@ -398,7 +395,7 @@ public class BitmapTriples implements TriplesPrivate {
 
 
 
-	private void createIndexObjectMemoryEfficient() {
+	private void createIndexObjectMemoryEfficient() throws IOException {
 		StopWatch global = new StopWatch();
 		StopWatch st = new StopWatch();
 
@@ -406,7 +403,6 @@ public class BitmapTriples implements TriplesPrivate {
 		long maxCount = 0;
 		long numDifferentObjects = 0;
 		long numReservedObjects = 8192;
-		@SuppressWarnings("resource")
 		SequenceLog64Big objectCount = new SequenceLog64Big(BitUtil.log2(seqZ.getNumberOfElements()), numReservedObjects, true);
 		for(long i=0;i<seqZ.getNumberOfElements(); i++) {
 			long val = seqZ.get(i);
@@ -446,12 +442,7 @@ public class BitmapTriples implements TriplesPrivate {
 		// Copy each object reference to its position
 		SequenceLog64Big objectInsertedCount = new SequenceLog64Big(BitUtil.log2(maxCount), numDifferentObjects);
 		objectInsertedCount.resize(numDifferentObjects);
-		File file = null;
-		try {
-			file = File.createTempFile("objectsArray", ".tmp");
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		File file = File.createTempFile("objectsArray", ".tmp");
 
 		SequenceLog64BigDisk objectArray = new SequenceLog64BigDisk(file.getAbsolutePath(),
 				BitUtil.log2(seqY.getNumberOfElements()), seqZ.getNumberOfElements());
@@ -662,7 +653,7 @@ public class BitmapTriples implements TriplesPrivate {
 	
 	
 	@Override
-	public void generateIndex(ProgressListener listener) {		
+	public void generateIndex(ProgressListener listener) throws IOException{
 		predicateIndex = new PredicateIndexArray(this);
 		predicateIndex.generate(listener);
 		

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArrayDisk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArrayDisk.java
@@ -3,87 +3,126 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation;
  * version 3.0 of the License.
- *
+ * <p>
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
+ * <p>
  * Contacting the authors:
- *   Dennis Diefenbach:         dennis.diefenbach@univ-st-etienne.fr
- *   Jose Gimenez Garcia:       jose.gimenez.garcia@univ-st-etienne.fr
+ * Dennis Diefenbach:         dennis.diefenbach@univ-st-etienne.fr
+ * Jose Gimenez Garcia:       jose.gimenez.garcia@univ-st-etienne.fr
  */
 
 package org.rdfhdt.hdt.util.disk;
+
+import org.rdfhdt.hdt.util.io.CloseMappedByteBuffer;
+import org.rdfhdt.hdt.util.io.IOUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 //Implementing an array of longs that is backed up on disk. Following this: http://vanillajava.blogspot.fr/2011/12/using-memory-mapped-file-for-huge.html
 
 public class LongArrayDisk implements Closeable {
     private static final long MAPPING_SIZE = 1 << 30;
-    private RandomAccessFile array = null;
-    private MappedByteBuffer[] mappings_array;
+    private FileChannel channel;
+    private CloseMappedByteBuffer[] mappings;
     private long size;
-    private String location;
+    private final Path location;
+
+    public LongArrayDisk(String location, long size) {
+        this(Path.of(location), size);
+    }
+
+    public LongArrayDisk(String location, long size, boolean overwrite) {
+        this(Path.of(location), size, overwrite);
+    }
+    public LongArrayDisk(Path location, long size) {
+        this(location, size, true);
+    }
+
+
+    public LongArrayDisk(Path location, long size, boolean overwrite) {
+        this.location = location;
+        try {
+            this.size = size;
+            this.channel = FileChannel.open(
+                    location,
+                    StandardOpenOption.READ,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE
+            );
+            long sizeBits = getSizeBits();
+            int blocks = (int) Math.ceil((double) sizeBits / MAPPING_SIZE);
+            mappings = new CloseMappedByteBuffer[blocks];
+            for (int block = 0; block < blocks; block++) {
+                long sizeMapping;
+                if (block + 1 == blocks && sizeBits % MAPPING_SIZE != 0) {
+                    sizeMapping = Math.min(MAPPING_SIZE, sizeBits % MAPPING_SIZE);
+                } else {
+                    sizeMapping = MAPPING_SIZE;
+                }
+                mappings[block] = IOUtil.mapChannel(location.toAbsolutePath().toString(), channel, FileChannel.MapMode.READ_WRITE, block * MAPPING_SIZE, sizeMapping);
+            }
+            if (overwrite) {
+                int lastBlock = 0;
+                for (long i = 0; i < this.size; i++) {
+                    if (i % 10000000 == 0) {
+                        int currentBlock = (int) (i / MAPPING_SIZE);
+                        //This is done because otherwise the changes are not written to disk fast enough
+                        for (int b = lastBlock; b <= currentBlock; b++) {
+                            mappings[b].force();
+                        }
+                        lastBlock = currentBlock;
+                    }
+                    this.set(i, 0);
+                }
+            }
+        } catch (IOException e) {
+            try {
+                try {
+                    if (mappings != null) {
+                        IOUtil.closeAll(mappings);
+                    }
+                } finally {
+                    if (channel != null) {
+                        channel.close();
+                    }
+                }
+            } catch (IOException e1) {
+                e.addSuppressed(e1);
+            }
+            throw new RuntimeException("can't create LongArrayDisk!", e);
+        }
+    }
 
     /**
      * Allows the {@link RandomAccessFile} and the array of {@link MappedByteBuffer} held by the instance to be
      * garbage-collected.
      */
+    @Override
     public void close() throws IOException {
-        this.array.close();
-        this.mappings_array = null;
-        this.array = null;
-    }
-
-    public LongArrayDisk(String location, long size){
-        try {
-            this.location = location;
-            this.size = size;
-            this.array = new RandomAccessFile(location, "rw");
-            size = 8 * (size);
-            int blocks = (int) Math.ceil((double)size / MAPPING_SIZE);
-            mappings_array = new MappedByteBuffer[blocks];
-            for (int block = 0; block < blocks; block++) {
-                long size2 = MAPPING_SIZE;
-                if (block+1==blocks){
-                    size2 = Math.min(MAPPING_SIZE, size%MAPPING_SIZE);
-                }
-                mappings_array[block] = array.getChannel().map(FileChannel.MapMode.READ_WRITE, block*MAPPING_SIZE, size2);
-            }
-            for (long i = 0; i< this.size; i++){
-                if (i%10000000==0){ //This is done because otherwise the changes are not written to disk fast enough
-                    for (int b=0; b<blocks; b++){
-                        mappings_array[b].force();
-                    }
-
-                }
-                this.set(i,0);
-            }
-        } catch (IOException e) {
-            try {
-                array.close();
-            } catch (IOException e1) {
-                e1.printStackTrace();
-            }
-            e.printStackTrace();
-        }
+        IOUtil.closeAll(mappings);
+        channel.close();
+        mappings = null;
+        channel = null;
     }
 
     public long get(long x) {
         long p = x * 8;
         int block = (int) (p / MAPPING_SIZE);
         int offset = (int) (p % MAPPING_SIZE);
-        return mappings_array[block].getLong(offset);
+        return mappings[block].getLong(offset);
     }
 
     public long getLong(long x) {
@@ -94,44 +133,59 @@ public class LongArrayDisk implements Closeable {
         long p = x * 8;
         int block = (int) (p / MAPPING_SIZE);
         int offset = (int) (p % MAPPING_SIZE);
-        mappings_array[block].putLong(offset, y);
+        mappings[block].putLong(offset, y);
     }
 
-    public long length(){
+    public long length() {
         return size;
     }
 
-    public void resize(long newSize){
+    public void resize(long newSize) {
+        long oldSize = this.size;
+        this.size = newSize;
+        long sizeBit = getSizeBits();
+
+        int blocks = (int) Math.ceil((double) sizeBit / MAPPING_SIZE);
+        CloseMappedByteBuffer[] mappings = new CloseMappedByteBuffer[blocks];
+        int block = 0;
         try {
-            long oldSize = this.size;
-            this.size = newSize;
-            long sizeBit = 8 * (newSize);
-
-            int blocks = (int) Math.ceil((double)sizeBit / MAPPING_SIZE);
-            mappings_array = new MappedByteBuffer[blocks];
-            for (int block = 0; block < blocks; block++) {
-                long sizeMapping = MAPPING_SIZE;
-                if (block+1==blocks){
-                    sizeMapping = Math.min(MAPPING_SIZE, sizeBit%MAPPING_SIZE);
+            for (; block < blocks; block++) {
+                long sizeMapping;
+                if (block + 1 == blocks && sizeBit % MAPPING_SIZE != 0) {
+                    sizeMapping = Math.min(MAPPING_SIZE, sizeBit % MAPPING_SIZE);
+                } else {
+                    sizeMapping = MAPPING_SIZE;
                 }
-                mappings_array[block] = array.getChannel().map(FileChannel.MapMode.READ_WRITE, block*MAPPING_SIZE, sizeMapping);
+                mappings[block] = IOUtil.mapChannel(location.toAbsolutePath().toString(), channel, FileChannel.MapMode.READ_WRITE, block * MAPPING_SIZE, sizeMapping);
             }
+            // close previous mapping
+            IOUtil.closeAll(this.mappings);
+            this.mappings = mappings;
 
-            for (long i = oldSize; i< newSize; i++){
-                if (i%10000000==0){ //This is done because otherwise the changes are not written to disk fast enough
-                    for (int b=0; b<blocks; b++){
-                        mappings_array[b].force();
+            for (long i = oldSize; i < newSize; i++) {
+                if (i % 10000000 == 0) { //This is done because otherwise the changes are not written to disk fast enough
+                    for (int b = 0; b < blocks; b++) {
+                        mappings[b].force();
                     }
                 }
-                this.set(i,0);
+                this.set(i, 0);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            try {
+                IOUtil.closeAll(mappings);
+            } catch (IOException ee) {
+                e.addSuppressed(ee);
+            }
+            throw new RuntimeException("Resize failed", e);
         }
-
     }
 
     public long getSize() {
         return size;
     }
+
+    public long getSizeBits() {
+        return size * 8L;
+    }
+
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/CloseMappedByteBuffer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/CloseMappedByteBuffer.java
@@ -1,0 +1,335 @@
+package org.rdfhdt.hdt.util.io;
+
+import java.io.Closeable;
+import java.nio.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CloseMappedByteBuffer implements Closeable {
+    private static final AtomicLong ID_GEN = new AtomicLong();
+    private static final Map<Long, Throwable> MAP_TEST_MAP = new HashMap<>();
+    private static boolean mapTest = false;
+
+    static void markMapTest() {
+        mapTest = true;
+        MAP_TEST_MAP.clear();
+    }
+
+    static void crashMapTest() {
+        mapTest = false;
+        MAP_TEST_MAP.entrySet().stream()
+                .sorted(Comparator.comparingLong(Map.Entry::getKey))
+                .map(Map.Entry::getValue)
+                .forEach(t -> {
+                    System.out.println("-------------------");
+                    t.printStackTrace();
+                    System.out.println("-------------------");
+                }
+        );
+        if (!MAP_TEST_MAP.isEmpty()) {
+            throw new RuntimeException("MAP NOT CLOSE: " + MAP_TEST_MAP.size());
+        }
+    }
+
+    private final long id = ID_GEN.incrementAndGet();
+    private final ByteBuffer buffer;
+    private final boolean duplicated;
+
+    CloseMappedByteBuffer(String filename, ByteBuffer buffer, boolean duplicated) {
+        this.duplicated = duplicated;
+        this.buffer = buffer;
+        if (mapTest && !duplicated) {
+            MAP_TEST_MAP.put(id, new Throwable("MAP " + filename + "#" + id + "|"+ buffer));
+        }
+    }
+
+    @Override
+    public void close() {
+        if (mapTest && !duplicated) {
+            MAP_TEST_MAP.remove(id);
+        }
+        IOUtil.cleanBuffer(buffer);
+    }
+
+    public boolean isLoaded() {
+        return ((MappedByteBuffer) buffer).isLoaded();
+    }
+
+    public MappedByteBuffer load() {
+        return ((MappedByteBuffer) buffer).load();
+    }
+
+    public MappedByteBuffer force() {
+        return ((MappedByteBuffer) buffer).force();
+    }
+
+    public ByteBuffer position(int newPosition) {
+        return buffer.position(newPosition);
+    }
+
+    public ByteBuffer limit(int newLimit) {
+        return buffer.limit(newLimit);
+    }
+
+    public ByteBuffer mark() {
+        return buffer.mark();
+    }
+
+    public ByteBuffer reset() {
+        return buffer.reset();
+    }
+
+    public ByteBuffer clear() {
+        return buffer.clear();
+    }
+
+    public ByteBuffer flip() {
+        return buffer.flip();
+    }
+
+    public ByteBuffer rewind() {
+        return buffer.rewind();
+    }
+
+    public ByteBuffer slice() {
+        return buffer.slice();
+    }
+
+    public ByteBuffer duplicate() {
+        return buffer.duplicate();
+    }
+
+    public ByteBuffer asReadOnlyBuffer() {
+        return buffer.asReadOnlyBuffer();
+    }
+
+    public byte get() {
+        return buffer.get();
+    }
+
+    public ByteBuffer put(byte b) {
+        return buffer.put(b);
+    }
+
+    public byte get(int index) {
+        return buffer.get(index);
+    }
+
+    public ByteBuffer put(int index, byte b) {
+        return buffer.put(index, b);
+    }
+
+    public ByteBuffer get(byte[] dst, int offset, int length) {
+        return buffer.get(dst, offset, length);
+    }
+
+    public ByteBuffer get(byte[] dst) {
+        return buffer.get(dst);
+    }
+
+    public ByteBuffer put(ByteBuffer src) {
+        return buffer.put(src);
+    }
+
+    public ByteBuffer put(byte[] src, int offset, int length) {
+        return buffer.put(src, offset, length);
+    }
+
+    public ByteBuffer put(byte[] src) {
+        return buffer.put(src);
+    }
+
+    public boolean hasArray() {
+        return buffer.hasArray();
+    }
+
+    public byte[] array() {
+        return buffer.array();
+    }
+
+    public int arrayOffset() {
+        return buffer.arrayOffset();
+    }
+
+    public ByteBuffer compact() {
+        return buffer.compact();
+    }
+
+    public boolean isDirect() {
+        return buffer.isDirect();
+    }
+
+    public int compareTo(ByteBuffer that) {
+        return buffer.compareTo(that);
+    }
+
+    public int mismatch(ByteBuffer that) {
+        return buffer.mismatch(that);
+    }
+
+    public ByteOrder order() {
+        return buffer.order();
+    }
+
+    public ByteBuffer order(ByteOrder bo) {
+        return buffer.order(bo);
+    }
+
+    public int alignmentOffset(int index, int unitSize) {
+        return buffer.alignmentOffset(index, unitSize);
+    }
+
+    public ByteBuffer alignedSlice(int unitSize) {
+        return buffer.alignedSlice(unitSize);
+    }
+
+    public char getChar() {
+        return buffer.getChar();
+    }
+
+    public ByteBuffer putChar(char value) {
+        return buffer.putChar(value);
+    }
+
+    public char getChar(int index) {
+        return buffer.getChar(index);
+    }
+
+    public ByteBuffer putChar(int index, char value) {
+        return buffer.putChar(index, value);
+    }
+
+    public CharBuffer asCharBuffer() {
+        return buffer.asCharBuffer();
+    }
+
+    public short getShort() {
+        return buffer.getShort();
+    }
+
+    public ByteBuffer putShort(short value) {
+        return buffer.putShort(value);
+    }
+
+    public short getShort(int index) {
+        return buffer.getShort(index);
+    }
+
+    public ByteBuffer putShort(int index, short value) {
+        return buffer.putShort(index, value);
+    }
+
+    public ShortBuffer asShortBuffer() {
+        return buffer.asShortBuffer();
+    }
+
+    public int getInt() {
+        return buffer.getInt();
+    }
+
+    public ByteBuffer putInt(int value) {
+        return buffer.putInt(value);
+    }
+
+    public int getInt(int index) {
+        return buffer.getInt(index);
+    }
+
+    public ByteBuffer putInt(int index, int value) {
+        return buffer.putInt(index, value);
+    }
+
+    public IntBuffer asIntBuffer() {
+        return buffer.asIntBuffer();
+    }
+
+    public long getLong() {
+        return buffer.getLong();
+    }
+
+    public ByteBuffer putLong(long value) {
+        return buffer.putLong(value);
+    }
+
+    public long getLong(int index) {
+        return buffer.getLong(index);
+    }
+
+    public ByteBuffer putLong(int index, long value) {
+        return buffer.putLong(index, value);
+    }
+
+    public LongBuffer asLongBuffer() {
+        return buffer.asLongBuffer();
+    }
+
+    public float getFloat() {
+        return buffer.getFloat();
+    }
+
+    public ByteBuffer putFloat(float value) {
+        return buffer.putFloat(value);
+    }
+
+    public float getFloat(int index) {
+        return buffer.getFloat(index);
+    }
+
+    public ByteBuffer putFloat(int index, float value) {
+        return buffer.putFloat(index, value);
+    }
+
+    public FloatBuffer asFloatBuffer() {
+        return buffer.asFloatBuffer();
+    }
+
+    public double getDouble() {
+        return buffer.getDouble();
+    }
+
+    public ByteBuffer putDouble(double value) {
+        return buffer.putDouble(value);
+    }
+
+    public double getDouble(int index) {
+        return buffer.getDouble(index);
+    }
+
+    public ByteBuffer putDouble(int index, double value) {
+        return buffer.putDouble(index, value);
+    }
+
+    public DoubleBuffer asDoubleBuffer() {
+        return buffer.asDoubleBuffer();
+    }
+
+    public int capacity() {
+        return buffer.capacity();
+    }
+
+    public int position() {
+        return buffer.position();
+    }
+
+    public int limit() {
+        return buffer.limit();
+    }
+
+    public int remaining() {
+        return buffer.remaining();
+    }
+
+    public boolean hasRemaining() {
+        return buffer.hasRemaining();
+    }
+
+    public boolean isReadOnly() {
+        return buffer.isReadOnly();
+    }
+
+    public ByteBuffer getInternalBuffer() {
+        return buffer;
+    }
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/writer/TripleWritterHDTTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/writer/TripleWritterHDTTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,39 +24,27 @@ public class TripleWritterHDTTest {
 	}
 
 	@Test
-	public void test() {
-		try {
-			File file = new File("out.hdt");
-			file.deleteOnExit();
-			
-			final TripleWriterHDT wr = new TripleWriterHDT("http://example.org", new HDTSpecification(), file.toString(), false);
-			
-			RDFParserCallback pars = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES);
-			pars.doParse("data/test.nt", "http://example.org", RDFNotation.NTRIPLES, false, new RDFParserCallback.RDFCallback() {
-				@Override
-				public void processTriple(TripleString triple, long pos) {				
-					try {
-						wr.addTriple(triple);
-					} catch (IOException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-				}
-			});
-			wr.close();
-			
-			HDT hdt = HDTManager.loadHDT(file.toString());
-			assertEquals("Successfully loaded HDT with same number of triples", 10, hdt.getTriples().getNumberOfElements());
-			
-			// Delete temp file
-			file.delete();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (ParserException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+	public void test() throws IOException, ParserException {
+		File file = new File("out.hdt");
+		file.deleteOnExit();
+
+		final TripleWriterHDT wr = new TripleWriterHDT("http://example.org", new HDTSpecification(), file.toString(), false);
+
+		RDFParserCallback pars = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES);
+		pars.doParse("data/test.nt", "http://example.org", RDFNotation.NTRIPLES, false, (triple, pos) -> {
+			try {
+				wr.addTriple(triple);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+		wr.close();
+
+		HDT hdt = HDTManager.loadHDT(file.toString());
+		assertEquals("Successfully loaded HDT with same number of triples", 10, hdt.getTriples().getNumberOfElements());
+
+		// Delete temp file
+		Files.delete(file.toPath());
 	}
 
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtCat/HdtCatLiteralsTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtCat/HdtCatLiteralsTest.java
@@ -1,88 +1,69 @@
 package org.rdfhdt.hdt.hdtCat;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 import org.rdfhdt.hdt.enums.RDFNotation;
-import org.rdfhdt.hdt.exceptions.NotFoundException;
 import org.rdfhdt.hdt.exceptions.ParserException;
 import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.hdtCat.utils.Utility;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.HDTSpecification;
-import org.rdfhdt.hdt.triples.IteratorTripleString;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
 
-public class HdtCatLiteralsTest implements ProgressListener {
+public class HdtCatLiteralsTest extends AbstractMapMemoryTest implements ProgressListener {
 
-    public void help(String file1, String file2, String concat){
-        if (SystemUtils.IS_OS_UNIX) {
-            try {
-                ClassLoader classLoader = getClass().getClassLoader();
-                HDT hdt1 = null;
-                HDT hdt2 = null;
-                String hdt1_location = file1.replace(".nt", ".hdt");
-                String hdt2_location = file2.replace(".nt", ".hdt");
-                HDTSpecification spec = new HDTSpecification();
-                spec.setOptions("tempDictionary.impl=multHash;dictionary.type=dictionaryMultiObj;");
-                hdt1 = HDTManager.generateHDT(new File(file1).getAbsolutePath(), "uri", RDFNotation.NTRIPLES, spec, this);
-                hdt1.saveToHDT(hdt1_location, null);
-                hdt2 = HDTManager.generateHDT(new File(file2).getAbsolutePath(), "uri", RDFNotation.NTRIPLES, spec, this);
-                hdt2.saveToHDT(hdt2_location, null);
-                HDT hdtCatOld = HDTManager.generateHDT(new File(concat).getAbsolutePath(), "uri", RDFNotation.NTRIPLES, spec, this);
+    private void help(String filename1, String filename2, String concatFilename) throws ParserException, IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        URL resource = classLoader.getResource(filename1);
+        if (resource == null) {
+            throw new FileNotFoundException(filename1);
+        }
+        String file1 = resource.getFile();
+        URL resource1 = classLoader.getResource(filename2);
+        if (resource1 == null) {
+            throw new FileNotFoundException(filename2);
+        }
+        String file2 = resource1.getFile();
+        URL resource2 = classLoader.getResource(concatFilename);
+        if (resource2 == null) {
+            throw new FileNotFoundException(concatFilename);
+        }
+        String concat = resource2.getFile();
 
-                File file = new File(file1);
-                File theDir = new File(file.getAbsolutePath() + "_tmp");
-                theDir.mkdirs();
-                HDT hdtCatNew = HDTManager.catHDT(theDir.getAbsolutePath(), hdt1_location, hdt2_location, spec, null);
-               hdtCatNew.saveToHDT(file.getAbsolutePath()+"_cat.hdt",null);
-               HDT hdt = HDTManager.mapIndexedHDT(file.getAbsolutePath()+"_cat.hdt");
-                //HDTCat hdtCatNew = new HDTCat(new HDTSpecification(),hdt1,hdt2,this);
 
-//                System.out.println("HDT1 ----------------------------------");
-//                Utility.printCustomDictionary(hdt1.getDictionary());
-//                System.out.println("HDT2 ----------------------------------");
-//                Utility.printCustomDictionary(hdt2.getDictionary());
-                System.out.println("original ----------------------------------");
-                Utility.printCustomDictionary(hdtCatOld.getDictionary());
+        String hdt1Location = file1.replace(".nt", ".hdt");
+        String hdt2Location = file2.replace(".nt", ".hdt");
+        HDTSpecification spec = new HDTSpecification();
+        spec.setOptions("tempDictionary.impl=multHash;dictionary.type=dictionaryMultiObj;");
+        try (HDT hdt = HDTManager.generateHDT(new File(file1).getAbsolutePath(), "uri", RDFNotation.NTRIPLES, spec, this)) {
+            hdt.saveToHDT(hdt1Location, null);
+        }
+        try (HDT hdt = HDTManager.generateHDT(new File(file2).getAbsolutePath(), "uri", RDFNotation.NTRIPLES, spec, this)) {
+            hdt.saveToHDT(hdt2Location, null);
+        }
+        File file = new File(file1);
+        File theDir = new File(file.getAbsolutePath() + "_tmp");
+        Files.createDirectories(theDir.toPath());
 
-                System.out.println("NEW ----------------------------------");
-                Utility.printCustomDictionary(hdtCatNew.getDictionary());
+        try (HDT hdtCatNew = HDTManager.catHDT(theDir.getAbsolutePath(), hdt1Location, hdt2Location, spec, null)) {
+            hdtCatNew.saveToHDT(file.getAbsolutePath() + "_cat.hdt", null);
+        }
 
-                Utility.compareCustomDictionary(hdtCatOld.getDictionary(), hdtCatNew.getDictionary());
-//                Utility.printTriples(hdtCatOld);
-                Utility.compareTriples(hdtCatOld,hdtCatNew);
-
-                try {
-                    IteratorTripleString it = hdtCatOld.search("", "", "");
-                    while (it.hasNext()) {
-                        System.out.println(it.next().toString());
-                    }
-
-                } catch (NotFoundException e) {
-                    e.printStackTrace();
-                }
-                System.out.println("------------------------------------");
-                try {
-                    IteratorTripleString it = hdtCatNew.search("", "", "");
-                    while (it.hasNext()) {
-                        System.out.println(it.next().toString());
-                    }
-
-                } catch (NotFoundException e) {
-                    e.printStackTrace();
-                }
-                theDir.delete();
-            } catch (ParserException e) {
-                e.printStackTrace();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+        try (HDT hdtCatOld = HDTManager.generateHDT(new File(concat).getAbsolutePath(), "uri", RDFNotation.NTRIPLES, spec, this);
+            HDT hdtCatNew = HDTManager.mapIndexedHDT(file.getAbsolutePath() + "_cat.hdt")) {
+            Utility.compareCustomDictionary(hdtCatOld.getDictionary(), hdtCatNew.getDictionary());
+            Utility.compareTriples(hdtCatOld, hdtCatNew);
+            Files.delete(theDir.toPath());
         }
     }
-//    @Test
+
+    //    @Test
 //    public void misc(){
 //        String file1 = "/Users/alyhdr/Desktop/qa-company/data/admin/eu/hdt_index/new_index_diff.hdt";
 //        String file2 = "/Users/alyhdr/Desktop/qa-company/data/admin/eu/hdt_index/new_index_v2.hdt";
@@ -128,134 +109,75 @@ public class HdtCatLiteralsTest implements ProgressListener {
 //
 //    }
     @Test
-    public void cat0() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("empty1.nt").getFile();
-        String file2 = classLoader.getResource("empty2.nt").getFile();
-        String concat = classLoader.getResource("empty1+2.nt").getFile();
-        help(file1,file2,concat);
-    }
-    @Test
-public void cat1() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example1.nt").getFile();
-        String file2 = classLoader.getResource("example2.nt").getFile();
-        String concat = classLoader.getResource("example1+2.nt").getFile();
-        help(file1,file2,concat);
+    public void cat1() throws ParserException, IOException {
+        help("example1.nt", "example2.nt", "example1+2.nt");
     }
 
     @Test
-    public void cat2() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example2.nt").getFile();
-        String file2 = classLoader.getResource("example3.nt").getFile();
-        String concat = classLoader.getResource("example2+3.nt").getFile();
-        help(file1,file2,concat);
+    public void cat2() throws ParserException, IOException {
+        help("example2.nt", "example3.nt", "example2+3.nt");
     }
 
     @Test
-    public void cat3() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example4.nt").getFile();
-        String file2 = classLoader.getResource("example5.nt").getFile();
-        String concat = classLoader.getResource("example4+5.nt").getFile();
-        help(file1,file2,concat);
+    public void cat3() throws ParserException, IOException {
+        help("example4.nt", "example5.nt", "example4+5.nt");
     }
 
     @Test
-    public void cat4() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example6.nt").getFile();
-        String file2 = classLoader.getResource("example7.nt").getFile();
-        String concat = classLoader.getResource("example6+7.nt").getFile();
-        help(file1,file2,concat);
+    public void cat4() throws ParserException, IOException {
+        help("example6.nt", "example7.nt", "example6+7.nt");
     }
 
     @Test
-    public void cat5() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example8.nt").getFile();
-        String file2 = classLoader.getResource("example9.nt").getFile();
-        String concat = classLoader.getResource("example8+9.nt").getFile();
-        help(file1,file2,concat);
+    public void cat5() throws ParserException, IOException {
+        help("example8.nt", "example9.nt", "example8+9.nt");
     }
 
     @Test
-    public void cat6() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example10.nt").getFile();
-        String file2 = classLoader.getResource("example11.nt").getFile();
-        String concat = classLoader.getResource("example10+11.nt").getFile();
-        help(file1,file2,concat);
+    public void cat6() throws ParserException, IOException {
+        help("example10.nt", "example11.nt", "example10+11.nt");
     }
 
     @Test
-    public void cat7() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example12.nt").getFile();
-        String file2 = classLoader.getResource("example13.nt").getFile();
-        String concat = classLoader.getResource("example12+13.nt").getFile();
-        help(file1,file2,concat);
+    public void cat7() throws ParserException, IOException {
+        help("example12.nt", "example13.nt", "example12+13.nt");
     }
 
     @Test
-    public void cat9() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example14.nt").getFile();
-        String file2 = classLoader.getResource("example15.nt").getFile();
-        String concat = classLoader.getResource("example14+15.nt").getFile();
-        help(file1,file2,concat);
+    public void cat9() throws ParserException, IOException {
+        help("example14.nt", "example15.nt", "example14+15.nt");
     }
 
     @Test
-    public void cat10() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example16.nt").getFile();
-        String file2 = classLoader.getResource("example17.nt").getFile();
-        String concat = classLoader.getResource("example16+17.nt").getFile();
-        help(file1,file2,concat);
+    public void cat10() throws ParserException, IOException {
+        help("example16.nt", "example17.nt", "example16+17.nt");
     }
 
     @Test
-    public void cat11() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example1.nt").getFile();
-        String file2 = classLoader.getResource("example1.nt").getFile();
-        String concat = classLoader.getResource("example1.nt").getFile();
-        help(file1,file2,concat);
+    public void cat11() throws ParserException, IOException {
+        help("example1.nt", "example1.nt", "example1.nt");
     }
+
     @Test
-    public void cat12() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example18.nt").getFile();
-        String file2 = classLoader.getResource("example19.nt").getFile();
-        String concat = classLoader.getResource("example18+19.nt").getFile();
-        help(file1,file2,concat);
+    public void cat12() throws ParserException, IOException {
+        help("example18.nt", "example19.nt", "example18+19.nt");
     }
+
     @Test
-    public void cat13() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example20.nt").getFile();
-        String file2 = classLoader.getResource("example21.nt").getFile();
-        String concat = classLoader.getResource("example20+21.nt").getFile();
-        help(file1,file2,concat);
+    public void cat13() throws ParserException, IOException {
+        help("example20.nt", "example21.nt", "example20+21.nt");
     }
+
     @Test
-    public void cat14() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example22.nt").getFile();
-        String file2 = classLoader.getResource("example23.nt").getFile();
-        String concat = classLoader.getResource("example22+23.nt").getFile();
-        help(file1,file2,concat);
+    public void cat14() throws ParserException, IOException {
+        help("example22.nt", "example23.nt", "example22+23.nt");
     }
+
     @Test
-    public void cat15() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String file1 = classLoader.getResource("example24.nt").getFile();
-        String file2 = classLoader.getResource("example25.nt").getFile();
-        String concat = classLoader.getResource("example24+25.nt").getFile();
-        help(file1,file2,concat);
+    public void cat15() throws ParserException, IOException {
+        help("example24.nt", "example25.nt", "example24+25.nt");
     }
+
     @Override
     public void notifyProgress(float level, String message) {
 

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtCat/HdtCatRandomTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtCat/HdtCatRandomTest.java
@@ -12,6 +12,7 @@ import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.hdtDiff.HdtDiffTest;
 import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.util.LargeFakeDataSetStreamSupplier;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class HdtCatRandomTest {
+public class HdtCatRandomTest extends AbstractMapMemoryTest {
 	@Parameterized.Parameters(name = "{0}")
 	public static Collection<Object[]> genParam() {
 		List<Object[]> list = new ArrayList<>();
@@ -56,9 +57,9 @@ public class HdtCatRandomTest {
 		supplier.createAndSaveFakeHDT(spec, hdt1F);
 		supplier.createAndSaveFakeHDT(spec, hdt2F);
 
-		HDT cat = HDTManager.catHDT(location, hdt1F, hdt2F, spec, null);
-		cat.saveToHDT(catOutput, null);
-		cat.close();
+		try (HDT cat = HDTManager.catHDT(location, hdt1F, hdt2F, spec, null)) {
+			cat.saveToHDT(catOutput, null);
+		}
 
 		HDT loadedHDT = HDTManager.loadIndexedHDT(catOutput, null, spec);
 		loadedHDT.close();

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtCat/utils/Utility.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtCat/utils/Utility.java
@@ -1,5 +1,6 @@
 package org.rdfhdt.hdt.hdtCat.utils;
 
+import org.junit.Assert;
 import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.DictionarySection;
 import org.rdfhdt.hdt.enums.TripleComponentRole;
@@ -10,162 +11,123 @@ import org.rdfhdt.hdt.triples.TripleID;
 import java.util.Iterator;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 public class Utility {
 
-    public static void printDictionary(Dictionary d){
-        Iterator i = d.getShared().getSortedEntries();
+    public static void printDictionary(Dictionary d) {
+        Iterator<? extends CharSequence> shared = d.getShared().getSortedEntries();
         int count = 0;
         System.out.println("SHARED");
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        while (shared.hasNext()){
+            System.out.println(count +"---"+shared.next().toString());
             count++;
         }
         System.out.println("SUBJECTS");
         count = 0;
-        i = d.getSubjects().getSortedEntries();
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        Iterator<? extends CharSequence> subjects = d.getSubjects().getSortedEntries();
+        while (subjects.hasNext()){
+            System.out.println(count +"---"+subjects.next().toString());
             count++;
         }
         System.out.println("OBJECTS");
         count = 0;
-        i = d.getObjects().getSortedEntries();
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        Iterator<? extends CharSequence> objects = d.getObjects().getSortedEntries();
+        while (objects.hasNext()){
+            System.out.println(count +"---"+objects.next().toString());
             count++;
         }
         System.out.println("PREDICATES");
         count = 0;
-        i = d.getPredicates().getSortedEntries();
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        Iterator<? extends CharSequence> predicates = d.getPredicates().getSortedEntries();
+        while (predicates.hasNext()){
+            System.out.println(count +"---"+predicates.next().toString());
             count++;
         }
     }
-    public static void printCustomDictionary(Dictionary d){
-        Iterator i = d.getShared().getSortedEntries();
+    public static void printCustomDictionary(Dictionary d) {
+        Iterator<? extends CharSequence> shared = d.getShared().getSortedEntries();
         int count = 0;
         System.out.println("SHARED");
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        while (shared.hasNext()){
+            System.out.println(count +"---"+shared.next().toString());
             count++;
         }
         System.out.println("SUBJECTS");
         count = 0;
-        i = d.getSubjects().getSortedEntries();
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        Iterator<? extends CharSequence> subjects = d.getSubjects().getSortedEntries();
+        while (subjects.hasNext()){
+            System.out.println(count +"---"+subjects.next().toString());
             count++;
         }
         System.out.println("OBJECTS");
         count = 0;
-        Iterator iter = d.getAllObjects().entrySet().iterator();
-        while (iter.hasNext()) {
-            i = ((DictionarySection)((Map.Entry)iter.next()).getValue()).getSortedEntries();
-            while (i.hasNext()) {
-                System.out.println(count + "---" + i.next().toString());
+        for (Map.Entry<String, DictionarySection> stringDictionarySectionEntry : d.getAllObjects().entrySet()) {
+            Iterator<? extends CharSequence> entries = stringDictionarySectionEntry.getValue().getSortedEntries();
+            while (entries.hasNext()) {
+                System.out.println(count + "---" + entries.next().toString());
                 count++;
             }
         }
         System.out.println("PREDICATES");
         count = 0;
-        i = d.getPredicates().getSortedEntries();
-        while (i.hasNext()){
-            System.out.println(count +"---"+i.next().toString());
+        subjects = d.getPredicates().getSortedEntries();
+        while (subjects.hasNext()){
+            System.out.println(count +"---"+subjects.next().toString());
             count++;
         }
     }
-    public static void compareDictionary(Dictionary d1, Dictionary d2){
-        Iterator i1 = d1.getShared().getSortedEntries();
-        Iterator i2 = d2.getShared().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
+
+    public static void assertEquals(Iterator<? extends CharSequence> i1, Iterator<? extends CharSequence> i2) {
+        while (i1.hasNext()) {
+            Assert.assertTrue("The dictionaries have a different size", i2.hasNext());
+            Assert.assertEquals(i1.next().toString(),i2.next().toString());
         }
-        i1 = d1.getSubjects().getSortedEntries();
-        i2 = d2.getSubjects().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
-        }
-        i1 = d1.getObjects().getSortedEntries();
-        i2 = d2.getObjects().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
-        }
-        i1 = d1.getPredicates().getSortedEntries();
-        i2 = d2.getPredicates().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
-        }
+        Assert.assertFalse("The dictionaries have a different size", i2.hasNext());
+    }
+
+    public static void compareDictionary(Dictionary d1, Dictionary d2) {
+        assertEquals(
+                d1.getShared().getSortedEntries(),
+                d2.getShared().getSortedEntries()
+        );
+        assertEquals(
+                d1.getSubjects().getSortedEntries(),
+                d2.getSubjects().getSortedEntries()
+        );
+        assertEquals(
+                d1.getObjects().getSortedEntries(),
+                d2.getObjects().getSortedEntries()
+        );
+        assertEquals(
+                d1.getPredicates().getSortedEntries(),
+                d2.getPredicates().getSortedEntries()
+        );
     }
     public static void compareCustomDictionary(Dictionary d1, Dictionary d2){
-        Iterator i1 = d1.getShared().getSortedEntries();
-        Iterator i2 = d2.getShared().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
-        }
-        i1 = d1.getSubjects().getSortedEntries();
-        i2 = d2.getSubjects().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
-        }
-        Iterator hmIter1 = d1.getAllObjects().entrySet().iterator();
-        Iterator hmIter2 = d2.getAllObjects().entrySet().iterator();
-        while (hmIter1.hasNext()){
-            if(hmIter2.hasNext() == false){
-                assertFalse("The dictionaries have a different number of objects subsections",true);
-            }else{
-                Map.Entry entry1 = (Map.Entry)hmIter1.next();
-                Map.Entry entry2 = (Map.Entry)hmIter2.next();
+        assertEquals(
+                d1.getShared().getSortedEntries(),
+                d2.getShared().getSortedEntries()
+        );
+        assertEquals(
+                d1.getSubjects().getSortedEntries(),
+                d2.getSubjects().getSortedEntries()
+        );
+        Iterator<Map.Entry<String, DictionarySection>> hmIter1 = d1.getAllObjects().entrySet().iterator();
+        Iterator<Map.Entry<String, DictionarySection>> hmIter2 = d2.getAllObjects().entrySet().iterator();
+        while (hmIter1.hasNext()) {
+            Assert.assertTrue("The dictionaries have a different number of objects subsections", hmIter2.hasNext());
+            Map.Entry<String, DictionarySection> entry1 = hmIter1.next();
+            Map.Entry<String, DictionarySection> entry2 = hmIter2.next();
 
-                i1 = ((DictionarySection)entry1.getValue()).getSortedEntries();
-                i2 = ((DictionarySection)entry2.getValue()).getSortedEntries();
-                while (i1.hasNext()){
-                    if (i2.hasNext()!=true){
-                        assertFalse("The subsections have a different size",true);
-                    } else {
-                        String s1 = i1.next().toString();
-                        String s2 = i2.next().toString();
-                        assertEquals(s1,s2);
-                    }
-                }
-            }
+            assertEquals(
+                    entry1.getValue().getSortedEntries(),
+                    entry2.getValue().getSortedEntries()
+            );
         }
-        i1 = d1.getPredicates().getSortedEntries();
-        i2 = d2.getPredicates().getSortedEntries();
-        while (i1.hasNext()){
-            if (i2.hasNext()!=true){
-                assertFalse("The dictionaries have a different size",true);
-            } else {
-                assertEquals(i1.next().toString(),i2.next().toString());
-            }
-        }
+        Assert.assertFalse("The dictionaries have a different number of objects subsections", hmIter2.hasNext());
+        assertEquals(
+                d1.getPredicates().getSortedEntries(),
+                d2.getPredicates().getSortedEntries()
+        );
     }
     public static void printTriples(HDT hdt){
         IteratorTripleID it = hdt.getTriples().searchAll();
@@ -181,10 +143,8 @@ public class Utility {
     public static void compareTriples(HDT hdt1, HDT hdt2){
         IteratorTripleID itOld = hdt1.getTriples().searchAll();
         IteratorTripleID itNew = hdt2.getTriples().searchAll();
-        while (itOld.hasNext()){
-            if (itNew.hasNext()!=true){
-                assertFalse("The number of triples is different",true);
-            }
+        while (itOld.hasNext()) {
+            Assert.assertTrue("The number of triples is different", itNew.hasNext());
             TripleID tripleIDOld = itOld.next();
             String subjectOld = hdt1.getDictionary().idToString(tripleIDOld.getSubject(), TripleComponentRole.SUBJECT).toString();
             String predicateOld = hdt1.getDictionary().idToString(tripleIDOld.getPredicate(), TripleComponentRole.PREDICATE).toString();
@@ -193,12 +153,45 @@ public class Utility {
             String subjectNew = hdt2.getDictionary().idToString(tripleIDNew.getSubject(), TripleComponentRole.SUBJECT).toString();
             String predicateNew = hdt2.getDictionary().idToString(tripleIDNew.getPredicate(), TripleComponentRole.PREDICATE).toString();
             String objectNew = hdt2.getDictionary().idToString(tripleIDNew.getObject(), TripleComponentRole.OBJECT).toString();
-            assertEquals(subjectOld,subjectNew);
-            assertEquals(predicateOld,predicateNew);
-            assertEquals(objectOld,objectNew);
+            Assert.assertEquals(subjectOld,subjectNew);
+            Assert.assertEquals(predicateOld,predicateNew);
+            Assert.assertEquals(objectOld,objectNew);
+        }
+        Assert.assertFalse("The number of triples is different", itNew.hasNext());
+    }
 
+    /**
+     * utility class to create closable from non closeable object
+     * @param object the object to close
+     * @param closeOperation close operation
+     * @return closeable
+     * @param <T> object type
+     * @param <E> close exception type
+     */
+    public static <T, E extends Exception> PackAutoCloseable<T, E> closeableOf(T object, CloseOperation<T, E> closeOperation) {
+        return new PackAutoCloseable<>(object, closeOperation);
+    }
+
+    public static class PackAutoCloseable<T, E extends Exception> implements AutoCloseable {
+        private final T object;
+        private final CloseOperation<T, E> closeOperation;
+
+        private PackAutoCloseable(T object, CloseOperation<T, E> closeOperation) {
+            this.object = object;
+            this.closeOperation = closeOperation;
+        }
+
+        public T getObject() {
+            return object;
+        }
+
+        @Override
+        public void close() throws E {
+            closeOperation.close(object);
         }
     }
 
-
+    public interface CloseOperation<T, E extends Exception> {
+        void close(T object) throws E;
+    }
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtDiff/HdtDiffTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtDiff/HdtDiffTest.java
@@ -19,6 +19,7 @@ import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.triples.IteratorTripleString;
 import org.rdfhdt.hdt.triples.TripleString;
 import org.rdfhdt.hdt.triples.impl.utils.HDTTestUtils;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +28,7 @@ import java.util.Collection;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class HdtDiffTest {
+public class HdtDiffTest extends AbstractMapMemoryTest {
     public static class DictionaryTestData {
         public final String dictionaryType;
         public final String dictionaryTempType;
@@ -214,53 +215,57 @@ public class HdtDiffTest {
         File hdtDiffExceptedFile = tempDir.newFile();
         createTestHDT(hdtFile1, hdtFile2, hdtDiffExceptedFile, spec, subjects, predicates, objects, shared, 4);
 
-        HDT hdtDiffExcepted = HDTManager.mapHDT(hdtDiffExceptedFile.getAbsolutePath(), null, spec);
+        try (HDT hdtDiffExcepted = HDTManager.mapHDT(hdtDiffExceptedFile.getAbsolutePath(), null, spec);
+            HDT hdtDiffActual = HDTManager.diffHDT(hdtFile1.getAbsolutePath(), hdtFile2.getAbsolutePath(), spec, null)) {
 
-        HDT hdtDiffActual = HDTManager.diffHDT(hdtFile1.getAbsolutePath(), hdtFile2.getAbsolutePath(), spec, null);
+            Assert.assertEquals(
+                    "Dictionaries aren't the same",
+                    hdtDiffExcepted.getDictionary().getType(),
+                    hdtDiffActual.getDictionary().getType()
+            );
 
-        Assert.assertEquals(
-                "Dictionaries aren't the same",
-                hdtDiffExcepted.getDictionary().getType(),
-                hdtDiffActual.getDictionary().getType()
-        );
-
-        assertHdtEquals(hdtDiffExcepted, hdtDiffActual);
+            assertHdtEquals(hdtDiffExcepted, hdtDiffActual);
+        }
     }
 
     @Test
     public void diffHDTBitIdentityTest() throws IOException {
         File f = tempDir.newFile();
         File location = tempDir.newFile();
-        HDTTestUtils hdtTestUtils = new HDTTestUtils(f, subjects, predicates, objects, shared, spec, true);
+        try (HDTTestUtils hdtTestUtils = new HDTTestUtils(f, subjects, predicates, objects, shared, spec, true)) {
 
-        HDT hdtDiffExcepted = hdtTestUtils.hdt;
-        HDT hdtDiffActual = HDTManager.diffHDTBit(location.getAbsolutePath(), f.getAbsolutePath(), new EmptyBitmap(hdtTestUtils.triples), spec, null);
+            HDT hdtDiffExcepted = hdtTestUtils.hdt;
+            try (HDT hdtDiffActual = HDTManager.diffHDTBit(location.getAbsolutePath(), f.getAbsolutePath(), new EmptyBitmap(hdtTestUtils.triples), spec, null)) {
 
-        Assert.assertEquals(
-                "Dictionaries aren't the same",
-                hdtDiffExcepted.getDictionary().getType(),
-                hdtDiffActual.getDictionary().getType()
-        );
+                Assert.assertEquals(
+                        "Dictionaries aren't the same",
+                        hdtDiffExcepted.getDictionary().getType(),
+                        hdtDiffActual.getDictionary().getType()
+                );
 
-        assertHdtEquals(hdtTestUtils.hdt, hdtDiffActual);
+                assertHdtEquals(hdtTestUtils.hdt, hdtDiffActual);
+            }
+        }
     }
     @Test
     public void diffHDTIdentityTest() throws IOException {
         File f = tempDir.newFile();
         File f2 = tempDir.newFile();
-        HDTTestUtils hdtTestUtils = new HDTTestUtils(f, subjects, predicates, objects, shared, spec, true);
-        new HDTTestUtils(f2, 0, 0, 0, 0, spec, true);
+        try (HDTTestUtils hdtTestUtils = new HDTTestUtils(f, subjects, predicates, objects, shared, spec, true)) {
+            new HDTTestUtils(f2, 0, 0, 0, 0, spec, true).close();
 
-        HDT hdtDiffExcepted = hdtTestUtils.hdt;
-        HDT hdtDiffActual = HDTManager.diffHDT(f.getAbsolutePath(), f2.getAbsolutePath(), spec, null);
+            HDT hdtDiffExcepted = hdtTestUtils.hdt;
+            try (HDT hdtDiffActual = HDTManager.diffHDT(f.getAbsolutePath(), f2.getAbsolutePath(), spec, null)) {
 
-        Assert.assertEquals(
-                "Dictionaries aren't the same",
-                hdtDiffExcepted.getDictionary().getType(),
-                hdtDiffActual.getDictionary().getType()
-        );
+                Assert.assertEquals(
+                        "Dictionaries aren't the same",
+                        hdtDiffExcepted.getDictionary().getType(),
+                        hdtDiffActual.getDictionary().getType()
+                );
 
-        assertHdtEquals(hdtTestUtils.hdt, hdtDiffActual);
+                assertHdtEquals(hdtTestUtils.hdt, hdtDiffActual);
+            }
+        }
 
     }
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/tests/AllTests.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/tests/AllTests.java
@@ -6,6 +6,7 @@ import org.rdfhdt.hdt.compact.array.IntegerArrayTest;
 import org.rdfhdt.hdt.compact.array.LongArrayTest;
 import org.rdfhdt.hdt.compact.bitmap.BitSequence375Test;
 import org.rdfhdt.hdt.compact.integer.VByteTest;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
 import org.rdfhdt.hdt.util.io.IOUtilTest;
 
 @RunWith(Suite.class)

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorPositionTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorPositionTest.java
@@ -278,25 +278,20 @@ public class BitmapTriplesIteratorPositionTest {
         Assert.assertNotNull("ntFile can't be null", ntFile);
 
         Files.copy(ntFile, f.toPath());
-        HDT hdt = HDTManager.generateHDT(f.getAbsolutePath(), HDTTestUtils.BASE_URI, RDFNotation.NTRIPLES, new HDTSpecification(), null);
-        RDFParserCallback parser = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES);
-
-        List<TripleString> triples = new ArrayList<>();
-        try {
+        try (HDT hdt = HDTManager.generateHDT(f.getAbsolutePath(), HDTTestUtils.BASE_URI, RDFNotation.NTRIPLES, new HDTSpecification(), null)) {
+            List<TripleString> triples = new ArrayList<>();
             hdt.search("", "", "").forEachRemaining(triples::add);
-        } catch (NotFoundException e) {
-            e.printStackTrace();
-        }
-        TripleString ts = triples.get(10);
-        CharSequence ss = s == 0 ? "" : ts.getSubject();
-        CharSequence sp = p == 0 ? "" : ts.getPredicate();
-        CharSequence so = o == 0 ? "" : ts.getObject();
+            TripleString ts = triples.get(10);
+            CharSequence ss = s == 0 ? "" : ts.getSubject();
+            CharSequence sp = p == 0 ? "" : ts.getPredicate();
+            CharSequence so = o == 0 ? "" : ts.getObject();
 
-        IteratorTripleString it = hdt.search(ss, sp, so);
+            IteratorTripleString it = hdt.search(ss, sp, so);
 
-        while (it.hasNext()) {
-            TripleString tripleString = it.next();
-            Assert.assertEquals("Sorted triple index", getIndex(triples, tripleString), it.getLastTriplePosition());
+            while (it.hasNext()) {
+                TripleString tripleString = it.next();
+                Assert.assertEquals("Sorted triple index", getIndex(triples, tripleString), it.getLastTriplePosition());
+            }
         }
     }
 

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/utils/HDTTestUtils.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/utils/HDTTestUtils.java
@@ -12,6 +12,7 @@ import org.rdfhdt.hdt.triples.IteratorTripleString;
 import org.rdfhdt.hdt.triples.TripleID;
 import org.rdfhdt.hdt.triples.TripleString;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
@@ -19,7 +20,7 @@ import java.io.IOException;
  * class to generate a synthetic hdt for test purposes.
  * @author ate47
  */
-public class HDTTestUtils {
+public class HDTTestUtils implements Closeable {
 
     /**
      * base URI
@@ -205,4 +206,8 @@ public class HDTTestUtils {
         return hdt.search(tr.getSubject(), tr.getPredicate(), tr.getObject());
     }
 
+    @Override
+    public void close() throws IOException {
+        hdt.close();
+    }
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplier.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplier.java
@@ -104,14 +104,14 @@ public class LargeFakeDataSetStreamSupplier {
 	}
 
 	public void createAndSaveFakeHDT(HDTOptions spec, String location) throws ParserException, IOException {
-		HDT hdt = createFakeHDT(spec);
-		hdt.saveToHDT(location, null);
-		hdt.close();
+		try (HDT hdt = createFakeHDT(spec)) {
+			hdt.saveToHDT(location, null);
+		}
 	}
 	public void createAndSaveFakeHDTTwoPass(HDTOptions spec, String location) throws ParserException, IOException {
-		HDT hdt = createFakeHDTTwoPass(spec);
-		hdt.saveToHDT(location, null);
-		hdt.close();
+		try (HDT hdt = createFakeHDTTwoPass(spec)) {
+			hdt.saveToHDT(location, null);
+		}
 	}
 
 	private CharSequence createSubject() {

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/LongArrayDiskTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/LongArrayDiskTest.java
@@ -1,0 +1,77 @@
+package org.rdfhdt.hdt.util.disk;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
+import org.rdfhdt.hdt.util.io.CloseMappedByteBuffer;
+import org.rdfhdt.hdt.util.io.IOUtil;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class LongArrayDiskTest  extends AbstractMapMemoryTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    public static String printByteBuff(ByteBuffer buffer) {
+        return IntStream.range(0, buffer.capacity())
+                        .mapToObj(buffer::get)
+                        .map(b -> String.format("%02x", b))
+                        .collect(Collectors.joining(" "));
+    }
+    @Test
+    public void testClose() throws IOException {
+        Path testDir = tempDir.newFolder().toPath();
+
+        Path arraydisk = testDir.resolve("arraydisk");
+        int size = 6;
+
+        try (LongArrayDisk array = new LongArrayDisk(arraydisk, size)) {
+            for (int i = 0; i < size; i++) {
+                array.set(i, i * 2);
+                Assert.assertEquals("index #" + i, i * 2, array.get(i));
+            }
+        }
+
+        String f1;
+
+        try (FileChannel channel = FileChannel.open(arraydisk, StandardOpenOption.READ)) {
+            ByteBuffer buffer = ByteBuffer.allocate(size * 8);
+            channel.read(buffer);
+            f1 = printByteBuff(buffer);
+        }
+
+        String f2;
+
+        try (FileChannel channel = FileChannel.open(arraydisk, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+             CloseMappedByteBuffer closeMappedByteBuffer = IOUtil.mapChannel(arraydisk.toAbsolutePath().toString(), channel, FileChannel.MapMode.READ_WRITE, 0, size * 8)) {
+            ByteBuffer map = closeMappedByteBuffer.getInternalBuffer();
+            try {
+                f2 = printByteBuff(map);
+            } finally {
+                IOUtil.cleanBuffer(map);
+            }
+        }
+        Assert.assertEquals(f1, f2);
+
+        try (LongArrayDisk array = new LongArrayDisk(arraydisk, size, false)) {
+            for (int i = 0; i < size; i++) {
+                Assert.assertEquals("index #" + i, i * 2, array.get(i));
+            }
+        }
+
+        Assert.assertTrue(Files.exists(arraydisk));
+        Files.delete(arraydisk);
+        Assert.assertFalse(Files.exists(arraydisk));
+    }
+
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/AbstractMapMemoryTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/AbstractMapMemoryTest.java
@@ -1,0 +1,35 @@
+package org.rdfhdt.hdt.util.io;
+
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * extend this class to all test using mapped memory to check if no unclose mapped file are present.
+ * <p>
+ * This code is equivalent to add:
+ *
+ * <pre>
+ * {@literal @Before}
+ *  public void setup() {
+ *      CloseMappedByteBufferUtil.markMapTest();
+ *  }
+ *
+ * {@literal @After}
+ *  public void complete() {
+ *      CloseMappedByteBufferUtil.crashMapTest();
+ *  }
+ * </pre>
+ *
+ * @author Antoine Willerval
+ */
+public class AbstractMapMemoryTest {
+    @Before
+    public void setup() {
+        CloseMappedByteBufferUtil.markMapTest();
+    }
+
+    @After
+    public void complete() {
+        CloseMappedByteBufferUtil.crashMapTest();
+    }
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/BigByteBufferTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/BigByteBufferTest.java
@@ -18,6 +18,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -116,10 +117,8 @@ public class BigByteBufferTest {
 	}
 
 	@Test
-	public void readFileTest() throws IOException {
-		final String rawFileName = Objects.requireNonNull(getClass().getClassLoader().getResource("dbpedia.hdt"), "can't find dbpedia hdt").getFile();
-
-		Path path = Paths.get(rawFileName);
+	public void readFileTest() throws IOException, URISyntaxException {
+		Path path = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource("dbpedia.hdt"), "can't find dbpedia hdt").toURI());
 
 		long size = Files.size(path);
 
@@ -127,13 +126,11 @@ public class BigByteBufferTest {
 
 		BigByteBuffer buffer = BigByteBuffer.allocate(size);
 
-		String file = Objects.requireNonNull(getClass().getClassLoader().getResource("dbpedia.hdt"), "Can't find dbpedia.hdt").getFile();
-
-		try (InputStream stream = IOUtil.getFileInputStream(file)) {
+		try (InputStream stream = Files.newInputStream(path)) {
 			buffer.readStream(stream, 0, size, null);
 		}
 
-		byte[] real = Files.readAllBytes(Paths.get(file));
+		byte[] real = Files.readAllBytes(path);
 		byte[] test = new byte[(int) buffer.size()];
 
 		int delta = (int) (size / 10);

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/BigMappedByteBufferTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/BigMappedByteBufferTest.java
@@ -1,20 +1,15 @@
 package org.rdfhdt.hdt.util.io;
 
 import org.junit.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.rdfhdt.hdt.exceptions.NotFoundException;
 import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
+import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,31 +20,35 @@ public class BigMappedByteBufferTest {
     private long size;
     private FileChannel ch;
 
+    private String filename;
+
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, URISyntaxException {
         normalBufferSize = BigMappedByteBuffer.maxBufferSize;
 
-        final String rawFileName = Objects.requireNonNull(getClass().getClassLoader().getResource("dbpedia.hdt"), "can't find dbpedia hdt").getFile();
 
-        Path path = Paths.get(rawFileName);
+        Path path = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource("dbpedia.hdt"), "can't find dbpedia hdt").toURI());
+
+        filename = path.toAbsolutePath().toString();
 
         size = Files.size(path);
 
         BigMappedByteBuffer.maxBufferSize = size / 5; // test with huge split
 
         ch = FileChannel.open(path);
-        buffer = BigMappedByteBuffer.ofFileChannel(ch, FileChannel.MapMode.READ_ONLY, 0, size);
+        buffer = BigMappedByteBuffer.ofFileChannel(filename, ch, FileChannel.MapMode.READ_ONLY, 0, size);
     }
 
     @After
     public void unSetup() throws IOException {
+        buffer.clean();
         ch.close();
         BigMappedByteBuffer.maxBufferSize = normalBufferSize;
     }
 
     @Test
     public void capacityBuffer() {
-        List<ByteBuffer> buffers = buffer.getBuffers();
+        List<CloseMappedByteBuffer> buffers = buffer.getBuffers();
 
         for (int i = 0; i < buffers.size() - 1; i++) {
             int c = buffers.get(i).capacity();
@@ -73,19 +72,20 @@ public class BigMappedByteBufferTest {
     @Test
     public void get() throws IOException {
         BigMappedByteBuffer buffer1 = buffer.duplicate();
-        MappedByteBuffer buffer2 = ch.map(FileChannel.MapMode.READ_ONLY, 0, size);
+        try (CloseMappedByteBuffer buffer2 = IOUtil.mapChannel(filename, ch, FileChannel.MapMode.READ_ONLY, 0, size)) {
 
-        while (buffer2.hasRemaining() && buffer1.hasRemaining()) {
-            Assert.assertEquals("position", buffer1.position(), buffer2.position());
-            Assert.assertEquals("byte op", buffer1.get(), buffer2.get());
+            while (buffer2.hasRemaining() && buffer1.hasRemaining()) {
+                Assert.assertEquals("position", buffer1.position(), buffer2.position());
+                Assert.assertEquals("byte op", buffer1.get(), buffer2.get());
+            }
+
+            Assert.assertFalse("Buffer 1 empty", buffer1.hasRemaining());
+            Assert.assertFalse("Buffer 2 empty", buffer2.hasRemaining());
         }
-
-        Assert.assertFalse("Buffer 1 empty", buffer1.hasRemaining());
-        Assert.assertFalse("Buffer 2 empty", buffer2.hasRemaining());
     }
 
     @Test
-    public void position() throws IOException {
+    public void position() {
         BigMappedByteBuffer test = buffer.duplicate();
 
         for (long i = 0; i < size; i++) {
@@ -97,30 +97,31 @@ public class BigMappedByteBufferTest {
     @Test
     public void getBuff() throws IOException {
         BigMappedByteBuffer buffer1 = buffer.duplicate();
-        MappedByteBuffer buffer2 = ch.map(FileChannel.MapMode.READ_ONLY, 0, size);
+        try (CloseMappedByteBuffer buffer2 = IOUtil.mapChannel(filename, ch, FileChannel.MapMode.READ_ONLY, 0, size)) {
 
-        // add +2 to assure the cross-buffer reading
-        byte[] bytes1 = new byte[(int)(BigMappedByteBuffer.maxBufferSize / 2 + 2)];
-        byte[] bytes2 = new byte[bytes1.length];
+            // add +2 to assure the cross-buffer reading
+            byte[] bytes1 = new byte[(int) (BigMappedByteBuffer.maxBufferSize / 2 + 2)];
+            byte[] bytes2 = new byte[bytes1.length];
 
-        while (buffer2.hasRemaining() && buffer1.hasRemaining()) {
-            int toRead = (int) Math.min(bytes1.length, buffer1.capacity() - buffer2.position());
-            buffer1.get(bytes1, 0, toRead);
-            buffer2.get(bytes2, 0, toRead);
-            Assert.assertArrayEquals("byte op", bytes1, bytes2);
+            while (buffer2.hasRemaining() && buffer1.hasRemaining()) {
+                int toRead = (int) Math.min(bytes1.length, buffer1.capacity() - buffer2.position());
+                buffer1.get(bytes1, 0, toRead);
+                buffer2.get(bytes2, 0, toRead);
+                Assert.assertArrayEquals("byte op", bytes1, bytes2);
+            }
+
+            Assert.assertFalse("Buffer 1 empty", buffer1.hasRemaining());
+            Assert.assertFalse("Buffer 2 empty", buffer2.hasRemaining());
         }
-
-        Assert.assertFalse("Buffer 1 empty", buffer1.hasRemaining());
-        Assert.assertFalse("Buffer 2 empty", buffer2.hasRemaining());
     }
 
 
     @Test
     @Ignore("HDT git ignored")
-    public void largeTest() throws IOException, NotFoundException {
+    public void largeTest() throws IOException {
         // see https://github.com/rdfhdt/hdt-java/issues/126#issuecomment-1036228969
-        HDT hdt = HDTManager.mapHDT("/Users/ate/Downloads/archive/dbpedia2016-10.hdt");
-
-        System.out.println(hdt.getTriples().getNumberOfElements());
+        try (HDT hdt = HDTManager.mapHDT("/Users/ate/Downloads/archive/dbpedia2016-10.hdt")) {
+            System.out.println(hdt.getTriples().getNumberOfElements());
+        }
     }
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/CloseMappedByteBufferUtil.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/CloseMappedByteBufferUtil.java
@@ -1,0 +1,22 @@
+package org.rdfhdt.hdt.util.io;
+
+/**
+ * Utility class to trace unclosed mapped buffer.
+ *
+ * @author Antoine Willerval
+ */
+public class CloseMappedByteBufferUtil {
+    /**
+     * start recording map tests
+     */
+    public static void markMapTest() {
+        CloseMappedByteBuffer.markMapTest();
+    }
+
+    /**
+     * end recording of map tests and crash if a mapped element wasn't closed
+     */
+    public static void crashMapTest() {
+        CloseMappedByteBuffer.crashMapTest();
+    }
+}


### PR DESCRIPTION
This pull request fix (I hope) all the non closed files and mapped buffer in HDT-JAVA-CORE, the main idea is to make it work on Windows, more strict on not closed files.

## API Changes

I've added to the `indexedHDT(...)` method a `throws IOException` to throw exception instead of a random runtime exception (probably a NPE) in case of error.

**Old HDTManager.java**
```java
HDT indexedHDT(HDT hdt, ProgressListener listener)
protected abstract HDT doIndexedHDT(HDT hdt, ProgressListener listener)
```

**New HDTManager.java**
```java
HDT indexedHDT(HDT hdt, ProgressListener listener) throws IOException
protected abstract HDT doIndexedHDT(HDT hdt, ProgressListener listener) throws IOException
```

## Core Changes

### Main

- add `close()` and `try-resource` in many methods.
- add `IOUtil.cleanBuffer(...)` method and `CloseMappedByteBuffer` class to clean byte buffer, this is using the Unsafe due to a [JVM exception](https://stackoverflow.com/questions/25238110/how-to-properly-close-mappedbytebuffer).
- add `IOUtil.mapChannel(...)` method to create mapped file memory to trace mapped memory cleaning (for test)
- Remove try-catch without throwing added in #128.
- fix LongArrayDisk if `sizeBit mod MAPPING_SIZE = 0`

### Tests

- add `close()` and `try-resource` in many tests.
- remove prints in HDTCat tests.
- add test for the `LongArrayDisk` class.
- add `AbstractMapMemoryTest` utility class to test mapped memory allocation.



## Workflow

- I've added a Java CI version for Windows to test the library in a Windows environment in the `.github/workflows/mvn-windows.yaml` file, I can remove it if asked.