### PR TITLE
Update JLargeArrays and use SequenceLog64Big instead of SequenceLog64

### DIFF
--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -49,8 +49,9 @@
             <artifactId>jena-arq</artifactId>
         </dependency>
         <dependency>
-            <groupId>pl.edu.icm</groupId>
+            <groupId>org.visnow</groupId>
             <artifactId>JLargeArrays</artifactId>
+            <version>1.7-20220624.150242-7</version>
         </dependency>
         <dependency>
             <groupId>pl.pragmatists</groupId>
@@ -63,7 +64,12 @@
 		    <version>1.6</version>
 		</dependency>		        
     </dependencies>
-
+    <repositories>
+        <repository>
+            <id>gitlab-maven</id>
+            <url>https://gitlab.com/api/v4/projects/375779/packages/maven</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Disk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Disk.java
@@ -111,7 +111,7 @@ public class Bitmap375Disk extends Bitmap64Disk implements ModifiableBitmap {
         if (bitIndex < 0)
             throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
 
-        int wordIndex = wordIndex(bitIndex);
+        long wordIndex = wordIndex(bitIndex);
         if(wordIndex>=words.length()) {
             return false;
         }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
@@ -105,9 +105,13 @@ public class SequenceInt32 implements DynamicSequence {
 	@Override
     public void append(long value) {
 		assert value>=0 && value<=Integer.MAX_VALUE;
-		
-		if(data.length<numelements+1) {
-			resizeArray(data.length*2);
+
+		long neededSize = numelements+1L;
+		if (neededSize > Integer.MAX_VALUE - 5) {
+			throw new IllegalArgumentException("Needed size exceeds the maximum size of this data structure " + neededSize);
+		}
+		if(data.length < neededSize) {
+			resizeArray((int) Math.min(Integer.MAX_VALUE - 5L, data.length*2L));
 		}
 		data[numelements++] = (int) value;
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
@@ -94,7 +94,7 @@ public class SequenceInt64 implements DynamicSequence {
 	@Override
     public void set(long position, long value) {
 		assert position>=0 && position<=Integer.MAX_VALUE;
-		assert value>=0 && value<=Long.MAX_VALUE;
+		assert value>=0;
 		
 		data[(int)position] = value;
 		numelements = (int) Math.max(numelements, position+1);
@@ -102,11 +102,15 @@ public class SequenceInt64 implements DynamicSequence {
 	
 	@Override
     public void append(long value) {
-		assert value>=0 && value<=Long.MAX_VALUE;
+		assert value>=0;
 		assert numelements<Long.MAX_VALUE;
-		
-		if(data.length<numelements+1) {
-			resizeArray(data.length*2);
+
+		long neededSize = numelements+1L;
+		if (neededSize > Integer.MAX_VALUE - 5) {
+			throw new IllegalArgumentException("Needed size exceeds the maximum size of this data structure " + neededSize);
+		}
+		if(data.length < neededSize) {
+			resizeArray((int) Math.min(Integer.MAX_VALUE - 5L, data.length*2L));
 		}
 		data[(int)numelements++] = value;
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
@@ -241,8 +241,11 @@ public class SequenceLog64 implements DynamicSequence {
 		}
 		
 		long neededSize = numWordsFor(numbits, numentries+1);
-		if(data.length<neededSize) {
-			resizeArray(data.length*2);
+		if (neededSize > Integer.MAX_VALUE - 5) {
+			throw new IllegalArgumentException("Needed size exceeds the maximum size of this data structure " + neededSize);
+		}
+		if(data.length < neededSize) {
+			resizeArray((int) Math.min(Integer.MAX_VALUE - 5L, data.length*2L));
 		}
 		
 		this.set((int)numentries, value);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
@@ -44,9 +44,8 @@ import org.rdfhdt.hdt.util.crc.CRC8;
 import org.rdfhdt.hdt.util.crc.CRCInputStream;
 import org.rdfhdt.hdt.util.crc.CRCOutputStream;
 import org.rdfhdt.hdt.util.io.IOUtil;
-
-import pl.edu.icm.jlargearrays.LongLargeArray;
-import pl.edu.icm.jlargearrays.LargeArrayUtils;
+import org.visnow.jlargearrays.LargeArrayUtils;
+import org.visnow.jlargearrays.LongLargeArray;
 
 /**
  * @author mario.arias,Lyudmila Balakireva
@@ -55,8 +54,8 @@ import pl.edu.icm.jlargearrays.LargeArrayUtils;
 public class SequenceLog64Big implements DynamicSequence { 
 	private static final byte W = 64;
 	private static final int INDEX = 1073741824;
-	
-    LongLargeArray data;
+
+	LongLargeArray data;
 	private int numbits;
 	private long numentries=0;
 	private long maxvalue;
@@ -77,7 +76,7 @@ public class SequenceLog64Big implements DynamicSequence {
 		long size = numWordsFor(numbits, capacity);
 		LongLargeArray.setMaxSizeOf32bitArray(SequenceLog64Big.INDEX);
 		
-		data = new LongLargeArray(Math.max((int)size,1)); 
+		data = new LongLargeArray(Math.max(size,1));
 	}
 	
 	public SequenceLog64Big(int numbits, long capacity, boolean initialize) {
@@ -158,11 +157,7 @@ public class SequenceLog64Big implements DynamicSequence {
 		//data = Arrays.copyOf(data, size);
 		if(size > 0) {
 			LongLargeArray a = new LongLargeArray(size);
-			if (size < data.length()) {
-				LargeArrayUtils.arraycopy(data, 0, a, 0, size);
-			} else {
-				LargeArrayUtils.arraycopy(data, 0, a, 0, data.length());
-			}
+			LargeArrayUtils.arraycopy(data, 0, a, 0, Math.min(size, data.length()));
 			data = a;
 		}else{
 			this.numentries = 0;
@@ -182,7 +177,7 @@ public class SequenceLog64Big implements DynamicSequence {
 		// Count and calculate number of bits needed per element.
 		while(elements.hasNext()) {
 			long val = elements.next();
-			max = val>max ? val : max;
+			max = Math.max(val, max);
 			numentries++;
 		}
 		
@@ -208,7 +203,7 @@ public class SequenceLog64Big implements DynamicSequence {
 		// Count and calculate number of bits needed per element.
 		for (int i=0;i<elements.size();i++){
 			long val = elements.get(i).longValue();
-			max = val>max ? val : max;
+			max = Math.max(val, max);
 			numentries++;
 		}
 		

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -786,7 +786,7 @@ public class HDTImpl implements HDTPrivate {
 			log.debug("Generating Triples...");
 			il.notifyProgress(40, "Generating Triples...");
 			// map the triples based on the new dictionary
-			BitmapTriplesIteratorMapDiff mapIter = new BitmapTriplesIteratorMapDiff(hdt, deleteBitmap, diff, iter.getCount() + 1);
+			BitmapTriplesIteratorMapDiff mapIter = new BitmapTriplesIteratorMapDiff(hdt, deleteBitmap, diff);
 
 			BitmapTriples triples = new BitmapTriples(spec);
 			triples.load(mapIter, listener);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
@@ -129,8 +129,8 @@ public class BitmapTriples implements TriplesPrivate {
 
 		long number = it.estimatedNumResults();
 		
-		SequenceLog64 vectorY = new SequenceLog64(BitUtil.log2(number), number);
-		SequenceLog64 vectorZ = new SequenceLog64(BitUtil.log2(number), number);
+		DynamicSequence vectorY = new SequenceLog64Big(BitUtil.log2(number), number);
+		DynamicSequence vectorZ = new SequenceLog64Big(BitUtil.log2(number), number);
 		
 		ModifiableBitmap bitY = new Bitmap375(number);
 		ModifiableBitmap bitZ = new Bitmap375(number);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorMapDiff.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesIteratorMapDiff.java
@@ -32,13 +32,13 @@ public class BitmapTriplesIteratorMapDiff implements IteratorTripleID {
     TripleIDComparator tripleIDComparator = new TripleIDComparator(TripleComponentOrder.SPO);
     Bitmap bitArrayDisk;
 
-    public BitmapTriplesIteratorMapDiff(HDT hdtOriginal, Bitmap deleteBitmap, DictionaryDiff dictionaryDiff, long countTriples) {
+    public BitmapTriplesIteratorMapDiff(HDT hdtOriginal, Bitmap deleteBitmap, DictionaryDiff dictionaryDiff) {
         this.subjMapping = dictionaryDiff.getAllMappings().get("subject");
         this.objMapping = dictionaryDiff.getAllMappings().get("object");
         this.predMapping = dictionaryDiff.getAllMappings().get("predicate");
         this.sharedMapping = dictionaryDiff.getAllMappings().get("shared");
         this.dictionaryDiff = dictionaryDiff;
-        this.countTriples = countTriples;
+        this.countTriples = Math.max(0, hdtOriginal.getTriples().getNumberOfElements() - deleteBitmap.countOnes());
         this.triples = hdtOriginal.getTriples();
         this.bitArrayDisk = deleteBitmap;
         list = getTripleID(0).listIterator();

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
@@ -30,7 +30,7 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.util.string.ByteStringUtil;
-import pl.edu.icm.jlargearrays.LargeArrayUtils;
+import org.visnow.jlargearrays.LargeArrayUtils;
 
 import java.io.*;
 import java.net.URL;

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/sequence/LargeArrayTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/sequence/LargeArrayTest.java
@@ -1,0 +1,20 @@
+package org.rdfhdt.hdt.compact.sequence;
+
+import org.junit.Test;
+import org.visnow.jlargearrays.LargeArray;
+import org.visnow.jlargearrays.LongLargeArray;
+
+public class LargeArrayTest {
+
+	@Test
+	public void allocationTest() {
+		int old = LargeArray.getMaxSizeOf32bitArray();
+		try {
+			LargeArray.setMaxSizeOf32bitArray(100);
+			long size = LargeArray.getMaxSizeOf32bitArray() + 2L;
+			new LongLargeArray(size);
+		} finally {
+			LargeArray.setMaxSizeOf32bitArray(old);
+		}
+	}
+}


### PR DESCRIPTION
In this pull request I've updated the JLargeArrays dependency to use the [latest version](https://gitlab.com/visnow.org/JLargeArrays/-/packages/1097495) with the fix for #167. It was required to use the Gitlab development release because no Maven central version exists.

Added to that I've updated the code for the new version and replaced SequenceLog64 to SequenceLog64Big.

It should also fix #173 