### PR TITLE
add disk HDT indexing

### DIFF
--- a/hdt-java-cli/bin/hdtVerify.bat
+++ b/hdt-java-cli/bin/hdtVerify.bat
@@ -1,0 +1,5 @@
+@echo off
+
+call "%~dp0\javaenv.bat"
+
+"%JAVACMD%" -XX:NewRatio=1 -XX:SurvivorRatio=9 %JAVAOPTIONS% -classpath %JAVACP% org.rdfhdt.hdt.tools.HDTVerify %*

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Disk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Disk.java
@@ -27,6 +27,7 @@ import org.rdfhdt.hdt.util.io.IOUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 /**
@@ -48,6 +49,14 @@ public class Bitmap375Disk extends Bitmap64Disk implements ModifiableBitmap {
     }
 
     public Bitmap375Disk(String location, long nbits) {
+        super(location, nbits);
+    }
+
+    public Bitmap375Disk(Path location) {
+        super(location);
+    }
+
+    public Bitmap375Disk(Path location, long nbits) {
         super(location, nbits);
     }
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/DynamicSequence.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/DynamicSequence.java
@@ -56,4 +56,6 @@ public interface DynamicSequence extends Sequence, LongArray {
 	default long length() {
 		return getNumberOfElements();
 	}
+
+	void resize(long size);
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
@@ -61,7 +61,16 @@ public class SequenceInt32 implements DynamicSequence {
 		data = new int[capacity];
 		numelements = 0;
 	}
-	
+
+	@Override
+	public void resize(long numentries) {
+		if (numentries > (long) Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("Can't resize to size bigger than int value");
+		}
+		resizeArray((int) numentries);
+		this.numelements = (int) numentries;
+	}
+
 	private void resizeArray(int size) {
 		int [] newData = new int[size];
 		System.arraycopy(data, 0, newData, 0, Math.min(newData.length, data.length));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
@@ -62,7 +62,16 @@ public class SequenceInt64 implements DynamicSequence {
 		data = new long[(int)capacity];
 		numelements = 0;
 	}
-	
+
+	@Override
+	public void resize(long numentries) {
+		if (numentries > (long) Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("Can't resize to size bigger than int value");
+		}
+		resizeArray((int) numentries);
+		this.numelements = numentries;
+	}
+
 	private void resizeArray(int size) {
 		long [] newData = new long[size];
 		System.arraycopy(data, 0, newData, 0, Math.min(newData.length, data.length));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
@@ -281,7 +281,8 @@ public class SequenceLog64 implements DynamicSequence {
     public void trimToSize() {
 		resizeArray((int)numWordsFor(numbits, numentries));
 	}
-	
+
+	@Override
 	public void resize(long numentries) {
 		this.numentries = numentries;
 		resizeArray((int)numWordsFor(numbits, numentries));	

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
@@ -156,9 +156,11 @@ public class SequenceLog64Big implements DynamicSequence {
 	private void resizeArray(long size) {
 		//data = Arrays.copyOf(data, size);
 		if(size > 0) {
-			LongLargeArray a = new LongLargeArray(size);
-			LargeArrayUtils.arraycopy(data, 0, a, 0, Math.min(size, data.length()));
-			data = a;
+			if (data.length() != size) {
+				LongLargeArray a = new LongLargeArray(size);
+				LargeArrayUtils.arraycopy(data, 0, a, 0, Math.min(size, data.length()));
+				data = a;
+			}
 		}else{
 			this.numentries = 0;
 		}
@@ -295,7 +297,8 @@ public class SequenceLog64Big implements DynamicSequence {
     public void trimToSize() {
 		resizeArray(numWordsFor(numbits, numentries));
 	}
-	
+
+	@Override
 	public void resize(long numentries) {
 		this.numentries = numentries;
 		resizeArray(numWordsFor(numbits, numentries));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTFactory.java
@@ -33,6 +33,8 @@ import org.rdfhdt.hdt.hdt.impl.TempHDTImpl;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.options.HDTSpecification;
 
+import java.io.IOException;
+
 /**
  * Factory that creates HDT objects
  * 
@@ -45,7 +47,7 @@ public class HDTFactory {
 	 * 
 	 * @return HDT
 	 */
-	public static HDT createHDT() {
+	public static HDT createHDT() throws IOException {
 		return new HDTImpl(new HDTSpecification());
 	}
 
@@ -54,7 +56,7 @@ public class HDTFactory {
 	 * 
 	 * @return HDT
 	 */
-	public static HDT createHDT(HDTOptions spec) {
+	public static HDT createHDT(HDTOptions spec) throws IOException {
 		return new HDTImpl(spec);
 	}
 	

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTManagerImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTManagerImpl.java
@@ -93,7 +93,7 @@ public class HDTManagerImpl extends HDTManager {
 	public HDT doLoadIndexedHDT(String hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException {
 		HDTPrivate hdt = new HDTImpl(spec);
 		hdt.loadFromHDT(hdtFileName, listener);
-		hdt.loadOrCreateIndex(listener);
+		hdt.loadOrCreateIndex(listener, spec);
 		return hdt;
 	}
 
@@ -102,7 +102,7 @@ public class HDTManagerImpl extends HDTManager {
 	public HDT doMapIndexedHDT(String hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException {
 		HDTPrivate hdt = new HDTImpl(spec);
 		hdt.mapFromHDT(new File(hdtFileName), 0, listener);
-		hdt.loadOrCreateIndex(listener);
+		hdt.loadOrCreateIndex(listener, spec);
 		return hdt;
 	}
 
@@ -110,13 +110,13 @@ public class HDTManagerImpl extends HDTManager {
 	public HDT doLoadIndexedHDT(InputStream hdtFile, ProgressListener listener, HDTOptions spec) throws IOException {
 		HDTPrivate hdt = new HDTImpl(spec);
 		hdt.loadFromHDT(hdtFile, listener);
-		hdt.loadOrCreateIndex(listener);
+		hdt.loadOrCreateIndex(listener, spec);
 		return hdt;
 	}
 
 	@Override
 	public HDT doIndexedHDT(HDT hdt, ProgressListener listener) throws IOException {
-		((HDTPrivate) hdt).loadOrCreateIndex(listener);
+		((HDTPrivate)hdt).loadOrCreateIndex(listener, new HDTSpecification());
 		return hdt;
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTPrivate.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTPrivate.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
 
 /**
  * HDT Operations that are using internally from the implementation.
@@ -36,7 +37,7 @@ public interface HDTPrivate extends HDT {
 	 * 
 	 * @param listener A listener to be notified of the progress.
 	 */
-	void loadOrCreateIndex(ProgressListener listener) throws IOException;
+	void loadOrCreateIndex(ProgressListener listener, HDTOptions disk) throws IOException;
 	
 	void populateHeaderStructure(String baseUri);
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -111,7 +111,7 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 	private boolean isMapped;
 	private boolean isClosed=false;
 
-	public HDTImpl(HDTOptions spec) {
+	public HDTImpl(HDTOptions spec) throws IOException {
 		super(spec);
 
 		header = HeaderFactory.createHeader(this.spec);
@@ -369,7 +369,7 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 	 * @see hdt.hdt.HDT#generateIndex(hdt.listener.ProgressListener)
 	 */
 	@Override
-	public void loadOrCreateIndex(ProgressListener listener) throws IOException {
+	public void loadOrCreateIndex(ProgressListener listener, HDTOptions spec) throws IOException {
 		if(triples.getNumberOfElements()==0) {
 			// We need no index.
 			return;
@@ -402,7 +402,7 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 
 			// GENERATE
 			StopWatch st = new StopWatch();
-			triples.generateIndex(listener);
+			triples.generateIndex(listener, spec);
 
 			// SAVE
 			if(this.hdtFileName!=null) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/WriteHDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/WriteHDTImpl.java
@@ -67,7 +67,7 @@ public class WriteHDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, Writ
 	}
 
 	@Override
-	public void loadOrCreateIndex(ProgressListener listener) {
+	public void loadOrCreateIndex(ProgressListener listener, HDTOptions disk) {
 		throw new NotImplementedException();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesFactory.java
@@ -34,6 +34,8 @@ import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.triples.impl.BitmapTriples;
 import org.rdfhdt.hdt.triples.impl.TriplesList;
 
+import java.io.IOException;
+
 /**
  * Factory that creates Triples objects
  * 
@@ -65,7 +67,7 @@ public class TriplesFactory {
 	 *            The HDTOptions to read
 	 * @return Triples
 	 */
-	static public TriplesPrivate createTriples(HDTOptions spec) {
+	static public TriplesPrivate createTriples(HDTOptions spec) throws IOException {
 		String type = spec.get("triples.format");
 		
 		if(type==null) {
@@ -86,7 +88,7 @@ public class TriplesFactory {
 	 *            The ControlInfo to read
 	 * @return Triples
 	 */
-	public static TriplesPrivate createTriples(ControlInfo ci) {
+	public static TriplesPrivate createTriples(ControlInfo ci) throws IOException {
 		String format = ci.getFormat();
 		
 		if(HDTVocabulary.TRIPLES_TYPE_TRIPLESLIST.equals(format)) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesPrivate.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesPrivate.java
@@ -9,6 +9,7 @@ import org.rdfhdt.hdt.enums.TripleComponentOrder;
 import org.rdfhdt.hdt.iterator.SuppliableIteratorTripleID;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.ControlInfo;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.util.io.CountInputStream;
 
 public interface TriplesPrivate extends Triples {
@@ -45,7 +46,7 @@ public interface TriplesPrivate extends Triples {
 	 * Generates the associated Index
 	 * @param listener
 	 */
-	void generateIndex(ProgressListener listener) throws IOException;
+	void generateIndex(ProgressListener listener, HDTOptions spec) throws IOException;
 	
 	/**
 	 * Loads the associated Index from an InputStream

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/OneReadTempTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/OneReadTempTriples.java
@@ -8,6 +8,7 @@ import org.rdfhdt.hdt.header.Header;
 import org.rdfhdt.hdt.iterator.SuppliableIteratorTripleID;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.ControlInfo;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.triples.IteratorTripleID;
 import org.rdfhdt.hdt.triples.TempTriples;
 import org.rdfhdt.hdt.triples.TripleID;
@@ -104,7 +105,7 @@ public class OneReadTempTriples implements TempTriples {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener) {
+	public void generateIndex(ProgressListener listener, HDTOptions disk) {
 		throw new NotImplementedException();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndex.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndex.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.util.io.CountInputStream;
 
 public interface PredicateIndex {
@@ -19,7 +20,7 @@ public interface PredicateIndex {
 	
 	void mapIndex(CountInputStream input, File f, ProgressListener listener) throws IOException;
 	
-	void generate(ProgressListener listener);
+	void generate(ProgressListener listener, HDTOptions spec);
 	
 	void close() throws IOException;
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesList.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesList.java
@@ -350,7 +350,7 @@ public class TriplesList implements TempTriples {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener) {
+	public void generateIndex(ProgressListener listener, HDTOptions specIndex) {
 		// TODO Auto-generated method stub
 
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesListLong.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesListLong.java
@@ -360,7 +360,7 @@ public class TriplesListLong implements TempTriples {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener) {
+	public void generateIndex(ProgressListener listener, HDTOptions specIndex) {
 		// TODO Auto-generated method stub
 
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/WriteBitmapTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/WriteBitmapTriples.java
@@ -134,7 +134,7 @@ public class WriteBitmapTriples implements TriplesPrivate {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener) {
+	public void generateIndex(ProgressListener listener, HDTOptions disk) {
 		throw new NotImplementedException();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/CloseMappedByteBuffer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/CloseMappedByteBuffer.java
@@ -64,6 +64,7 @@ public class CloseMappedByteBuffer implements Closeable {
     }
 
     public MappedByteBuffer force() {
+        assert buffer instanceof MappedByteBuffer;
         return ((MappedByteBuffer) buffer).force();
     }
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
@@ -91,6 +91,18 @@ public class IOUtil {
 	}
 
 	/**
+	 * close an object if it implements closeable
+	 *
+	 * @param object the object (nullable)
+	 * @throws IOException close exception
+	 */
+	public static void closeObject(Object object) throws IOException {
+		if (object instanceof Closeable) {
+			((Closeable) object).close();
+		}
+	}
+
+	/**
 	 * map a FileChannel, same as {@link FileChannel#map(FileChannel.MapMode, long, long)}, but used to fix unclean map.
 	 * @param ch channel to map
 	 * @param mode mode of the map
@@ -110,7 +122,7 @@ public class IOUtil {
 	 * @throws IOException if one runnable throw an IOException
 	 */
 	public static void closeAll(Closeable... closeables) throws IOException {
-		if (closeables.length == 0) {
+		if (closeables == null || closeables.length == 0) {
 			return;
 		}
 		if (closeables.length == 1) {

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesTest.java
@@ -1,0 +1,171 @@
+package org.rdfhdt.hdt.triples.impl;
+
+import org.apache.commons.io.file.PathUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rdfhdt.hdt.compact.bitmap.Bitmap;
+import org.rdfhdt.hdt.compact.sequence.Sequence;
+import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.options.ControlInformation;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTSpecification;
+import org.rdfhdt.hdt.triples.Triples;
+import org.rdfhdt.hdt.util.LargeFakeDataSetStreamSupplier;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BitmapTriplesTest extends AbstractMapMemoryTest {
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	private HDT loadOrMap(Path path, HDTOptions spec, boolean map) throws IOException {
+		String location = path.toAbsolutePath().toString();
+		if (map) {
+			return HDTManager.mapIndexedHDT(location, spec, null);
+		} else {
+			return HDTManager.loadIndexedHDT(location, null, spec);
+		}
+	}
+
+	private void assertEqualsSeq(String name, Sequence seqE, Sequence seqA) {
+		assertEquals(seqE.getNumberOfElements(), seqA.getNumberOfElements());
+
+		for (long i = 0; i < seqE.getNumberOfElements(); i++) {
+			long e = seqE.get(i);
+			long a = seqA.get(i);
+
+			assertEquals(name + " | longs #" + i + "/" + seqE.getNumberOfElements() + " aren't the same", e, a);
+		}
+	}
+
+	private void assertEqualsBM(String name, Bitmap seqE, Bitmap seqA) {
+		assertEquals(seqE.getNumBits(), seqA.getNumBits());
+
+		for (long i = 0; i < seqE.getNumBits(); i++) {
+			boolean e = seqE.access(i);
+			boolean a = seqA.access(i);
+
+			assertEquals(name + " | bits #" + i + "/" + seqE.getNumBits() + " aren't the same", e, a);
+		}
+	}
+
+	private void assertBitmapTriplesEquals(BitmapTriples excepted, BitmapTriples actual) {
+		// maps
+		assertEqualsSeq("seqY", excepted.getSeqY(), actual.getSeqY());
+		assertEqualsSeq("seqZ", excepted.getSeqZ(), actual.getSeqZ());
+		assertEqualsBM("bitmapY", excepted.getBitmapY(), actual.getBitmapY());
+		assertEqualsBM("bitmapZ", excepted.getBitmapZ(), actual.getBitmapZ());
+		// INDEX
+		assertEqualsBM("bitmapIndexZ", excepted.getBitmapIndex(), actual.getBitmapIndex());
+		assertEqualsSeq("indexZ", excepted.getIndexZ(), actual.getIndexZ());
+		assertEqualsSeq("predicateCount", excepted.getPredicateCount(), actual.getPredicateCount());
+	}
+
+	public void diskBitmapIndexTest(boolean map, boolean disk) throws IOException, ParserException {
+		Path root = tempDir.newFolder().toPath();
+
+		Path hdt1Path = root.resolve("hdt1.hdt");
+		Path hdt2Path = root.resolve("hdt2.hdt");
+
+		try {
+			// create 1 one fake HDT
+			try (HDT hdt = LargeFakeDataSetStreamSupplier
+					.createSupplierWithMaxTriples(10_000L, 42)
+					.createFakeHDT(new HDTSpecification())) {
+				hdt.saveToHDT(hdt1Path.toAbsolutePath().toString(), null);
+			}
+			// copy this fake HDT to another file (faster than creating the same twice)
+			Files.copy(hdt1Path, hdt2Path);
+
+			// hdt1 = DISK, hdt2 = OLD IMPLEMENTATION
+			HDTOptions optDisk = new HDTSpecification();
+			HDTOptions optDefault = new HDTSpecification();
+
+			// set config
+			if (disk) {
+				optDisk.set("bitmaptriples.sequence.disk", "true");
+				optDisk.set("bitmaptriples.sequence.disk.location", root.resolve("indexdir").toAbsolutePath().toString());
+			}
+
+			try (
+					ByteArrayOutputStream indexDisk = new ByteArrayOutputStream();
+					ByteArrayOutputStream indexDefault = new ByteArrayOutputStream()
+			) {
+
+				// create the index for both HDTs
+				try (HDT hdt = loadOrMap(hdt1Path, optDisk, map && disk)) {
+					Triples triples = hdt.getTriples();
+
+					assertTrue(triples instanceof BitmapTriples);
+
+					BitmapTriples bitmapTriples = (BitmapTriples) triples;
+
+					if (disk) {
+						assertNotNull(bitmapTriples.diskSequenceLocation);
+						assertTrue(bitmapTriples.diskSequence);
+					}
+
+					try (HDT hdt2 = loadOrMap(hdt2Path, optDefault, map)) {
+						Triples triples2 = hdt2.getTriples();
+
+						assertTrue(triples2 instanceof BitmapTriples);
+
+						BitmapTriples bitmapTriples2 = (BitmapTriples) triples2;
+
+						if (disk) {
+							assertNull(bitmapTriples2.diskSequenceLocation);
+							assertFalse(bitmapTriples2.diskSequence);
+						}
+						bitmapTriples2.saveIndex(indexDefault, new ControlInformation(), null);
+
+						assertBitmapTriplesEquals(bitmapTriples2, bitmapTriples);
+					}
+
+					bitmapTriples.saveIndex(indexDisk, new ControlInformation(), null);
+				}
+
+				// read and compare indexes
+				byte[] indexDiskArr = indexDisk.toByteArray();
+				byte[] indexDefaultArr = indexDefault.toByteArray();
+
+				assertArrayEquals("index not equals", indexDefaultArr, indexDiskArr);
+			}
+		} finally {
+			PathUtils.deleteDirectory(root);
+		}
+	}
+
+	@Test
+	public void diskBitmapMapIndexedTest() throws IOException, ParserException {
+		diskBitmapIndexTest(false, true);
+	}
+
+	@Test
+	public void diskBitmapLoadIndexedTest() throws IOException, ParserException {
+		diskBitmapIndexTest(false, true);
+	}
+
+	@Test
+	public void memBitmapMapIndexedTest() throws IOException, ParserException {
+		diskBitmapIndexTest(false, false);
+	}
+
+	@Test
+	public void memBitmapLoadIndexedTest() throws IOException, ParserException {
+		diskBitmapIndexTest(false, false);
+	}
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/LongArrayDiskTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/LongArrayDiskTest.java
@@ -17,6 +17,8 @@ import java.nio.file.StandardOpenOption;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.junit.Assert.assertEquals;
+
 public class LongArrayDiskTest  extends AbstractMapMemoryTest {
 
     @Rule
@@ -38,7 +40,7 @@ public class LongArrayDiskTest  extends AbstractMapMemoryTest {
         try (LongArrayDisk array = new LongArrayDisk(arraydisk, size)) {
             for (int i = 0; i < size; i++) {
                 array.set(i, i * 2);
-                Assert.assertEquals("index #" + i, i * 2, array.get(i));
+                assertEquals("index #" + i, i * 2, array.get(i));
             }
         }
 
@@ -61,17 +63,45 @@ public class LongArrayDiskTest  extends AbstractMapMemoryTest {
                 IOUtil.cleanBuffer(map);
             }
         }
-        Assert.assertEquals(f1, f2);
+        assertEquals(f1, f2);
 
         try (LongArrayDisk array = new LongArrayDisk(arraydisk, size, false)) {
             for (int i = 0; i < size; i++) {
-                Assert.assertEquals("index #" + i, i * 2, array.get(i));
+                assertEquals("index #" + i, i * 2, array.get(i));
             }
         }
 
         Assert.assertTrue(Files.exists(arraydisk));
         Files.delete(arraydisk);
         Assert.assertFalse(Files.exists(arraydisk));
+    }
+
+    @Test
+    public void resizeTest() throws IOException {
+        Path root = tempDir.getRoot().toPath();
+
+        try (LongArrayDisk array = new LongArrayDisk(root.resolve("file"), 4)) {
+
+            assertEquals(array.length(), 4);
+
+            array.set(0, 1);
+            array.set(1, 2);
+            array.set(2, 3);
+            array.set(3, 4);
+
+
+            assertEquals(array.get(0), 1);
+            assertEquals(array.get(1), 2);
+            assertEquals(array.get(2), 3);
+            assertEquals(array.get(3), 4);
+
+            array.resize(8);
+
+            assertEquals(array.get(0), 1);
+            assertEquals(array.get(1), 2);
+            assertEquals(array.get(2), 3);
+            assertEquals(array.get(3), 4);
+        }
     }
 
 }

--- a/hdt-jena/src/test/java/org/rdfhdt/hdtjena/util/GraphConverter.java
+++ b/hdt-jena/src/test/java/org/rdfhdt/hdtjena/util/GraphConverter.java
@@ -39,8 +39,9 @@ public class GraphConverter {
         IteratorTripleString tripleIter = new JenaModelIterator(model);
         HDTPrivate hdt;
         try {
-            hdt = (HDTPrivate) HDTManager.generateHDT(tripleIter, "http://example.com", new HDTSpecification(), null);
-            hdt.loadOrCreateIndex(null);
+            HDTSpecification spec = new HDTSpecification();
+            hdt = (HDTPrivate) HDTManager.generateHDT(tripleIter, "http://example.com", spec, null);
+            hdt.loadOrCreateIndex(null, spec);
         } catch (IOException | ParserException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
In this PR I added the hdt option `bitmaptriples.sequence.disk` (boolean) to allow to Index an HDT using the disk versions of the Sequence/Bitmap, this is an internal change to the CORE, so if the option isn't specified, nothing will change.

I've fixed a bug in the LongArrayDisk class.

I've added tests to check my changes.