### PR TITLE
Update CI to Java 17 and add package for release

### DIFF
--- a/.github/workflows/mvn-windows.yaml
+++ b/.github/workflows/mvn-windows.yaml
@@ -1,4 +1,4 @@
-name: Java CI (Windows)
+name: Test Java (Windows)
 
 on: [push]
 
@@ -7,10 +7,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:

--- a/.github/workflows/mvn.yaml
+++ b/.github/workflows/mvn.yaml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Test Java CI
 
 on: [push]
 
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 15
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 15
+        java-version: 17
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,34 @@
+name: Build package for release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Package
+        run: mvn package -DskipTests -Dmaven.javadoc.skip=true
+      - name: Get files
+        run: cp hdt-java-package/target/hdt-java-package-*.tar.gz rdfhdt.tar.gz
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: rdfhdt.tar.gz
+          asset_name: rdfhdt.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
Hello!

This is a small pull request to add the package archive into the release when releasing a new version, I've made a demo here with [this release](https://github.com/ate47/hdt-java/releases/tag/test), we can download the rdfhdt.tar.gz file created with mvn package

The link https://github.com/rdfhdt/hdt-java/releases/latest/download/rdfhdt.tar.gz can be put in a readme

I've also updated the Java version of the CI to Java 17, but I'm packaging using Java 11 to avoid compiling issues.