### PR TITLE
K-HDTCat

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTManager.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTManager.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Iterator;
+import java.util.List;
 
 import org.rdfhdt.hdt.compact.bitmap.Bitmap;
 import org.rdfhdt.hdt.enums.CompressionType;
@@ -461,6 +462,18 @@ public abstract class HDTManager {
 	public static HDT catHDT(String location, String hdtFileName1, String hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
 		return HDTManager.getInstance().doHDTCat(location, hdtFileName1, hdtFileName2, hdtFormat, listener);
 	}
+
+	/**
+	 * Create an HDT file from HDT files by joining the triples.
+	 * @param hdtFileNames hdt file names
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT catHDT(List<String> hdtFileNames, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		return HDTManager.getInstance().doHDTCat(hdtFileNames, hdtFormat, listener);
+	}
 	/**
 	 * Create a new HDT by removing from hdt1 the triples of hdt2.
 	 * @param hdtFileName1 First hdt file name
@@ -561,6 +574,7 @@ public abstract class HDTManager {
 	protected abstract TripleWriter doGetHDTWriter(OutputStream out, String baseURI, HDTOptions hdtFormat) throws IOException;
 	protected abstract TripleWriter doGetHDTWriter(String outFile, String baseURI, HDTOptions hdtFormat) throws IOException;
 	protected abstract HDT doHDTCat(String location, String hdtFileName1, String hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException;
+	protected abstract HDT doHDTCat(List<String> hdtFileNames, HDTOptions hdtFormat, ProgressListener listener) throws IOException;
 	protected abstract HDT doHDTDiff(String hdtFileName1, String hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException;
 	protected abstract HDT doHDTDiffBit(String location, String hdtFileName, Bitmap deleteBitmap, HDTOptions hdtFormat, ProgressListener listener) throws IOException;
 	protected abstract HDT doHDTCatTree(RDFFluxStop fluxStop, HDTSupplier supplier, String filename, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException;

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptions.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptions.java
@@ -27,10 +27,12 @@
 
 package org.rdfhdt.hdt.options;
 
+import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.rdf.RDFFluxStop;
 import org.rdfhdt.hdt.util.Profiler;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.DoubleSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -54,6 +56,10 @@ public interface HDTOptions {
 	 * @return value or null if not defined
 	 */
 	String get(String key);
+
+	default Set<Object> getKeys() {
+		throw new NotImplementedException();
+	}
 
 	/**
 	 * get a value
@@ -85,6 +91,20 @@ public interface HDTOptions {
 	 */
 	default boolean getBoolean(String key) {
 		return "true".equalsIgnoreCase(get(key));
+	}
+	/**
+	 * get a boolean
+	 *
+	 * @param key key
+	 * @param defaultValue default value
+	 * @return boolean or false if the value isn't defined
+	 */
+	default boolean getBoolean(String key, boolean defaultValue) {
+		String v = get(key);
+		if (v == null) {
+			return defaultValue;
+		}
+		return "true".equalsIgnoreCase(v);
 	}
 
 	/**

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
@@ -140,6 +140,12 @@ public class HDTOptionsKeys {
 	 */
 	@Key(type = Key.Type.DOUBLE, desc = "Memory fault factor for HDTCat tree method split")
 	public static final String LOADER_CATTREE_MEMORY_FAULT_FACTOR = "loader.cattree.memoryFaultFactor";
+	/**
+	 * Key for the k-merge HDTCat for the {@link org.rdfhdt.hdt.hdt.HDTManager} catTree default to 2 using default
+	 * implementation of HDTCat, not K-HDTCat
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "Number of HDT to merge at the same time with K-HDTCat, by default it use the default HDTCat implementation")
+	public static final String LOADER_CATTREE_KCAT = "loader.cattree.kcat";
 
 	/**
 	 * Key for the hdt supplier type, default to memory

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
@@ -271,6 +271,22 @@ public class HDTOptionsKeys {
 	@Value(key = DICTIONARY_TYPE_KEY, desc = "Multi section dictionary")
 	public static final String DICTIONARY_TYPE_VALUE_MULTI_OBJECTS = "dictionaryMultiObj";
 
+	/**
+	 * Location of the HDTCat temp files
+	 */
+	@Key(type = Key.Type.PATH, desc = "Location of the HDTCat temp files")
+	public static final String HDTCAT_LOCATION = "hdtcat.location";
+	/**
+	 * Location of the HDTCat hdt after the loading
+	 */
+	@Key(type = Key.Type.PATH, desc = "Location of the HDTCat hdt after the loading")
+	public static final String HDTCAT_FUTURE_LOCATION = "hdtcat.location.future";
+	/**
+	 * Delete the HDTCat temp files directory after HDTCat
+	 */
+	@Key(type = Key.Type.BOOLEAN, desc = "Delete the HDTCat temp files directory after HDTCat, default to true")
+	public static final String HDTCAT_DELETE_LOCATION = "hdtcat.deleteLocation";
+
 	// use tree-map to have a better order
 	private static final Map<String, Option> OPTION_MAP = new TreeMap<>();
 

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/triples/TripleID.java
@@ -37,7 +37,7 @@ import org.rdfhdt.hdt.util.LongCompare;
  * TripleID holds a triple using Long IDs
  *
  */
-public final class TripleID implements Comparable<TripleID>, Serializable {
+public final class TripleID implements Comparable<TripleID>, Serializable, Cloneable {
 	private static final long serialVersionUID = -4685524566493494912L;
 
 	private long subject;
@@ -253,6 +253,15 @@ public final class TripleID implements Comparable<TripleID>, Serializable {
 		}
 		TripleID other = (TripleID) o;
 		return !( subject!=other.subject || predicate!=other.predicate || object!=other.object );
+	}
+
+	@Override
+	public TripleID clone() {
+		try {
+			return (TripleID) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new AssertionError(e);
+		}
 	}
 
 	@Override

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/util/Profiler.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/util/Profiler.java
@@ -270,6 +270,7 @@ public class Profiler implements AutoCloseable {
 	public Section getMainSection() {
 		if (this.mainSection == null) {
 			this.mainSection = new Section(name);
+			maxSize = Math.max(name.length() + deep * 2, maxSize);
 		}
 		return this.mainSection;
 	}

--- a/hdt-java-cli/bin/hdtCat.bat
+++ b/hdt-java-cli/bin/hdtCat.bat
@@ -1,0 +1,5 @@
+@echo off
+
+call "%~dp0\javaenv.bat"
+
+"%JAVACMD%" %JAVAOPTIONS% -classpath %~dp0\..\lib\* org.rdfhdt.hdt.tools.HDTCat %*

--- a/hdt-java-cli/bin/javaenv.bat
+++ b/hdt-java-cli/bin/javaenv.bat
@@ -1,5 +1,6 @@
 set JAVAOPTIONS=-Xmx1G
 set JAVACMD=java
+set RDFHDT_COLOR=false
 
 set JAVACP="%~dp0\..\target;%~dp0\..\target\classes;%~dp0\..\target\dependency\*.jar;.
 

--- a/hdt-java-cli/bin/javaenv.sh
+++ b/hdt-java-cli/bin/javaenv.sh
@@ -21,7 +21,13 @@ else
     JAVA="$JAVA_HOME/bin/java -server"
 fi
 
+# Set HDT Color options, set to true to allow color
+if [ "$RDFHDT_COLOR" = "" ] ; then
+    export RDFHDT_COLOR="false"
+fi
+
 # Set Java options
 if [ "$JAVA_OPTIONS" = "" ] ; then
     JAVA_OPTIONS="-Xmx1g"
 fi
+

--- a/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDTVerify.java
+++ b/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDTVerify.java
@@ -5,179 +5,313 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.internal.Lists;
 import org.rdfhdt.hdt.dictionary.DictionarySection;
 import org.rdfhdt.hdt.dictionary.impl.MultipleBaseDictionary;
+import org.rdfhdt.hdt.exceptions.NotFoundException;
 import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.triples.IteratorTripleString;
+import org.rdfhdt.hdt.triples.TripleString;
+import org.rdfhdt.hdt.util.io.IOUtil;
 import org.rdfhdt.hdt.util.listener.ColorTool;
+import org.rdfhdt.hdt.util.listener.IntermediateListener;
+import org.rdfhdt.hdt.util.listener.MultiThreadListenerConsole;
 import org.rdfhdt.hdt.util.string.ByteString;
 import org.rdfhdt.hdt.util.string.CompactString;
 import org.rdfhdt.hdt.util.string.ReplazableString;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 public class HDTVerify {
 
-    private HDTVerify() {
-    }
+	private HDTVerify() {
+	}
 
-    @Parameter(description = "<input HDT>")
-    public List<String> parameters = Lists.newArrayList();
+	@Parameter(description = "<input HDTs>")
+	public List<String> parameters = Lists.newArrayList();
 
-    @Parameter(names = "-unicode", description = "Ignore UNICODE order")
-    public boolean unicode;
+	@Parameter(names = "-unicode", description = "Ignore UNICODE order")
+	public boolean unicode;
 
-    @Parameter(names = "-color", description = "Print using color (if available)")
-    public boolean color;
+	@Parameter(names = "-progress", description = "Show progression")
+	public boolean progress;
 
-    @Parameter(names = "-binary", description = "Print binaries of the string in case of signum error")
-    public boolean binary;
+	@Parameter(names = "-color", description = "Print using color (if available)")
+	public boolean color;
 
-    @Parameter(names = "-quiet", description = "Do not show progress of the conversion")
-    public boolean quiet;
+	@Parameter(names = "-binary", description = "Print binaries of the string in case of signum error")
+	public boolean binary;
 
-    @Parameter(names = "-load", description = "Load the HDT in memory for faster results (might be impossible for large a HDT)")
-    public boolean load;
+	@Parameter(names = "-quiet", description = "Do not show progress of the conversion")
+	public boolean quiet;
 
-    public ColorTool colorTool;
+	@Parameter(names = "-load", description = "Load the HDT in memory for faster results (might be impossible for large a HDT)")
+	public boolean load;
 
-    private HDT loadOrMap(String file) throws IOException {
-        return load ? HDTManager.loadHDT(file) : HDTManager.mapHDT(file);
-    }
+	@Parameter(names = "-equals", description = "Test all the input HDTs are equals instead of checking validity")
+	public boolean equals;
 
-    private void print(byte[] arr) {
-        for (byte b : arr) {
-            System.out.printf("%02X ", b);
-        }
-        System.out.println();
-    }
+	public ColorTool colorTool;
 
-    private void print(CharSequence seq) {
-        if (seq instanceof CompactString) {
-            CompactString cs1 = (CompactString) seq;
-            print(cs1.getData());
-        }
+	private HDT loadOrMap(String file, ProgressListener listener) throws IOException {
+		return load ? HDTManager.loadHDT(file, listener) : HDTManager.mapHDT(file, listener);
+	}
 
-        if (seq instanceof String) {
-            String rs1 = (String) seq;
-            print(rs1.getBytes());
-        }
-    }
+	private void print(byte[] arr) {
+		for (byte b : arr) {
+			System.out.printf("%02X ", b);
+		}
+		System.out.println();
+	}
 
-    public boolean checkDictionarySectionOrder(Iterator<? extends CharSequence> it) {
-        ReplazableString prev = new ReplazableString();
-        String lastStr = "";
-        boolean error = false;
-        while (it.hasNext()) {
-            ByteString charSeq = ByteString.of(it.next());
-            String str = charSeq.toString();
+	private void print(CharSequence seq) {
+		if (seq instanceof CompactString) {
+			CompactString cs1 = (CompactString) seq;
+			print(cs1.getData());
+		}
 
-            int cmp = prev.compareTo(charSeq);
+		if (seq instanceof String) {
+			String rs1 = (String) seq;
+			print(rs1.getBytes());
+		}
+	}
 
-            if (cmp >= 0) {
-                error = true;
-                if (cmp == 0) {
-                    colorTool.error("Duplicated(bs)", prev + " == " + charSeq);
-                } else {
-                    colorTool.error("Bad order(bs)", prev + " > " + charSeq);
-                }
-            }
+	public boolean checkDictionarySectionOrder(String name, DictionarySection section, MultiThreadListenerConsole console) {
+		Iterator<? extends CharSequence> it = section.getSortedEntries();
+		long size = section.getNumberOfElements();
+		IntermediateListener il = new IntermediateListener(console);
+		il.setPrefix(name + ": ");
+		ReplazableString prev = new ReplazableString();
+		String lastStr = "";
+		boolean error = false;
+		long count = 0;
+		while (it.hasNext()) {
+			ByteString charSeq = ByteString.of(it.next());
+			String str = charSeq.toString();
+			count++;
 
-            if (!unicode) {
-                int cmp2 = lastStr.compareTo(str);
+			int cmp = prev.compareTo(charSeq);
 
-                if (cmp2 >= 0) {
-                    error = true;
-                    if (cmp == 0) {
-                        colorTool.error("Duplicated(str)", lastStr + " == " + str);
-                    } else {
-                        colorTool.error("Bad order(str)", lastStr + " > " + str);
-                    }
-                }
+			if (cmp >= 0) {
+				error = true;
+				if (cmp == 0) {
+					colorTool.error("Duplicated(bs)", prev + " == " + charSeq);
+				} else {
+					colorTool.error("Bad order(bs)", prev + " > " + charSeq);
+				}
+			}
 
-                if (Math.signum(cmp) != Math.signum(cmp2)) {
-                    error = true;
-                    colorTool.error("Not equal", cmp + " != " + cmp2 + " for " + lastStr + " / " + str);
-                    if (binary) {
-                        print(prev);
-                        print(charSeq);
-                        print(lastStr);
-                        print(str);
-                    }
-                }
+			if (!unicode) {
+				int cmp2 = lastStr.compareTo(str);
 
-                lastStr = str;
-            }
+				if (cmp2 >= 0) {
+					error = true;
+					if (cmp == 0) {
+						colorTool.error("Duplicated(str)", lastStr + " == " + str);
+					} else {
+						colorTool.error("Bad order(str)", lastStr + " > " + str);
+					}
+				}
 
-            prev.replace(charSeq);
-        }
-        if (error) {
-            colorTool.warn("Not valid section");
-        } else {
-            colorTool.log("valid section");
-        }
-        return error;
-    }
+				if (Math.signum(cmp) != Math.signum(cmp2)) {
+					error = true;
+					colorTool.error("Not equal", cmp + " != " + cmp2 + " for " + lastStr + " / " + str);
+					if (binary) {
+						print(prev);
+						print(charSeq);
+						print(lastStr);
+						print(str);
+					}
+				}
 
-    public void exec() throws Throwable {
-        try (HDT hdt = loadOrMap(parameters.get(0))) {
-            boolean error;
-            long count = 0;
-            if (hdt.getDictionary() instanceof MultipleBaseDictionary) {
-                colorTool.log("Checking subject entries");
-                error = checkDictionarySectionOrder(hdt.getDictionary().getSubjects().getSortedEntries());
-                count += hdt.getDictionary().getSubjects().getNumberOfElements();
-                colorTool.log("Checking predicate entries");
-                error |= checkDictionarySectionOrder(hdt.getDictionary().getPredicates().getSortedEntries());
-                count += hdt.getDictionary().getPredicates().getNumberOfElements();
-                colorTool.log("Checking object entries");
-                Map<? extends CharSequence, DictionarySection> allObjects = hdt.getDictionary().getAllObjects();
-                for (Map.Entry<? extends CharSequence, DictionarySection> entry : allObjects.entrySet()) {
-                    CharSequence sectionName = entry.getKey();
-                    DictionarySection section = entry.getValue();
-                    colorTool.log("Checking object section " + sectionName);
-                    error |= checkDictionarySectionOrder(section.getSortedEntries());
-                    count += section.getNumberOfElements();
-                }
-                colorTool.log("Checking shared entries");
-                error |= checkDictionarySectionOrder(hdt.getDictionary().getShared().getSortedEntries());
-                count += hdt.getDictionary().getShared().getNumberOfElements();
-            } else {
-                colorTool.log("Checking subject entries");
-                error = checkDictionarySectionOrder(hdt.getDictionary().getSubjects().getSortedEntries());
-                count += hdt.getDictionary().getSubjects().getNumberOfElements();
-                colorTool.log("Checking predicate entries");
-                error |= checkDictionarySectionOrder(hdt.getDictionary().getPredicates().getSortedEntries());
-                count += hdt.getDictionary().getPredicates().getNumberOfElements();
-                colorTool.log("Checking object entries");
-                error |= checkDictionarySectionOrder(hdt.getDictionary().getObjects().getSortedEntries());
-                count += hdt.getDictionary().getObjects().getNumberOfElements();
-                colorTool.log("Checking shared entries");
-                error |= checkDictionarySectionOrder(hdt.getDictionary().getShared().getSortedEntries());
-                count += hdt.getDictionary().getShared().getNumberOfElements();
-            }
+				lastStr = str;
+			}
 
-            if (error) {
-                colorTool.error("This HDT isn't valid", true);
-                System.exit(-1);
-            } else {
-                colorTool.log(count + " element(s) parsed");
-                colorTool.log(colorTool.color(0, 5, 0) + "This HDT is valid", true);
-            }
-        }
-    }
+			if (count % 10_000 == 0) {
+				il.notifyProgress(
+						100f * count / size,
+						"Verify (" + count + "/" + size + "): "
+								+ colorTool.color(3, 3, 3)
+								+ (str.length() > 17 ? (str.substring(0, 17) + "...") : str)
+				);
+			}
 
-    public static void main(String[] args) throws Throwable {
-        HDTVerify verify = new HDTVerify();
-        JCommander com = new JCommander(verify);
-        com.parse(args);
-        verify.colorTool = new ColorTool(verify.color, verify.quiet);
-        com.setProgramName("hdtVerify");
-        if (verify.parameters.size() < 1) {
-            com.usage();
-            System.exit(-1);
-        }
-        verify.exec();
-    }
+			prev.replace(charSeq);
+		}
+		il.notifyProgress(100f, "Verify...");
+
+		if (error) {
+			colorTool.warn("Not valid section");
+		} else {
+			colorTool.log("valid section");
+		}
+		return error;
+	}
+
+	public boolean assertHdtEquals(HDT hdt1, HDT hdt2, MultiThreadListenerConsole console, String desc) {
+		IntermediateListener il = new IntermediateListener(console);
+		il.setPrefix(desc + ": ");
+		if (hdt1.getTriples().getNumberOfElements() != hdt2.getTriples().getNumberOfElements()) {
+			colorTool.error("HDT with different number of elements!");
+			return false;
+		}
+
+		IteratorTripleString its1;
+		IteratorTripleString its2;
+
+		try {
+			its1 = hdt1.search("", "", "");
+			its2 = hdt2.search("", "", "");
+		} catch (NotFoundException e) {
+			throw new AssertionError(e);
+		}
+
+		long tripleError = 0;
+		long count = 0;
+		long size = hdt1.getTriples().getNumberOfElements();
+		while (true) {
+			if (!its1.hasNext()) {
+				if (its2.hasNext()) {
+					colorTool.error("Bad iteration");
+					break;
+				}
+				return true;
+			}
+
+			if (!its2.hasNext()) {
+				colorTool.error("Bad iteration");
+				return false;
+			}
+
+			TripleString ts1 = its1.next();
+			TripleString ts2 = its2.next();
+			if (!ts1.equals(ts2)) {
+				colorTool.error("Triple not equal!", ts1 + "!=" + ts2);
+				tripleError++;
+			}
+
+			count++;
+
+			if (count % 10_000 == 0) {
+				String str = ts1.toString();
+				il.notifyProgress(
+						100f * count / size,
+						"Verify (" + count + "/" + size + "): "
+								+ colorTool.color(3, 3, 3)
+								+ (str.length() > 17 ? (str.substring(0, 17) + "...") : str)
+				);
+			}
+		}
+
+		return tripleError == 0;
+	}
+
+
+	public void exec() throws Throwable {
+		MultiThreadListenerConsole console = progress ? new MultiThreadListenerConsole(color) : null;
+		colorTool.setConsole(console);
+		List<HDT> hdts = new ArrayList<>(parameters.size());
+
+		try {
+			for (String hdtLocation : parameters) {
+				hdts.add(loadOrMap(hdtLocation, console));
+			}
+			if (equals) {
+				// we know that we have at least one HDT
+				HDT current = hdts.get(0);
+
+				boolean error = false;
+				for (int i = 1; i < hdts.size(); i++) {
+					if (!assertHdtEquals(current, hdts.get(i), console, "#0?" + i)) {
+						colorTool.error("HDT NOT EQUALS!", "hdt#0 != hdt#" + i);
+						error = true;
+					}
+				}
+
+				if (error) {
+					colorTool.error("HDTs not equal!", true);
+					System.exit(-1);
+				} else {
+					colorTool.log(colorTool.color(0, 5, 0) + "All the HDTs are equal", true);
+				}
+
+				if (console != null) {
+					console.removeLast();
+				}
+
+			} else {
+				for (HDT hdtl : hdts) {
+					try (HDT hdt = hdtl) {
+						boolean error;
+						long count = 0;
+						if (hdt.getDictionary() instanceof MultipleBaseDictionary) {
+							colorTool.log("Checking subject entries");
+							error = checkDictionarySectionOrder("subject", hdt.getDictionary().getSubjects(), console);
+							count += hdt.getDictionary().getSubjects().getNumberOfElements();
+							colorTool.log("Checking predicate entries");
+							error |= checkDictionarySectionOrder("predicate", hdt.getDictionary().getPredicates(), console);
+							count += hdt.getDictionary().getPredicates().getNumberOfElements();
+							colorTool.log("Checking object entries");
+							Map<? extends CharSequence, DictionarySection> allObjects = hdt.getDictionary().getAllObjects();
+							for (Map.Entry<? extends CharSequence, DictionarySection> entry : allObjects.entrySet()) {
+								CharSequence sectionName = entry.getKey();
+								DictionarySection section = entry.getValue();
+								colorTool.log("Checking object section " + sectionName);
+								error |= checkDictionarySectionOrder("sectionName", section, console);
+								count += section.getNumberOfElements();
+							}
+							colorTool.log("Checking shared entries");
+							error |= checkDictionarySectionOrder("shared", hdt.getDictionary().getShared(), console);
+							count += hdt.getDictionary().getShared().getNumberOfElements();
+						} else {
+							colorTool.log("Checking subject entries");
+							error = checkDictionarySectionOrder("subject", hdt.getDictionary().getSubjects(), console);
+							count += hdt.getDictionary().getSubjects().getNumberOfElements();
+							colorTool.log("Checking predicate entries");
+							error |= checkDictionarySectionOrder("predicate", hdt.getDictionary().getPredicates(), console);
+							count += hdt.getDictionary().getPredicates().getNumberOfElements();
+							colorTool.log("Checking object entries");
+							error |= checkDictionarySectionOrder("object", hdt.getDictionary().getObjects(), console);
+							count += hdt.getDictionary().getObjects().getNumberOfElements();
+							colorTool.log("Checking shared entries");
+							error |= checkDictionarySectionOrder("shared", hdt.getDictionary().getShared(), console);
+							count += hdt.getDictionary().getShared().getNumberOfElements();
+						}
+
+						if (error) {
+							colorTool.error("This HDT isn't valid", true);
+							System.exit(-1);
+						} else {
+							colorTool.log(count + " element(s) parsed");
+							colorTool.log(colorTool.color(0, 5, 0) + "This HDT is valid", true);
+						}
+
+						if (console != null) {
+							console.removeLast();
+						}
+					}
+				}
+			}
+		} catch (Throwable t) {
+			IOUtil.closeAll(hdts);
+			throw t;
+		}
+
+	}
+
+	public static void main(String[] args) throws Throwable {
+		HDTVerify verify = new HDTVerify();
+		JCommander com = new JCommander(verify);
+		com.parse(args);
+		verify.colorTool = new ColorTool(verify.color, verify.quiet);
+		com.setProgramName("hdtVerify");
+		if (verify.parameters.size() < 1) {
+			com.usage();
+			System.exit(-1);
+		}
+		verify.exec();
+	}
 }

--- a/hdt-java-cli/src/main/java/org/rdfhdt/hdt/util/listener/ColorTool.java
+++ b/hdt-java-cli/src/main/java/org/rdfhdt/hdt/util/listener/ColorTool.java
@@ -3,9 +3,10 @@ package org.rdfhdt.hdt.util.listener;
 public class ColorTool {
 	private final boolean color;
 	private final boolean quiet;
+	private MultiThreadListenerConsole console;
 
 	public ColorTool(boolean color, boolean quiet) {
-		this.color = color;
+		this.color = color || MultiThreadListenerConsole.ALLOW_COLOR_SEQUENCE;
 		this.quiet = quiet;
 	}
 
@@ -13,6 +14,17 @@ public class ColorTool {
 		this(color, false);
 	}
 
+	public void setConsole(MultiThreadListenerConsole console) {
+		this.console = console;
+	}
+
+	private void print(String str) {
+		if (console != null) {
+			console.printLine(str);
+		} else {
+			System.out.println(str);
+		}
+	}
 
 	public String prefix(String pref, int r, int g, int b) {
 		return colorReset() + "[" + color(r, g, b) + pref + colorReset() + "]";
@@ -23,13 +35,13 @@ public class ColorTool {
 	}
 	public void log(String msg, boolean ignoreQuiet) {
 		if (!quiet || ignoreQuiet) {
-			System.out.println(prefix("INFO", 3, 1, 5) + " " + colorReset() + msg);
+			print(prefix("INFO", 3, 1, 5) + " " + colorReset() + msg);
 		}
 	}
 
 	public void logValue(String msg, String value, boolean ignoreQuiet) {
 		if (!quiet || ignoreQuiet) {
-			System.out.println(color(3, 1, 5) + msg + colorReset() + value);
+			print(color(3, 1, 5) + msg + colorReset() + value);
 		}
 	}
 
@@ -43,7 +55,7 @@ public class ColorTool {
 
 	public void warn(String msg, boolean ignoreQuiet) {
 		if (!quiet || ignoreQuiet) {
-			System.out.println(prefix("WARN", 5, 5, 0) + " " + colorReset() + msg);
+			print(prefix("WARN", 5, 5, 0) + " " + colorReset() + msg);
 		}
 	}
 	public void error(String text) {
@@ -62,9 +74,9 @@ public class ColorTool {
 	public void error(String title, String text, boolean ignoreQuiet) {
 		if (!quiet || ignoreQuiet) {
 			if (title != null) {
-				System.out.println(prefix("ERRR", 5, 0, 0) + " " + prefix(title, 5, 3, 0) + " " + colorReset() + text);
+				print(prefix("ERRR", 5, 0, 0) + " " + prefix(title, 5, 3, 0) + " " + colorReset() + text);
 			} else {
-				System.out.println(prefix("ERRR", 5, 0, 0) + " " + colorReset() + text);
+				print(prefix("ERRR", 5, 0, 0) + " " + colorReset() + text);
 			}
 		}
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Map.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Map.java
@@ -79,7 +79,6 @@ public class SequenceLog64Map implements Sequence,Closeable {
 		this(in, f, false);
 	}
 	
-	@SuppressWarnings("resource")
 	private SequenceLog64Map(CountInputStream in, File f, boolean closeInput) throws IOException {
 		CRCInputStream crcin = new CRCInputStream(in, new CRC8());
 		
@@ -189,7 +188,7 @@ public class SequenceLog64Map implements Sequence,Closeable {
 	@Override
 	public long get(long index) {
 		if(index<0 || index>=numentries) {
-			throw new IndexOutOfBoundsException();
+			throw new IndexOutOfBoundsException(index + " < 0 || " + index + ">= " + numentries);
 		}
 		if(numbits==0) return 0;
 		

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryKCat.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryKCat.java
@@ -1,0 +1,56 @@
+package org.rdfhdt.hdt.dictionary;
+
+import java.util.Map;
+
+public interface DictionaryKCat {
+
+	/**
+	 * @return the subsections to merge
+	 */
+	Map<CharSequence, DictionarySection> getSubSections();
+
+	/**
+	 * @return the subject section
+	 */
+	DictionarySection getSubjectSection();
+
+	/**
+	 * @return the object section
+	 */
+	DictionarySection getObjectSection();
+
+	/**
+	 * @return the predicate section
+	 */
+	DictionarySection getPredicateSection();
+
+	/**
+	 * @return the shared section
+	 */
+	DictionarySection getSharedSection();
+
+	/**
+	 * @return the number of subjects
+	 */
+	long countSubjects();
+
+	/**
+	 * @return the number of shared
+	 */
+	long countShared();
+
+	/**
+	 * @return the number of predicates
+	 */
+	long countPredicates();
+
+	/**
+	 * @return the number of objects
+	 */
+	long countObjects();
+
+	/**
+	 * @return the object shift in the dictionary IDs
+	 */
+	long objectShift();
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/WriteFourSectionDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/WriteFourSectionDictionary.java
@@ -1,5 +1,7 @@
 package org.rdfhdt.hdt.dictionary.impl;
 
+import org.rdfhdt.hdt.dictionary.DictionarySection;
+import org.rdfhdt.hdt.dictionary.DictionarySectionPrivate;
 import org.rdfhdt.hdt.dictionary.TempDictionary;
 import org.rdfhdt.hdt.dictionary.impl.section.WriteDictionarySection;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
@@ -23,6 +25,7 @@ import java.nio.file.Path;
 
 /**
  * Version of four section dictionary with {@link org.rdfhdt.hdt.dictionary.impl.section.WriteDictionarySection}
+ *
  * @author Antoine Willerval
  */
 public class WriteFourSectionDictionary extends BaseDictionary {
@@ -33,6 +36,17 @@ public class WriteFourSectionDictionary extends BaseDictionary {
 		predicates = new WriteDictionarySection(spec, filename.resolveSibling(name + "PR"), bufferSize);
 		objects = new WriteDictionarySection(spec, filename.resolveSibling(name + "OB"), bufferSize);
 		shared = new WriteDictionarySection(spec, filename.resolveSibling(name + "SH"), bufferSize);
+	}
+
+	public WriteFourSectionDictionary(HDTOptions spec, DictionarySectionPrivate subjects,
+									  DictionarySectionPrivate predicates,
+									  DictionarySectionPrivate objects,
+									  DictionarySectionPrivate shared) {
+		super(spec);
+		this.subjects = subjects;
+		this.predicates = predicates;
+		this.objects = objects;
+		this.shared = shared;
 	}
 
 	@Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/WriteMultipleSectionDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/WriteMultipleSectionDictionary.java
@@ -49,6 +49,22 @@ public class WriteMultipleSectionDictionary extends MultipleBaseDictionary {
 		objects = new TreeMap<>();
 		shared = new WriteDictionarySection(spec, filename.resolveSibling(name + "SH"), bufferSize);
 	}
+	public WriteMultipleSectionDictionary(HDTOptions spec,
+										  DictionarySectionPrivate subjects,
+										  DictionarySectionPrivate predicates,
+										  DictionarySectionPrivate shared,
+										  TreeMap<ByteString, DictionarySectionPrivate> objects) {
+		super(spec);
+		// useless
+		this.filename = null;
+		this.bufferSize = 0;
+
+		// write sections
+		this.subjects = subjects;
+		this.predicates = predicates;
+		this.objects = objects;
+		this.shared = shared;
+	}
 
 	@Override
 	public long getNAllObjects() {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/FourSectionDictionaryKCat.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/FourSectionDictionaryKCat.java
@@ -1,0 +1,67 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.rdfhdt.hdt.dictionary.Dictionary;
+import org.rdfhdt.hdt.dictionary.DictionaryKCat;
+import org.rdfhdt.hdt.dictionary.DictionarySection;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class FourSectionDictionaryKCat implements DictionaryKCat {
+	private final Dictionary dictionary;
+
+	public FourSectionDictionaryKCat(Dictionary dictionary) {
+		this.dictionary = dictionary;
+	}
+
+	@Override
+	public Map<CharSequence, DictionarySection> getSubSections() {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public DictionarySection getSubjectSection() {
+		return dictionary.getSubjects();
+	}
+
+	@Override
+	public DictionarySection getObjectSection() {
+		return dictionary.getObjects();
+	}
+
+	@Override
+	public DictionarySection getPredicateSection() {
+		return dictionary.getPredicates();
+	}
+
+	@Override
+	public DictionarySection getSharedSection() {
+		return dictionary.getShared();
+	}
+
+	@Override
+	public long countSubjects() {
+		return dictionary.getSubjects().getNumberOfElements() + countShared();
+	}
+
+	@Override
+	public long countShared() {
+		return dictionary.getShared().getNumberOfElements();
+	}
+
+
+	@Override
+	public long countPredicates() {
+		return dictionary.getPredicates().getNumberOfElements();
+	}
+
+	@Override
+	public long countObjects() {
+		return dictionary.getObjects().getNumberOfElements() + countShared();
+	}
+
+	@Override
+	public long objectShift() {
+		return countShared();
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/GroupBySubjectMapIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/GroupBySubjectMapIterator.java
@@ -1,0 +1,359 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.iterator.utils.CombinedIterator;
+import org.rdfhdt.hdt.iterator.utils.ExceptionIterator;
+import org.rdfhdt.hdt.iterator.utils.MapIterator;
+import org.rdfhdt.hdt.iterator.utils.MergeExceptionIterator;
+import org.rdfhdt.hdt.iterator.utils.PeekIterator;
+import org.rdfhdt.hdt.triples.IteratorTripleID;
+import org.rdfhdt.hdt.triples.TripleID;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * @author Antoine Willerval
+ */
+public class GroupBySubjectMapIterator implements Iterator<TripleID> {
+	private final PeekIterator<TripleID> mergeIterator;
+	private final List<TripleID> groupList = new ArrayList<>();
+	private Iterator<TripleID> groupListIterator;
+	private TripleID next;
+
+	public GroupBySubjectMapIterator(Iterator<TripleID> mergeIterator) {
+		this.mergeIterator = new PeekIterator<>(mergeIterator);
+	}
+
+	@Override
+	public boolean hasNext() {
+		if (next != null) {
+			return true;
+		}
+
+		// get triples from the group
+		if (groupListIterator != null) {
+			if (groupListIterator.hasNext()) {
+				next = groupListIterator.next();
+				return true;
+			}
+
+			// clear the group and set to new iteration
+			groupList.clear();
+			groupListIterator = null;
+		}
+
+		// do we have more elements?
+		if (!mergeIterator.hasNext()) {
+			return false;
+		}
+
+		long subject = mergeIterator.peek().getSubject();
+
+		// we add all the elements while the subject are the same
+		do {
+			groupList.add(mergeIterator.next().clone());
+		} while (mergeIterator.hasNext() && mergeIterator.peek().getSubject() == subject);
+
+		groupList.sort(TripleID::compareTo);
+
+		groupListIterator = groupList.iterator();
+
+		if (groupListIterator.hasNext()) {
+			next = groupListIterator.next();
+			return true;
+		}
+
+		// just to be sure
+		return false;
+	}
+
+	@Override
+	public TripleID next() {
+		if (!hasNext()) {
+			return null;
+		}
+		try {
+			return next;
+		} finally {
+			next = null;
+		}
+	}
+
+	private static long firstSubjectTripleId(HDT hdt) {
+		IteratorTripleID it = hdt.getTriples().search(new TripleID(
+				hdt.getDictionary().getNshared() + 1,
+				0,
+				0
+		));
+		if (it.hasNext()) {
+			// extract result
+			it.next();
+			return it.getLastTriplePosition();
+		} else {
+			return -1;
+		}
+	}
+
+	public static Iterator<TripleID> fromHDTs(KCatMerger merger, HDT[] hdts) {
+		final long shared = merger.getCountShared();
+		List<ExceptionIterator<TripleID, RuntimeException>> sharedSubjectIterators = IntStream.range(0, hdts.length)
+				.mapToObj(hdtIndex -> {
+					// extract hdt elements for this index
+					HDT hdt = hdts[hdtIndex];
+
+					// get the first subject triple id
+					long firstSubjectTripleId = firstSubjectTripleId(hdt);
+
+					// create a subject iterator, mapped to the new IDs
+					IteratorTripleID subjectIterator = hdt.getTriples().searchAll();
+					subjectIterator.goTo(firstSubjectTripleId);
+					ExceptionIterator<TripleID, RuntimeException> subjectIteratorMapped = ExceptionIterator.of(
+							new SharedOnlyIterator(
+									new MapIterator<>(subjectIterator, (tid) -> {
+										assert inHDT(tid, hdts[hdtIndex]);
+										return merger.extractMapped(hdtIndex, tid);
+									}),
+									shared
+							)
+					);
+
+					if (shared == 0) {
+						return subjectIteratorMapped;
+					}
+
+					Iterator<TripleID> sharedIterator = new SharedStopIterator(hdt.getTriples().searchAll(), hdt.getDictionary().getNshared());
+					Iterator<TripleID> sharedIteratorMapped = new MapIterator<>(sharedIterator, (tid) -> {
+						assert inHDT(tid, hdts[hdtIndex]);
+						return merger.extractMapped(hdtIndex, tid);
+					});
+
+					return new MergeExceptionIterator<>(
+							subjectIteratorMapped,
+							ExceptionIterator.of(sharedIteratorMapped),
+							Comparator.comparingLong(TripleID::getSubject)
+					);
+				}).collect(Collectors.toList());
+		List<ExceptionIterator<TripleID, RuntimeException>> subjectIterators = IntStream.range(0, hdts.length)
+				.mapToObj(hdtIndex -> {
+					// extract hdt elements for this index
+					HDT hdt = hdts[hdtIndex];
+
+					// get the first subject triple id
+					long firstSubjectTripleId = firstSubjectTripleId(hdt);
+
+					// create a subject iterator, mapped to the new IDs
+					IteratorTripleID subjectIterator = hdt.getTriples().searchAll();
+					subjectIterator.goTo(firstSubjectTripleId);
+
+					return ExceptionIterator.<TripleID, RuntimeException>of(
+							new NoSharedIterator(
+									new MapIterator<>(subjectIterator, (tid) -> merger.extractMapped(hdtIndex, tid)),
+									shared
+							)
+					);
+				}).collect(Collectors.toList());
+		return new GroupBySubjectMapIterator(
+				new NoDupeTripleIDIterator(
+						CombinedIterator.combine(List.of(
+								MergeExceptionIterator.buildOfTree(
+										Function.identity(),
+										Comparator.comparingLong(TripleID::getSubject),
+										sharedSubjectIterators,
+										0,
+										sharedSubjectIterators.size()
+								).asIterator(),
+								MergeExceptionIterator.buildOfTree(
+										Function.identity(),
+										Comparator.comparingLong(TripleID::getSubject),
+										subjectIterators,
+										0,
+										subjectIterators.size()
+								).asIterator()
+						))
+				));
+	}
+
+	private static boolean inHDT(TripleID id, HDT hdt) {
+		long s = id.getSubject();
+		long p = id.getPredicate();
+		long o = id.getObject();
+		return s >= 1 && s <= hdt.getDictionary().getNsubjects()
+				&& p >= 1 && p <= hdt.getDictionary().getNpredicates()
+				&& o >= 1 && o <= hdt.getDictionary().getNobjects();
+	}
+
+	private static class NoDupeTripleIDIterator implements Iterator<TripleID> {
+		private TripleID next;
+		private final PeekIterator<TripleID> it;
+
+		public NoDupeTripleIDIterator(Iterator<TripleID> it) {
+			this.it = new PeekIterator<>(it);
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (next != null) {
+				return true;
+			}
+			if (!it.hasNext()) {
+				return false;
+			}
+
+			next = it.next();
+
+			assert next.isValid() : "Can't have empty tripleID";
+
+			// pass all the duplicated fields
+			while (it.hasNext() && it.peek().equals(next)) {
+				it.next();
+			}
+
+			return true;
+		}
+
+		@Override
+		public TripleID next() {
+			if (!hasNext()) {
+				return null;
+			}
+			try {
+				return next;
+			} finally {
+				next = null;
+			}
+		}
+	}
+
+	private static class SharedStopIterator implements Iterator<TripleID> {
+		private final Iterator<TripleID> it;
+		private final long shared;
+		private TripleID next;
+
+		private SharedStopIterator(Iterator<TripleID> it, long shared) {
+			this.it = it;
+			this.shared = shared;
+		}
+
+
+		@Override
+		public boolean hasNext() {
+			if (next != null) {
+				return next.getSubject() <= shared;
+			}
+
+			if (!it.hasNext()) {
+				return false;
+			}
+
+			next = it.next();
+
+			return next.getSubject() <= shared;
+		}
+
+		@Override
+		public TripleID next() {
+			if (!hasNext()) {
+				return null;
+			}
+			try {
+				return next;
+			} finally {
+				next = null;
+			}
+		}
+	}
+
+	private static class SharedOnlyIterator implements Iterator<TripleID> {
+		private final Iterator<TripleID> it;
+		private final long shared;
+		private TripleID next;
+
+		private SharedOnlyIterator(Iterator<TripleID> it, long shared) {
+			this.it = it;
+			this.shared = shared;
+		}
+
+
+		@Override
+		public boolean hasNext() {
+			if (next != null) {
+				return true;
+			}
+
+			// search over the next results
+			while (it.hasNext()) {
+				TripleID next = it.next();
+
+				// is this element a shared element?
+				if (next.getSubject() <= shared) {
+					this.next = next;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		@Override
+		public TripleID next() {
+			if (!hasNext()) {
+				return null;
+			}
+			try {
+				return next;
+			} finally {
+				next = null;
+			}
+		}
+	}
+
+	private static class NoSharedIterator implements Iterator<TripleID> {
+		private final Iterator<TripleID> it;
+		private final long shared;
+		private TripleID next;
+
+		private NoSharedIterator(Iterator<TripleID> it, long shared) {
+			this.it = it;
+			this.shared = shared;
+		}
+
+
+		@Override
+		public boolean hasNext() {
+			if (next != null) {
+				return true;
+			}
+
+			// search over the next results
+			while (it.hasNext()) {
+				TripleID next = it.next();
+
+				// is this element a shared element?
+				if (next.getSubject() > shared) {
+					this.next = next;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		@Override
+		public TripleID next() {
+			if (!hasNext()) {
+				return null;
+			}
+			try {
+				return next;
+			} finally {
+				next = null;
+			}
+		}
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatImpl.java
@@ -1,0 +1,226 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.rdfhdt.hdt.dictionary.DictionaryPrivate;
+import org.rdfhdt.hdt.enums.TripleComponentOrder;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.hdt.HDTManagerImpl;
+import org.rdfhdt.hdt.hdt.HDTVocabulary;
+import org.rdfhdt.hdt.hdt.impl.HDTBase;
+import org.rdfhdt.hdt.hdt.impl.WriteHDTImpl;
+import org.rdfhdt.hdt.header.HeaderFactory;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
+import org.rdfhdt.hdt.triples.TripleID;
+import org.rdfhdt.hdt.triples.Triples;
+import org.rdfhdt.hdt.triples.impl.BitmapTriples;
+import org.rdfhdt.hdt.triples.impl.OneReadTempTriples;
+import org.rdfhdt.hdt.triples.impl.WriteBitmapTriples;
+import org.rdfhdt.hdt.util.io.CloseSuppressPath;
+import org.rdfhdt.hdt.util.io.IOUtil;
+import org.rdfhdt.hdt.util.listener.IntermediateListener;
+import org.rdfhdt.hdt.util.listener.ListenerUtil;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Implementation of HDTCat_K algorithm
+ *
+ * @author Antoine Willerval
+ */
+public class KCatImpl implements Closeable {
+	private static TripleComponentOrder getOrder(HDT hdt) {
+		Triples triples = hdt.getTriples();
+		if (!(triples instanceof BitmapTriples)) {
+			throw new IllegalArgumentException("HDT Triples can't be BitmapTriples");
+		}
+
+		BitmapTriples bt = (BitmapTriples) triples;
+
+		return bt.getOrder();
+	}
+
+	private final String baseURI;
+	final HDT[] hdts;
+	private final CloseSuppressPath location;
+	private final Path futureLocation;
+	private final boolean futureMap;
+	private final boolean clearLocation;
+	private final ProgressListener listener;
+	private final String dictionaryType;
+	private final int bufferSize;
+	private final HDTOptions hdtFormat;
+	private final TripleComponentOrder order;
+	private final long rawSize;
+
+	/**
+	 * Create implementation
+	 *
+	 * @param hdtFileNames the hdt files to cat
+	 * @param hdtFormat    the format to config the cat
+	 * @param listener     listener to get information from the cat
+	 * @throws IOException io exception during loading
+	 */
+	public KCatImpl(List<String> hdtFileNames, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		this.listener = ListenerUtil.multiThreadListener(listener);
+
+		hdts = new HDT[hdtFileNames.size()];
+		this.hdtFormat = hdtFormat;
+
+		long bufferSizeLong = hdtFormat.getInt(HDTOptionsKeys.LOADER_DISK_BUFFER_SIZE_KEY, CloseSuppressPath.BUFFER_SIZE);
+		if (bufferSizeLong > Integer.MAX_VALUE - 5L || bufferSizeLong <= 0) {
+			throw new IllegalArgumentException("Buffer size can't be negative or bigger than the size of an array!");
+		} else {
+			bufferSize = (int) bufferSizeLong;
+		}
+
+		try {
+			ListIterator<String> it = hdtFileNames.listIterator();
+
+			int firstIndex = it.nextIndex();
+			String firstHDTFile = it.next();
+
+			HDT firstHDT = HDTManagerImpl.loadOrMapHDT(firstHDTFile, listener, hdtFormat);
+			hdts[firstIndex] = firstHDT;
+
+			dictionaryType = firstHDT.getDictionary().getType();
+			baseURI = firstHDT.getBaseURI();
+			order = getOrder(firstHDT);
+
+			long rawSize = HDTBase.getRawSize(firstHDT.getHeader());
+
+
+			IntermediateListener iListener = new IntermediateListener(listener);
+			iListener.setRange(0, 10);
+			// map all the HDTs
+			while (it.hasNext()) {
+				int index = it.nextIndex();
+				String hdtFile = it.next();
+
+				iListener.notifyProgress(index * 100f / hdtFileNames.size(), "map hdt (" + (index + 1) + "/" + hdtFileNames.size() + ")");
+
+				HDT hdt = HDTManagerImpl.loadOrMapHDT(hdtFile, listener, hdtFormat);
+
+				rawSize = rawSize == -1 ? -1 : HDTBase.getRawSize(hdt.getHeader());
+
+				hdts[index] = hdt;
+
+				// try that all the HDTs have the same type
+				if (!dictionaryType.equals(hdt.getDictionary().getType())) {
+					throw new IllegalArgumentException("Trying to cat hdt with different type, type(hdt0) [" + dictionaryType + "] != type(hdt" + index + ") [" + hdt.getDictionary().getType() + "]");
+				}
+				TripleComponentOrder order = getOrder(hdt);
+
+				if (!order.equals(this.order)) {
+					throw new IllegalArgumentException("Trying to cat hdt with different order, order(hdt0) [" + this.order + "] != type(hdt" + index + ") [" + order + "]");
+				}
+			}
+
+			this.rawSize = rawSize;
+
+			String hdtcatLocationOpt = hdtFormat.get(HDTOptionsKeys.HDTCAT_LOCATION);
+			if (hdtcatLocationOpt == null || hdtcatLocationOpt.isEmpty()) {
+				location = CloseSuppressPath.of(Files.createTempDirectory("hdtCat"));
+				clearLocation = true; // delete temp directory
+			} else {
+				location = CloseSuppressPath.of(hdtcatLocationOpt);
+				Files.createDirectories(location);
+				clearLocation = hdtFormat.getBoolean(HDTOptionsKeys.HDTCAT_DELETE_LOCATION, true);
+			}
+
+			String hdtcatFutureLocationOpt = hdtFormat.get(HDTOptionsKeys.HDTCAT_FUTURE_LOCATION);
+			if (hdtcatFutureLocationOpt == null || hdtcatFutureLocationOpt.isEmpty()) {
+				futureLocation = location.resolve("gen.hdt");
+				futureMap = false;
+			} else {
+				futureLocation = Path.of(hdtcatFutureLocationOpt);
+				futureMap = true;
+			}
+
+			location.closeWithDeleteRecurse();
+		} catch (Throwable t) {
+			for (HDT hdt : hdts) {
+				IOUtil.closeQuietly(hdt);
+			}
+			throw t;
+		}
+	}
+
+	/**
+	 * @return a merger from the config
+	 * @throws IOException io exception
+	 */
+	KCatMerger createMerger(ProgressListener listener) throws IOException {
+		return new KCatMerger(hdts, location, listener, bufferSize, dictionaryType, hdtFormat);
+	}
+
+	/**
+	 * @return a cat from the config HDTs
+	 * @throws IOException io exception
+	 */
+	public HDT cat() throws IOException {
+		IntermediateListener il = new IntermediateListener(listener);
+		String futureLocationStr = futureLocation.toAbsolutePath().toString();
+		il.setRange(0, 40);
+		il.setPrefix("Merge Dict: ");
+		try (KCatMerger merger = createMerger(il)) {
+			// create the dictionary
+			try (DictionaryPrivate dictionary = merger.buildDictionary()) {
+				assert merger.assertReadCorrectly();
+				// create a GROUP BY subject iterator to get the new ordered stream
+				Iterator<TripleID> tripleIterator = GroupBySubjectMapIterator.fromHDTs(merger, hdts);
+				try (WriteBitmapTriples triples = new WriteBitmapTriples(hdtFormat, location.resolve("triples"), bufferSize)) {
+					long count = Arrays.stream(hdts).mapToLong(h -> h.getTriples().getNumberOfElements()).sum();
+
+					il.setRange(40, 80);
+					il.setPrefix("Merge triples: ");
+					triples.load(new OneReadTempTriples(tripleIterator, order, count), il);
+
+					WriteHDTImpl writeHDT = new WriteHDTImpl(hdtFormat, location, dictionary, triples, HeaderFactory.createHeader(hdtFormat));
+					writeHDT.populateHeaderStructure(baseURI);
+					// add a raw size from the previous values (if available)
+					if (rawSize != -1) {
+						writeHDT.getHeader().insert("_:statistics", HDTVocabulary.ORIGINAL_SIZE, String.valueOf(rawSize));
+					}
+
+					il.setRange(80, 90);
+					il.setPrefix("Save HDT: ");
+					writeHDT.saveToHDT(futureLocationStr, il);
+				}
+			}
+
+		} catch (InterruptedException e) {
+			throw new IOException("Interruption", e);
+		}
+
+		il.setRange(90, 100);
+		HDT hdt;
+		if (futureMap) {
+			hdt = HDTManager.mapHDT(futureLocationStr, il);
+		} else {
+			hdt = HDTManager.loadHDT(futureLocationStr, il);
+			Files.deleteIfExists(futureLocation);
+		}
+		il.notifyProgress(100, "cat done.");
+		return hdt;
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			IOUtil.closeAll(hdts);
+		} finally {
+			if (clearLocation) {
+				location.close();
+			}
+		}
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMerger.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMerger.java
@@ -1,0 +1,861 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.rdfhdt.hdt.compact.sequence.SequenceLog64BigDisk;
+import org.rdfhdt.hdt.dictionary.DictionaryFactory;
+import org.rdfhdt.hdt.dictionary.DictionaryKCat;
+import org.rdfhdt.hdt.dictionary.DictionaryPrivate;
+import org.rdfhdt.hdt.dictionary.DictionarySection;
+import org.rdfhdt.hdt.dictionary.DictionarySectionPrivate;
+import org.rdfhdt.hdt.dictionary.impl.section.OneReadDictionarySection;
+import org.rdfhdt.hdt.dictionary.impl.section.WriteDictionarySection;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.iterator.utils.ExceptionIterator;
+import org.rdfhdt.hdt.iterator.utils.MapIterator;
+import org.rdfhdt.hdt.iterator.utils.MergeExceptionIterator;
+import org.rdfhdt.hdt.iterator.utils.PipedCopyIterator;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.triples.TripleID;
+import org.rdfhdt.hdt.util.BitUtil;
+import org.rdfhdt.hdt.util.LiteralsUtils;
+import org.rdfhdt.hdt.util.concurrent.ExceptionThread;
+import org.rdfhdt.hdt.util.concurrent.SyncSeq;
+import org.rdfhdt.hdt.util.io.CloseSuppressPath;
+import org.rdfhdt.hdt.util.io.Closer;
+import org.rdfhdt.hdt.util.string.ByteString;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Class to merge multiple dictionaries into S/O/SH streams with map writing
+ *
+ * @author Antoine Willerval
+ */
+public class KCatMerger implements AutoCloseable {
+	private static final long SHARED_MASK = 0b01;
+	private static final long TYPED_MASK = 0b10;
+
+	final HDT[] hdts;
+
+	private final ProgressListener listener;
+	private final CloseSuppressPath[] locations;
+	final SyncSeq[] subjectsMaps;
+	final SyncSeq[] predicatesMaps;
+	final SyncSeq[] objectsMaps;
+	private final ExceptionThread catMergerThread;
+	final boolean typedHDT;
+	private final int shift;
+	private final String dictionaryType;
+
+	private final PipedCopyIterator<DuplicateBuffer> subjectPipe = new PipedCopyIterator<>();
+	private final PipedCopyIterator<DuplicateBuffer> objectPipe = new PipedCopyIterator<>();
+	private final PipedCopyIterator<BiDuplicateBuffer> sharedPipe = new PipedCopyIterator<>();
+	private final DuplicateBufferIterator<RuntimeException> sortedSubject;
+	private final DuplicateBufferIterator<RuntimeException> sortedObject;
+	private final DuplicateBufferIterator<RuntimeException> sortedPredicates;
+	private final Map<ByteString, DuplicateBufferIterator<RuntimeException>> sortedSubSections;
+
+	private final long estimatedSizeP;
+	private final AtomicLong countTyped = new AtomicLong();
+	private final AtomicLong countShared = new AtomicLong();
+	final AtomicLong[] countSubject;
+	final AtomicLong[] countObject;
+
+	private final WriteDictionarySection sectionSubject;
+	private final WriteDictionarySection sectionShared;
+	private final WriteDictionarySection sectionObject;
+	private final WriteDictionarySection sectionPredicate;
+	private final Map<ByteString, WriteDictionarySection> sectionSub;
+	private final Map<ByteString, Integer> typeId = new HashMap<>();
+	private boolean running;
+
+	/**
+	 * Create KCatMerger
+	 *
+	 * @param hdts           the hdts to cat
+	 * @param location       working location
+	 * @param listener       listener to log the state
+	 * @param bufferSize     buffer size
+	 * @param dictionaryType dictionary type
+	 * @param spec           spec to config the HDT
+	 * @throws java.io.IOException io exception
+	 */
+	public KCatMerger(HDT[] hdts, CloseSuppressPath location, ProgressListener listener, int bufferSize, String dictionaryType, HDTOptions spec) throws IOException {
+		this.hdts = hdts;
+		this.listener = listener;
+		this.dictionaryType = dictionaryType;
+
+		DictionaryKCat[] cats = new DictionaryKCat[hdts.length];
+		subjectsMaps = new SyncSeq[hdts.length];
+		predicatesMaps = new SyncSeq[hdts.length];
+		objectsMaps = new SyncSeq[hdts.length];
+		locations = new CloseSuppressPath[hdts.length * 3];
+
+		countSubject = IntStream.range(0, hdts.length).mapToObj(i -> new AtomicLong()).toArray(AtomicLong[]::new);
+		countObject = IntStream.range(0, hdts.length).mapToObj(i -> new AtomicLong()).toArray(AtomicLong[]::new);
+
+		long sizeS = 0;
+		long sizeP = 0;
+		long sizeO = 0;
+		long sizeShared = 0;
+
+		Map<ByteString, PreIndexSection[]> subSections = new TreeMap<>();
+
+		for (int i = 0; i < cats.length; i++) {
+			DictionaryKCat cat = DictionaryFactory.createDictionaryKCat(hdts[i].getDictionary());
+
+			// compute max allocated sizes
+			sizeS += cat.countSubjects();
+			sizeP += cat.countPredicates();
+			sizeO += cat.countObjects();
+			sizeShared += cat.countShared();
+
+			long start = 1L + cat.countShared();
+			// compute allocated sizes for HDT with sub sections
+			for (Map.Entry<CharSequence, DictionarySection> e : cat.getSubSections().entrySet()) {
+				CharSequence key = e.getKey();
+				DictionarySection section = e.getValue();
+
+				PreIndexSection[] sections = subSections.computeIfAbsent(
+						ByteString.of(key),
+						k -> new PreIndexSection[cats.length]
+				);
+				sections[i] = new PreIndexSection(start, section);
+				start += section.getNumberOfElements();
+			}
+			cats[i] = cat;
+		}
+		// if this HDT is typed, we don't have to allocate 1 bit / node to note a typed node
+		this.typedHDT = !subSections.isEmpty();
+		if (typedHDT) {
+			shift = 2;
+		} else {
+			shift = 1;
+		}
+
+		this.estimatedSizeP = sizeP;
+		try {
+			// create maps, allocate more bits for the shared part
+			int numbitsS = BitUtil.log2(sizeS + 1 + sizeShared) + 1 + shift;
+			int numbitsP = BitUtil.log2(sizeP + 1);
+			int numbitsO = BitUtil.log2(sizeO + 1 + sizeShared) + 1 + shift;
+			for (int i = 0; i < cats.length; i++) {
+				DictionaryKCat cat = cats[i];
+				subjectsMaps[i] = new SyncSeq(new SequenceLog64BigDisk((locations[i * 3] = location.resolve("subjectsMap_" + i)).toAbsolutePath().toString(), numbitsS, cat.countSubjects() + 1));
+				predicatesMaps[i] = new SyncSeq(new SequenceLog64BigDisk((locations[i * 3 + 1] = location.resolve("predicatesMap_" + i)).toAbsolutePath().toString(), numbitsP, cat.countPredicates() + 1));
+				objectsMaps[i] = new SyncSeq(new SequenceLog64BigDisk((locations[i * 3 + 2] = location.resolve("objectsMap_" + i)).toAbsolutePath().toString(), numbitsO, cat.countObjects() + 1));
+			}
+
+			// merge the subjects/objects/shared from all the HDTs
+			sortedSubject = mergeSection(
+					cats,
+					(hdtIndex, c) -> createMergeIt(
+							hdtIndex,
+							c.getSubjectSection().getSortedEntries(),
+							c.getSharedSection().getSortedEntries(),
+							c.countShared()
+					)
+			);
+			sortedObject = mergeSection(
+					cats,
+					(hdtIndex, c) -> createMergeIt(
+							hdtIndex,
+							c.getObjectSection().getSortedEntries(),
+							c.getSharedSection().getSortedEntries(),
+							c.objectShift()
+					)
+			);
+
+			// merge the other sections
+			sortedPredicates = mergeSection(cats, (hdtIndex, c) -> {
+				ExceptionIterator<? extends CharSequence, RuntimeException> of = ExceptionIterator.of(c.getPredicateSection().getSortedEntries());
+				return of.map(((element, index) -> new LocatedIndexedNode(hdtIndex, index + 1, ByteString.of(element))));
+			});
+
+			sortedSubSections = new TreeMap<>();
+			// create a merge section for each section
+			subSections.forEach((key, sections) -> sortedSubSections.put(key, mergeSection(sections, (hdtIndex, pre) -> {
+				ExceptionIterator<? extends CharSequence, RuntimeException> of = ExceptionIterator.of(pre.getSortedEntries());
+				return of.map(((element, index) -> new LocatedIndexedNode(hdtIndex, pre.getStart() + index, ByteString.of(element))));
+			})));
+
+			// convert the dupe buffer streams to byte string streams
+
+			Iterator<ByteString> subject = subjectPipe.mapWithId((db, id) -> {
+				long header = withEmptyHeader(id + 1);
+				db.stream().forEach(node -> {
+					SyncSeq map = subjectsMaps[node.getHdt()];
+					assert map.get(node.getIndex()) == 0 : "overwriting previous subject value";
+					map.set(node.getIndex(), header);
+					countSubject[node.getHdt()].incrementAndGet();
+				});
+				return db.peek();
+			});
+
+			Iterator<ByteString> object = objectPipe.mapWithId((db, id) -> {
+				long header = withEmptyHeader(id + 1);
+				db.stream().forEach(node -> {
+					SyncSeq map = objectsMaps[node.getHdt()];
+					assert map.get(node.getIndex()) == 0 : "overwriting previous object value";
+					assert node.getIndex() >= 1 && node.getIndex() <= hdts[node.getHdt()].getDictionary().getNobjects();
+					map.set(node.getIndex(), header);
+					countObject[node.getHdt()].incrementAndGet();
+				});
+				return db.peek();
+			});
+
+			// left = subjects
+			// right = objects
+			Iterator<ByteString> shared = sharedPipe.mapWithId((bdb, id) -> {
+				long header = withSharedHeader(id + 1);
+				countShared.incrementAndGet();
+				// left = subjects
+				bdb.getLeft().stream().forEach(node -> {
+					SyncSeq map = subjectsMaps[node.getHdt()];
+					assert map.get(node.getIndex()) == 0 : "overwriting previous subject value";
+					map.set(node.getIndex(), header);
+					countSubject[node.getHdt()].incrementAndGet();
+				});
+				// right = objects
+				bdb.getRight().stream().forEach(node -> {
+					SyncSeq map = objectsMaps[node.getHdt()];
+					assert map.get(node.getIndex()) == 0 : "overwriting previous object value";
+					assert node.getIndex() >= 1 && node.getIndex() <= hdts[node.getHdt()].getDictionary().getNobjects();
+					map.set(node.getIndex(), header);
+					countObject[node.getHdt()].incrementAndGet();
+				});
+				return bdb.peek();
+			});
+
+			sectionSubject = new WriteDictionarySection(spec, location.resolve("sortedSubject"), bufferSize);
+			sectionShared = new WriteDictionarySection(spec, location.resolve("sortedShared"), bufferSize);
+			sectionObject = new WriteDictionarySection(spec, location.resolve("sortedObject"), bufferSize);
+			sectionPredicate = new WriteDictionarySection(spec, location.resolve("sortedPredicate"), bufferSize);
+			sectionSub = new TreeMap<>();
+			sortedSubSections.keySet().forEach((key) -> sectionSub.put(key, new WriteDictionarySection(spec, location.resolve("sortedSub" + getTypeId(key)), bufferSize)));
+
+			catMergerThread = new ExceptionThread(this::runSharedCompute, "KCatMergerThreadShared")
+					.attach(new ExceptionThread(this::runSubSectionCompute, "KCatMergerThreadSubSection"))
+					.attach(new ExceptionThread(createWriter(sectionSubject, sizeS, subject), "KCatMergerThreadWriterS"))
+					.attach(new ExceptionThread(createWriter(sectionShared, sizeS + sizeO - sizeShared, shared), "KCatMergerThreadWriterSH"))
+					.attach(new ExceptionThread(createWriter(sectionObject, sizeO, object), "KCatMergerThreadWriterO"));
+		} catch (Throwable t) {
+			try {
+				throw t;
+			} finally {
+				close();
+			}
+		}
+	}
+
+	private static ExceptionIterator<LocatedIndexedNode, RuntimeException> createMergeIt(int hdtIndex, Iterator<? extends CharSequence> subjectObject, Iterator<? extends CharSequence> shared, long sharedCount) {
+		return MergeExceptionIterator.buildOfTree(List.of(
+				MapIterator.of(subjectObject, (element, index) ->
+								new LocatedIndexedNode(hdtIndex, sharedCount + index + 1, ByteString.of(element)))
+						.asExceptionIterator(),
+				MapIterator.of(shared, (element, index) ->
+								new LocatedIndexedNode(hdtIndex, index + 1, ByteString.of(element)))
+						.asExceptionIterator()
+		));
+	}
+
+	/**
+	 * create a sorted LocatedIndexedNode iterator from an array of sections
+	 *
+	 * @param sections the sections
+	 * @return iterator
+	 */
+	public static <T> DuplicateBufferIterator<RuntimeException> mergeSection(T[] sections, MergerFunction<T> mapper) {
+		return new DuplicateBufferIterator<>(
+				MergeExceptionIterator
+						.buildOfTree(
+								(Integer hdtIndex, T e) -> {
+									if (e == null) {
+										// empty section (not defined for this HDT)
+										return ExceptionIterator.empty();
+									}
+									// convert all the entries into located nodes
+									return mapper.apply(hdtIndex, e);
+								},
+								LocatedIndexedNode::compareTo,
+								List.of(sections),
+								0,
+								sections.length
+						),
+				sections.length
+		);
+	}
+
+	/**
+	 * get an UID for a type
+	 *
+	 * @param str the type
+	 * @return UID
+	 */
+	public int getTypeId(ByteString str) {
+		return typeId.computeIfAbsent(str, (key) -> typeId.size());
+	}
+
+	/**
+	 * add a typed header to this value
+	 *
+	 * @param value value
+	 * @return header value
+	 * @see #withEmptyHeader(long)
+	 * @see #withSharedHeader(long)
+	 */
+	public long withTypedHeader(long value) {
+		assert value != 0 : "value can't be 0!";
+		return (value << shift) | TYPED_MASK;
+	}
+
+	/**
+	 * add a shared header to this value
+	 *
+	 * @param value value
+	 * @return header value
+	 * @see #withEmptyHeader(long)
+	 * @see #withTypedHeader(long)
+	 */
+	public long withSharedHeader(long value) {
+		assert value != 0 : "value can't be 0!";
+		return (value << shift) | SHARED_MASK;
+	}
+
+	/**
+	 * add a header to this value
+	 *
+	 * @param value value
+	 * @return header value
+	 * @see #withTypedHeader(long)
+	 * @see #withSharedHeader(long)
+	 */
+	public long withEmptyHeader(long value) {
+		assert value != 0 : "value can't be 0!";
+		return value << shift;
+	}
+
+	boolean assertReadCorrectly() {
+		for (int i = 0; i < hdts.length; i++) {
+			HDT hdt = hdts[i];
+			assert countObject[i].get() == hdt.getDictionary().getNobjects();
+			assert countSubject[i].get() == hdt.getDictionary().getNsubjects();
+		}
+		return true;
+	}
+
+	/**
+	 * test if a header value is shared
+	 *
+	 * @param headerValue header value
+	 * @return true if the header is shared, false otherwise
+	 */
+	public boolean isShared(long headerValue) {
+		return (headerValue & SHARED_MASK) != 0;
+	}
+
+	/**
+	 * test if a header value is typed
+	 *
+	 * @param headerValue header value
+	 * @return true if the header is typed, false otherwise
+	 */
+	public boolean isTyped(long headerValue) {
+		return typedHDT && (headerValue & TYPED_MASK) != 0;
+	}
+
+	/**
+	 * wait for the merger to complete
+	 *
+	 * @throws InterruptedException thread interruption
+	 */
+	public DictionaryPrivate buildDictionary() throws InterruptedException {
+		synchronized (this) {
+			if (!running) {
+				startMerger();
+			}
+		}
+		catMergerThread.joinAndCrashIfRequired();
+
+		return DictionaryFactory.createWriteDictionary(
+				dictionaryType,
+				null,
+				getSectionSubject(),
+				getSectionPredicate(),
+				getSectionObject(),
+				getSectionShared(),
+				getSectionSub()
+		);
+	}
+
+	private void runSharedCompute() {
+		// merge the sections
+		try {
+			sharedLoop:
+			while (sortedObject.hasNext() && sortedSubject.hasNext()) {
+				// last was a shared node
+				DuplicateBuffer newSubject = sortedSubject.next();
+				DuplicateBuffer newObject = sortedObject.next();
+				int comp = newSubject.compareTo(newObject);
+				while (comp != 0) {
+					if (comp < 0) {
+						subjectPipe.addElement(newSubject.trim());
+						if (!sortedSubject.hasNext()) {
+							// no more subjects, send the current object and break the shared loop
+							objectPipe.addElement(newObject.trim());
+							break sharedLoop;
+						}
+						newSubject = sortedSubject.next();
+					} else {
+						objectPipe.addElement(newObject.trim());
+						if (!sortedObject.hasNext()) {
+							// no more objects, send the current subject and break the shared loop
+							subjectPipe.addElement(newSubject.trim());
+							break sharedLoop;
+						}
+						newObject = sortedObject.next();
+					}
+					comp = newSubject.compareTo(newObject);
+				}
+
+				// shared element
+				sharedPipe.addElement(newSubject.trim().asBi(newObject.trim()));
+			}
+
+			// at least one iterator is empty, closing the shared pipe
+			sharedPipe.closePipe();
+			// do we have subjects?
+			while (sortedSubject.hasNext()) {
+				subjectPipe.addElement(sortedSubject.next().trim());
+			}
+			subjectPipe.closePipe();
+			// do we have objects?
+			while (sortedObject.hasNext()) {
+				objectPipe.addElement(sortedObject.next().trim());
+			}
+			objectPipe.closePipe();
+		} catch (Throwable t) {
+			objectPipe.closePipe(t);
+			subjectPipe.closePipe(t);
+			sharedPipe.closePipe(t);
+			throw t;
+		}
+	}
+
+	private void runSubSectionCompute() {
+		// convert all the sections
+
+		// load predicates
+		sectionPredicate.load(new OneReadDictionarySection(sortedPredicates.map((db, id) -> {
+			db.stream().forEach(node -> {
+				SyncSeq map = predicatesMaps[node.getHdt()];
+				assert map.get(node.getIndex()) == 0 : "overwriting previous predicate value";
+				map.set(node.getIndex(), id + 1);
+			});
+			return db.peek();
+		}).asIterator(), estimatedSizeP), null);
+
+		long shift = 1L;
+		// load data typed sections
+		for (Map.Entry<ByteString, WriteDictionarySection> e : sectionSub.entrySet()) {
+			ByteString key = e.getKey();
+			WriteDictionarySection section = e.getValue();
+
+			DuplicateBufferIterator<RuntimeException> bufferIterator = sortedSubSections.get(key);
+
+			final long currentShift = shift;
+			section.load(new OneReadDictionarySection(bufferIterator.map((db, id) -> {
+				long headerID = withTypedHeader(id + currentShift);
+				countTyped.incrementAndGet();
+				db.stream().forEach(node -> {
+					SyncSeq map = objectsMaps[node.getHdt()];
+					assert map.get(node.getIndex()) == 0 : "overwriting previous object value";
+					assert node.getIndex() >= 1 && node.getIndex() <= hdts[node.getHdt()].getDictionary().getNobjects();
+					map.set(node.getIndex(), headerID);
+					countObject[node.getHdt()].incrementAndGet();
+				});
+				return db.peek();
+			}).asIterator(), estimatedSizeP), null);
+			shift += section.getNumberOfElements();
+		}
+	}
+
+	private ExceptionThread.ExceptionRunnable createWriter(DictionarySectionPrivate sect, long size, Iterator<ByteString> iterator) {
+		// convert all the sections
+		return () -> sect.load(new OneReadDictionarySection(iterator, size), listener);
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			if (catMergerThread != null) {
+				catMergerThread.joinAndCrashIfRequired();
+			}
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} finally {
+			Closer.of(sectionSubject, sectionPredicate, sectionObject, sectionShared)
+					.with(sectionSub.values())
+					.with(subjectsMaps)
+					.with(predicatesMaps)
+					.with(objectsMaps)
+					.with(locations)
+					.close();
+		}
+	}
+
+	/**
+	 * remove the header of a header id
+	 *
+	 * @param headerID header id
+	 * @return id
+	 */
+	public long removeHeader(long headerID) {
+		return headerID >>> shift;
+	}
+
+	/**
+	 * extract the subject from an HDT
+	 *
+	 * @param hdtIndex the HDT index
+	 * @param oldID    the ID in the HDT triples
+	 * @return ID in the new HDT
+	 */
+	public long extractSubject(int hdtIndex, long oldID) {
+		long headerID = subjectsMaps[hdtIndex].get(oldID);
+		if (isShared(headerID)) {
+			return headerID >>> shift;
+		}
+		return (headerID >>> shift) + countShared.get();
+	}
+
+	/**
+	 * extract the predicate from an HDT
+	 *
+	 * @param hdtIndex the HDT index
+	 * @param oldID    the ID in the HDT triples
+	 * @return ID in the new HDT
+	 */
+	public long extractPredicate(int hdtIndex, long oldID) {
+		return predicatesMaps[hdtIndex].get(oldID);
+	}
+
+	/**
+	 * extract the object from an HDT
+	 *
+	 * @param hdtIndex the HDT index
+	 * @param oldID    the ID in the HDT triples
+	 * @return ID in the new HDT
+	 */
+	public long extractObject(int hdtIndex, long oldID) {
+		long headerID = objectsMaps[hdtIndex].get(oldID);
+		if (isShared(headerID)) {
+			return headerID >>> shift;
+		}
+		if (isTyped(headerID)) {
+			return (headerID >>> shift) + countShared.get();
+		}
+		return (headerID >>> shift) + countShared.get() + countTyped.get();
+	}
+
+	/**
+	 * copy into a new TripleID the mapped version of a tripleID
+	 *
+	 * @param hdtIndex the origin HDT of this tripleID
+	 * @param id       the tripleID
+	 * @return mapped tripleID
+	 */
+	public TripleID extractMapped(int hdtIndex, TripleID id) {
+		TripleID mapped = new TripleID(
+				extractSubject(hdtIndex, id.getSubject()),
+				extractPredicate(hdtIndex, id.getPredicate()),
+				extractObject(hdtIndex, id.getObject())
+		);
+		assert mapped.isValid() : "mapped to empty triples! " + id + " => " + mapped;
+		return mapped;
+	}
+
+	/**
+	 * @return the count of shared elements
+	 */
+	public long getCountShared() {
+		return countShared.get();
+	}
+
+	/**
+	 * @return subject section
+	 */
+	public DictionarySectionPrivate getSectionSubject() {
+		return sectionSubject;
+	}
+
+	/**
+	 * @return shared section
+	 */
+	public DictionarySectionPrivate getSectionShared() {
+		return sectionShared;
+	}
+
+	/**
+	 * @return object section
+	 */
+	public DictionarySectionPrivate getSectionObject() {
+		return sectionObject;
+	}
+
+	/**
+	 * @return predicate section
+	 */
+	public DictionarySectionPrivate getSectionPredicate() {
+		return sectionPredicate;
+	}
+
+	/**
+	 * @return sub sections
+	 */
+	public TreeMap<ByteString, DictionarySectionPrivate> getSectionSub() {
+		TreeMap<ByteString, DictionarySectionPrivate> sub = new TreeMap<>(sectionSub);
+		sub.put(LiteralsUtils.NO_DATATYPE, getSectionObject());
+		return sub;
+	}
+
+	/**
+	 * start the merger threads
+	 */
+	public synchronized void startMerger() {
+		if (running) {
+			throw new IllegalArgumentException("KCatMerger is already running!");
+		}
+		running = true;
+
+		catMergerThread.startAll();
+	}
+
+	static class BiDuplicateBuffer implements Comparable<BiDuplicateBuffer> {
+		private final DuplicateBuffer left;
+		private final DuplicateBuffer right;
+
+
+		public BiDuplicateBuffer(DuplicateBuffer left, DuplicateBuffer right) {
+			this.left = Objects.requireNonNull(left, "left buffer can't be null!");
+			this.right = Objects.requireNonNull(right, "right buffer can't be null!");
+			assert left.isEmpty() || right.isEmpty() || left.peek().equals(right.peek()) : "Can't have heterogeneous bi dupe buffer";
+		}
+
+		public DuplicateBuffer getLeft() {
+			return left;
+		}
+
+		public DuplicateBuffer getRight() {
+			return right;
+		}
+
+		public boolean isEmpty() {
+			return getLeft().isEmpty() && getRight().isEmpty();
+		}
+
+		public ByteString peek() {
+			if (!left.isEmpty()) {
+				return left.peek();
+			}
+			if (!right.isEmpty()) {
+				return right.peek();
+			}
+			return null;
+		}
+
+		@Override
+		public int compareTo(BiDuplicateBuffer o) {
+			return peek().compareTo(o.peek());
+		}
+	}
+
+	static class DuplicateBuffer implements Comparable<DuplicateBuffer> {
+		private final LocatedIndexedNode[] buffer;
+		private int used;
+
+		public DuplicateBuffer(int bufferSize) {
+			this.buffer = new LocatedIndexedNode[bufferSize];
+		}
+
+		/**
+		 * add a node to this buffer
+		 *
+		 * @param node node
+		 * @return if this node was added to the buffer
+		 */
+		private boolean add(LocatedIndexedNode node) {
+			// start case
+			if (isEmpty() || buffer[0].getNode().equals(node.getNode())) {
+				// we can't have more than buffer size because a source HDT wouldn't be
+				// without duplicated or a so/sh conflict
+				buffer[used++] = node;
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * convert this buffer to a bi duplicate buffer
+		 *
+		 * @param other right part
+		 * @return BiDuplicateBuffer
+		 */
+		public BiDuplicateBuffer asBi(DuplicateBuffer other) {
+			return new BiDuplicateBuffer(this, other);
+		}
+
+		/**
+		 * @return if this buffer contains at least one element
+		 */
+		public boolean isEmpty() {
+			return used == 0;
+		}
+
+		/**
+		 * clear the buffer
+		 */
+		public void clear() {
+			// clear old values
+			for (int i = 0; i < used; i++) {
+				buffer[i] = null;
+			}
+			used = 0;
+		}
+
+		/**
+		 * @return a stream of the current duplicate objects
+		 */
+		public Stream<LocatedIndexedNode> stream() {
+			return Arrays.stream(buffer, 0, used);
+		}
+
+		@Override
+		public int compareTo(DuplicateBuffer o) {
+			if (isEmpty() || o.isEmpty()) {
+				throw new IllegalArgumentException("Can't compare empty buffers");
+			}
+			return buffer[0].compareTo(o.buffer[0]);
+		}
+
+		/**
+		 * @return a trimmed version of this buffer
+		 */
+		public DuplicateBuffer trim() {
+			DuplicateBuffer other = new DuplicateBuffer(used);
+			System.arraycopy(buffer, 0, other.buffer, 0, used);
+			other.used = used;
+			return other;
+		}
+
+		/**
+		 * @return the buffered byte string, null if empty
+		 */
+		public ByteString peek() {
+			if (isEmpty()) {
+				return null;
+			}
+			return buffer[0].getNode();
+		}
+
+		/**
+		 * @return the size of the buffer
+		 */
+		public int size() {
+			return used;
+		}
+	}
+
+	static class DuplicateBufferIterator<E extends Exception> implements ExceptionIterator<DuplicateBuffer, E> {
+		private final ExceptionIterator<LocatedIndexedNode, E> iterator;
+		private final DuplicateBuffer buffer;
+		private LocatedIndexedNode last;
+		private DuplicateBuffer next;
+
+		public DuplicateBufferIterator(ExceptionIterator<LocatedIndexedNode, E> iterator, int bufferSize) {
+			this.iterator = iterator;
+			buffer = new DuplicateBuffer(bufferSize);
+		}
+
+		@Override
+		public boolean hasNext() throws E {
+			if (next != null) {
+				return true;
+			}
+
+			// clear previous buffer
+			buffer.clear();
+			while (true) {
+				// load an element from the iterator
+				if (last == null) {
+					if (!iterator.hasNext()) {
+						if (buffer.isEmpty()) {
+							return false;
+						}
+						break;
+					}
+					last = iterator.next();
+				}
+
+				// add the elements from the iterator
+				if (!buffer.add(last)) {
+					break;
+				}
+				last = null;
+			}
+
+			next = buffer.trim();
+			return true;
+		}
+
+		@Override
+		public DuplicateBuffer next() throws E {
+			if (!hasNext()) {
+				return null;
+			}
+			try {
+				return next;
+			} finally {
+				next = null;
+			}
+		}
+
+	}
+
+	private interface MergerFunction<T> {
+		ExceptionIterator<LocatedIndexedNode, RuntimeException> apply(int hdtIndex, T t);
+	}
+
+	private static class PreIndexSection {
+		long start;
+		DictionarySection section;
+
+		public PreIndexSection(long start, DictionarySection section) {
+			this.start = start;
+			this.section = section;
+		}
+
+		public long getStart() {
+			return start;
+		}
+
+		public DictionarySection getSection() {
+			return section;
+		}
+
+		public Iterator<? extends CharSequence> getSortedEntries() {
+			return getSection().getSortedEntries();
+		}
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/LocatedIndexedNode.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/LocatedIndexedNode.java
@@ -1,0 +1,35 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.rdfhdt.hdt.triples.IndexedNode;
+import org.rdfhdt.hdt.util.string.ByteString;
+
+public class LocatedIndexedNode extends IndexedNode {
+	private final int hdt;
+
+	public LocatedIndexedNode(int hdt, long index, ByteString string) {
+		super(string, index);
+		this.hdt = hdt;
+	}
+
+	public int getHdt() {
+		return hdt;
+	}
+
+	public int compareTo(LocatedIndexedNode o) {
+		return super.compareTo(o);
+	}
+
+	@Override
+	public LocatedIndexedNode clone() {
+		return (LocatedIndexedNode) super.clone();
+	}
+
+	@Override
+	public String toString() {
+		return "LocatedIndexedNode{" +
+				"hdt=" + hdt +
+				", index=" + getIndex() +
+				", node=" + getNode() +
+				'}';
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/MultipleSectionDictionaryKCat.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/kcat/MultipleSectionDictionaryKCat.java
@@ -1,0 +1,80 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.rdfhdt.hdt.dictionary.Dictionary;
+import org.rdfhdt.hdt.dictionary.DictionaryKCat;
+import org.rdfhdt.hdt.dictionary.DictionarySection;
+import org.rdfhdt.hdt.util.LiteralsUtils;
+import org.rdfhdt.hdt.util.string.ByteString;
+import org.rdfhdt.hdt.util.string.CharSequenceComparator;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class MultipleSectionDictionaryKCat implements DictionaryKCat {
+	private final Dictionary dictionary;
+
+	public MultipleSectionDictionaryKCat(Dictionary dictionary) {
+		this.dictionary = dictionary;
+	}
+
+	@Override
+	public Map<CharSequence, DictionarySection> getSubSections() {
+		Map<CharSequence, DictionarySection> sections = new TreeMap<>(CharSequenceComparator.getInstance());
+		dictionary.getAllObjects().forEach((key, section) -> {
+			if (!LiteralsUtils.NO_DATATYPE.equals(key)) {
+				// we ignore this section because it will be used in the shared compute
+				sections.put(ByteString.of(key), section);
+			}
+		});
+		return sections;
+	}
+
+	@Override
+	public DictionarySection getSubjectSection() {
+		return dictionary.getSubjects();
+	}
+
+	@Override
+	public DictionarySection getPredicateSection() {
+		return dictionary.getPredicates();
+	}
+
+	@Override
+	public DictionarySection getObjectSection() {
+		return dictionary.getAllObjects().get("NO_DATATYPE");
+	}
+
+	@Override
+	public DictionarySection getSharedSection() {
+		return dictionary.getShared();
+	}
+
+	@Override
+	public long countSubjects() {
+		return dictionary.getSubjects().getNumberOfElements() + countShared();
+	}
+
+	@Override
+	public long countShared() {
+		return dictionary.getShared().getNumberOfElements();
+	}
+
+	@Override
+	public long countPredicates() {
+		return dictionary.getPredicates().getNumberOfElements();
+	}
+
+	@Override
+	public long countObjects() {
+		long count = 0;
+		for (DictionarySection sec : dictionary.getAllObjects().values()) {
+			count += sec.getNumberOfElements();
+		}
+		return count + countShared();
+	}
+
+	@Override
+	public long objectShift() {
+		return countObjects() - getObjectSection().getNumberOfElements();
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/WriteDictionarySection.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/section/WriteDictionarySection.java
@@ -74,16 +74,16 @@ public class WriteDictionarySection implements DictionarySectionPrivate {
 					blocks.append(out.getTotalBytes());
 
 					// Copy full string
-					ByteStringUtil.append(out, str, 0);
+					ByteStringUtil.append(crcout, str, 0);
 				} else {
 					// Find common part.
 					int delta = ByteStringUtil.longestCommonPrefix(previousStr, str);
 					// Write Delta in VByte
-					VByte.encode(out, delta);
+					VByte.encode(crcout, delta);
 					// Write remaining
-					ByteStringUtil.append(out, str, delta);
+					ByteStringUtil.append(crcout, str, delta);
 				}
-				out.write(0);
+				crcout.write(0);
 				previousStr = str;
 				numberElements++;
 				if (currentCount % block == 0) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTBase.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTBase.java
@@ -1,6 +1,7 @@
 package org.rdfhdt.hdt.hdt.impl;
 
 import org.rdfhdt.hdt.dictionary.DictionaryPrivate;
+import org.rdfhdt.hdt.exceptions.NotFoundException;
 import org.rdfhdt.hdt.hdt.HDTPrivate;
 import org.rdfhdt.hdt.hdt.HDTVocabulary;
 import org.rdfhdt.hdt.header.Header;
@@ -9,6 +10,7 @@ import org.rdfhdt.hdt.options.ControlInfo;
 import org.rdfhdt.hdt.options.ControlInformation;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.options.HDTSpecification;
+import org.rdfhdt.hdt.triples.IteratorTripleString;
 import org.rdfhdt.hdt.triples.TriplesPrivate;
 import org.rdfhdt.hdt.util.StringUtil;
 import org.rdfhdt.hdt.util.listener.IntermediateListener;
@@ -91,6 +93,10 @@ public abstract class HDTBase<H extends Header, D extends DictionaryPrivate, T e
 		return dictionary.size() + triples.size();
 	}
 
+	public HDTOptions getSpec() {
+		return spec;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 *
@@ -117,6 +123,22 @@ public abstract class HDTBase<H extends Header, D extends DictionaryPrivate, T e
 		ci.clear();
 		ci.setType(ControlInfo.Type.TRIPLES);
 		triples.save(output, ci, iListener);
+	}
+
+	public static long getRawSize(Header header) {
+
+		try {
+			IteratorTripleString rawSize1 = header.search("_:statistics", HDTVocabulary.ORIGINAL_SIZE, "");
+			if (!rawSize1.hasNext()) {
+				return -1;
+			}
+
+			CharSequence obj = rawSize1.next().getObject();
+			// remove "s in "<long>"
+			return Long.parseLong(obj, 1, obj.length() - 1, 10);
+		} catch (NotFoundException e) {
+			return -1;
+		}
 	}
 
 	@Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -557,22 +557,6 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 		profiler.popSection();
 	}
 
-	public static long getRawSize(Header header) {
-
-		try {
-			IteratorTripleString rawSize1 = header.search("_:statistics", HDTVocabulary.ORIGINAL_SIZE, "");
-			if (!rawSize1.hasNext()) {
-				return -1;
-			}
-
-			CharSequence obj = rawSize1.next().getObject();
-			// remove "s in "<long>"
-			return Long.parseLong(obj, 1, obj.length() - 1, 10);
-		} catch (NotFoundException e) {
-			return -1;
-		}
-	}
-
 	public void catCustom(String location, HDT hdt1, HDT hdt2, ProgressListener listener, Profiler profiler) throws IOException {
 		if (listener != null) {
 			listener.notifyProgress(0, "Generating dictionary");

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/WriteHDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/WriteHDTImpl.java
@@ -2,16 +2,13 @@ package org.rdfhdt.hdt.hdt.impl;
 
 import org.rdfhdt.hdt.dictionary.DictionaryFactory;
 import org.rdfhdt.hdt.dictionary.DictionaryPrivate;
-import org.rdfhdt.hdt.dictionary.impl.WriteFourSectionDictionary;
-import org.rdfhdt.hdt.dictionary.impl.WriteMultipleSectionDictionary;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
-import org.rdfhdt.hdt.hdt.HDTVocabulary;
 import org.rdfhdt.hdt.header.HeaderFactory;
 import org.rdfhdt.hdt.header.HeaderPrivate;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.HDTOptions;
-import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.triples.IteratorTripleString;
+import org.rdfhdt.hdt.triples.TriplesPrivate;
 import org.rdfhdt.hdt.triples.impl.WriteBitmapTriples;
 import org.rdfhdt.hdt.util.io.CloseSuppressPath;
 import org.rdfhdt.hdt.util.io.IOUtil;
@@ -29,7 +26,7 @@ import java.nio.file.Path;
  *
  * @author Antoine Willerval
  */
-public class WriteHDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, WriteBitmapTriples> {
+public class WriteHDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPrivate> {
 	private String baseURI;
 	private final CloseSuppressPath workingLocation;
 	private boolean isClosed;
@@ -44,6 +41,17 @@ public class WriteHDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, Writ
 		triples = new WriteBitmapTriples(this.spec, workingLocation.resolve("tripleBitmap"), bufferSize);
 		// small, can use default implementation
 		header = HeaderFactory.createHeader(this.spec);
+	}
+	public WriteHDTImpl(HDTOptions spec, CloseSuppressPath workingLocation, DictionaryPrivate dict, TriplesPrivate triples, HeaderPrivate header) throws IOException {
+		super(spec);
+		this.workingLocation = workingLocation;
+		workingLocation.mkdirs();
+
+		dictionary = dict;
+		// we need to have the bitmaps in memory, so we can't bypass the implementation
+		this.triples = triples;
+		// small, can use default implementation
+		this.header = header;
 	}
 
 	@Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/ExceptionIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/ExceptionIterator.java
@@ -1,5 +1,7 @@
 package org.rdfhdt.hdt.iterator.utils;
 
+import org.rdfhdt.hdt.listener.ProgressListener;
+
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -108,6 +110,25 @@ public interface ExceptionIterator<T, E extends Exception> {
 	 */
 	default <M> ExceptionIterator<M, E> map(MapExceptionIterator.MapWithIdFunction<T, M, E> mappingFunc) {
 		return new MapExceptionIterator<>(this, mappingFunc);
+	}
+
+	/**
+	 * Convert to notification iterator
+	 *
+	 * @param estimatedSize the estimated size
+	 * @param maxSplit the maximum split
+	 * @param message message of the notification
+	 * @param listener listener
+	 * @return notification iterator
+	 */
+	default ExceptionIterator<T, E> notif(long estimatedSize, long maxSplit, String message, ProgressListener listener) {
+		return new NotificationExceptionIterator<>(
+				this,
+				estimatedSize,
+				Math.max(maxSplit, estimatedSize / 10_000),
+				message,
+				listener
+		);
 	}
 
 	/**

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MapIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MapIterator.java
@@ -5,11 +5,20 @@ import java.util.function.Function;
 
 /**
  * Iterator to map a value to another
+ *
  * @param <M> origin type
  * @param <N> return type
  * @author Antoine Willerval
  */
 public class MapIterator<M, N> implements Iterator<N> {
+	public static <M, N> MapIterator<M, N> of(Iterator<M> base, Function<M, N> mappingFunction) {
+		return new MapIterator<>(base, mappingFunction);
+	}
+
+	public static <M, N> MapIterator<M, N> of(Iterator<M> base, MapWithIdFunction<M, N> mappingFunction) {
+		return new MapIterator<>(base, mappingFunction);
+	}
+
 	private final MapWithIdFunction<M, N> mappingFunction;
 	private final Iterator<M> base;
 	private long index;
@@ -17,6 +26,7 @@ public class MapIterator<M, N> implements Iterator<N> {
 	public MapIterator(Iterator<M> base, Function<M, N> mappingFunction) {
 		this(base, (m, i) -> mappingFunction.apply(m));
 	}
+
 	public MapIterator(Iterator<M> base, MapWithIdFunction<M, N> mappingFunction) {
 		this.base = base;
 		this.mappingFunction = mappingFunction;
@@ -35,6 +45,13 @@ public class MapIterator<M, N> implements Iterator<N> {
 	@Override
 	public void remove() {
 		base.remove();
+	}
+
+	/**
+	 * @return this iterator, but as an exception iterator
+	 */
+	public ExceptionIterator<N, RuntimeException> asExceptionIterator() {
+		return ExceptionIterator.of(this);
 	}
 
 	@FunctionalInterface

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MergeExceptionIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MergeExceptionIterator.java
@@ -3,19 +3,21 @@ package org.rdfhdt.hdt.iterator.utils;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class MergeExceptionIterator<T, E extends Exception> implements ExceptionIterator<T, E> {
 
 	/**
 	 * Create a tree of merge iterators from an array of element
+	 *
 	 * @param itFunction a function to create an iterator from an element
-	 * @param comp comparator for the merge iterator
-	 * @param array the elements
-	 * @param length the number of elements
-	 * @param <I> input of the element
-	 * @param <T> type of the element in the iterator
-	 * @param <E> exception returned by the iterator
+	 * @param comp       comparator for the merge iterator
+	 * @param array      the elements
+	 * @param length     the number of elements
+	 * @param <I>        input of the element
+	 * @param <T>        type of the element in the iterator
+	 * @param <E>        exception returned by the iterator
 	 * @return the iterator
 	 */
 	public static <I, T, E extends Exception> ExceptionIterator<T, E> buildOfTree(
@@ -25,13 +27,14 @@ public class MergeExceptionIterator<T, E extends Exception> implements Exception
 
 	/**
 	 * Create a tree of merge iterators from an array of element
+	 *
 	 * @param itFunction a function to create an iterator from an element
-	 * @param comp comparator for the merge iterator
-	 * @param array the elements
-	 * @param start the start of the array (inclusive)
-	 * @param end the end of the array (exclusive)
-	 * @param <T> type of the element
-	 * @param <E> exception returned by the iterator
+	 * @param comp       comparator for the merge iterator
+	 * @param array      the elements
+	 * @param start      the start of the array (inclusive)
+	 * @param end        the end of the array (exclusive)
+	 * @param <T>        type of the element
+	 * @param <E>        exception returned by the iterator
 	 * @return the iterator
 	 */
 	public static <I, T, E extends Exception> ExceptionIterator<T, E> buildOfTree(
@@ -41,23 +44,83 @@ public class MergeExceptionIterator<T, E extends Exception> implements Exception
 
 	/**
 	 * Create a tree of merge iterators from an array of element
+	 *
 	 * @param itFunction a function to create an iterator from an element
-	 * @param comp comparator for the merge iterator
-	 * @param array the elements
-	 * @param start the start of the array (inclusive)
-	 * @param end the end of the array (exclusive)
-	 * @param <T> type of the element
-	 * @param <E> exception returned by the iterator
+	 * @param comp       comparator for the merge iterator
+	 * @param array      the elements
+	 * @param start      the start of the array (inclusive)
+	 * @param end        the end of the array (exclusive)
+	 * @param <T>        type of the element
+	 * @param <E>        exception returned by the iterator
 	 * @return the iterator
 	 */
 	public static <I, T, E extends Exception> ExceptionIterator<T, E> buildOfTree(
 			Function<I, ExceptionIterator<T, E>> itFunction, Comparator<T> comp, List<I> array, int start, int end) {
+		return buildOfTree((index, o) -> itFunction.apply(o), comp, array, start, end);
+	}
+
+	/**
+	 * Create a tree of merge iterators from an array of element
+	 *
+	 * @param itFunction a function to create an iterator from an element
+	 * @param array      the elements
+	 * @param start      the start of the array (inclusive)
+	 * @param end        the end of the array (exclusive)
+	 * @param <T>        type of the element
+	 * @param <E>        exception returned by the iterator
+	 * @return the iterator
+	 */
+	public static <I, T extends Comparable<T>, E extends Exception> ExceptionIterator<T, E> buildOfTree(
+			Function<I, ExceptionIterator<T, E>> itFunction, List<I> array, int start, int end) {
+		return buildOfTree((index, o) -> itFunction.apply(o), Comparable::compareTo, array, start, end);
+	}
+
+	/**
+	 * Create a tree of merge iterators from an array of element
+	 *
+	 * @param array the elements
+	 * @param start the start of the array (inclusive)
+	 * @param end   the end of the array (exclusive)
+	 * @param <T>   type of the element
+	 * @param <E>   exception returned by the iterator
+	 * @return the iterator
+	 */
+	public static <T extends Comparable<T>, E extends Exception> ExceptionIterator<T, E> buildOfTree(List<ExceptionIterator<T, E>> array, int start, int end) {
+		return MergeExceptionIterator.buildOfTree(Function.identity(), Comparable::compareTo, array, start, end);
+	}
+
+	/**
+	 * Create a tree of merge iterators from an array of element
+	 *
+	 * @param array the elements
+	 * @param <T>   type of the element
+	 * @param <E>   exception returned by the iterator
+	 * @return the iterator
+	 */
+	public static <T extends Comparable<? super T>, E extends Exception> ExceptionIterator<T, E> buildOfTree(List<ExceptionIterator<T, E>> array) {
+		return MergeExceptionIterator.buildOfTree(Function.identity(), Comparable::compareTo, array, 0, array.size());
+	}
+
+	/**
+	 * Create a tree of merge iterators from an array of element
+	 *
+	 * @param itFunction a function to create an iterator from an element
+	 * @param comp       comparator for the merge iterator
+	 * @param array      the elements
+	 * @param start      the start of the array (inclusive)
+	 * @param end        the end of the array (exclusive)
+	 * @param <T>        type of the element
+	 * @param <E>        exception returned by the iterator
+	 * @return the iterator
+	 */
+	public static <I, T, E extends Exception> ExceptionIterator<T, E> buildOfTree(
+			BiFunction<Integer, I, ExceptionIterator<T, E>> itFunction, Comparator<T> comp, List<I> array, int start, int end) {
 		int length = end - start;
 		if (length <= 0) {
 			return ExceptionIterator.empty();
 		}
 		if (length == 1) {
-			return itFunction.apply(array.get(start));
+			return itFunction.apply(start, array.get(start));
 		}
 		int mid = (start + end) / 2;
 		return new MergeExceptionIterator<>(

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HDTOptionsBase.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HDTOptionsBase.java
@@ -28,6 +28,7 @@
 package org.rdfhdt.hdt.options;
 
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * @author mario.arias
@@ -80,7 +81,10 @@ public class HDTOptionsBase implements HDTOptions {
 		properties.setProperty(key, Long.toString(value));
 	}
 
-
+	@Override
+	public Set<Object> getKeys() {
+		return properties.keySet();
+	}
 
 	@Override
     public void clear() {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HideHDTOptions.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HideHDTOptions.java
@@ -1,6 +1,8 @@
 package org.rdfhdt.hdt.options;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -19,6 +21,11 @@ public class HideHDTOptions implements HDTOptions {
     public HideHDTOptions(HDTOptions spec, Function<String, String> mapper) {
         this.spec = spec;
         this.mapper = mapper;
+    }
+
+    @Override
+    public Set<Object> getKeys() {
+        return spec.getKeys();
     }
 
     private String map(String key) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/IndexedNode.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/IndexedNode.java
@@ -2,11 +2,12 @@ package org.rdfhdt.hdt.triples;
 
 import org.rdfhdt.hdt.util.string.ByteString;
 import org.rdfhdt.hdt.util.string.CharSequenceComparator;
+import org.rdfhdt.hdt.util.string.CompactString;
 
 import java.util.Comparator;
 
 
-public final class IndexedNode implements Comparable<IndexedNode> {
+public class IndexedNode implements Comparable<IndexedNode>, Cloneable {
 	private ByteString node;
 	private long index;
 
@@ -40,5 +41,17 @@ public final class IndexedNode implements Comparable<IndexedNode> {
 	@Override
 	public int compareTo(IndexedNode o) {
 		return node.compareTo(o.node);
+	}
+
+
+	@Override
+	public IndexedNode clone() {
+		try {
+			IndexedNode clone = (IndexedNode) super.clone();
+			clone.node = new CompactString(node);
+			return clone;
+		} catch (CloneNotSupportedException e) {
+			throw new AssertionError(e);
+		}
 	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/concurrent/SyncSeq.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/concurrent/SyncSeq.java
@@ -1,0 +1,32 @@
+package org.rdfhdt.hdt.util.concurrent;
+
+import org.rdfhdt.hdt.compact.sequence.DynamicSequence;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Class to synchronize a {@link org.rdfhdt.hdt.compact.sequence.DynamicSequence} map
+ *
+ * @author Antoine Willerval
+ */
+public class SyncSeq implements Closeable {
+	private final DynamicSequence seq;
+
+	public SyncSeq(DynamicSequence seq) {
+		this.seq = seq;
+	}
+
+	public synchronized long get(long index) {
+		return seq.get(index);
+	}
+
+	public synchronized void set(long index, long value) {
+		seq.set(index, value);
+	}
+
+	@Override
+	public synchronized void close() throws IOException {
+		seq.close();
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/Closer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/Closer.java
@@ -1,0 +1,63 @@
+package org.rdfhdt.hdt.util.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Class to close many {@link java.io.Closeable} objects at once without having to do a large try-finally tree
+ *
+ * @author Antoine Willerval
+ */
+public class Closer implements Iterable<Closeable>, Closeable {
+	private final List<Closeable> list;
+
+	private Closer(Closeable... other) {
+		list = new ArrayList<>(Arrays.asList(other));
+	}
+
+	/**
+	 * create closer with closeables
+	 * @param other closeables
+	 * @return closer
+	 */
+	public static Closer of(Closeable... other) {
+		return new Closer(other);
+	}
+
+	/**
+	 * add closeables to this closer
+	 *
+	 * @param other closeables
+	 * @return this
+	 */
+	public Closer with(Closeable... other) {
+		return with(List.of(other));
+	}
+
+	/**
+	 * add closeables iterable to this closer
+	 *
+	 * @param iterable closeables
+	 * @return this
+	 */
+	public Closer with(Iterable<? extends Closeable> iterable) {
+		list.addAll(StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toList()));
+		return this;
+	}
+
+	@Override
+	public Iterator<Closeable> iterator() {
+		return list.iterator();
+	}
+
+	@Override
+	public void close() throws IOException {
+		IOUtil.closeAll(list);
+	}
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMergerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMergerTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.rdfhdt.hdt.compact.sequence.DynamicSequence;
 import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.DictionaryPrivate;
 import org.rdfhdt.hdt.dictionary.DictionarySection;
@@ -27,292 +26,286 @@ import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
 import org.rdfhdt.hdt.util.io.Closer;
 import org.rdfhdt.hdt.util.string.ByteString;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class KCatMergerTest extends AbstractMapMemoryTest {
-	@Parameterized.Parameters(name = "multi: {0}, unicode: {1}, map: {2}")
-	public static Collection<Object[]> params() {
-		return Stream.of(false, true).flatMap(
-				multi -> Stream.of(false, true).flatMap(
-						unicode -> Stream.of(false, true).map(
-								map -> new Object[]{multi, unicode, map}
-						)
-				)
-		).collect(Collectors.toList());
-	}
+    @Parameterized.Parameters(name = "multi: {0}, unicode: {1}, map: {2}, count: {3}")
+    public static Collection<Object[]> params() {
+        return Stream.of(false, true).flatMap(
+                multi -> Stream.of(false, true).flatMap(
+                        unicode -> Stream.of(false, true).flatMap(
+                                map -> Stream.of(2, 10).map(
+                                        kcat -> new Object[]{multi, unicode, map, kcat}
+                                )
+                        )
+                )
+        ).collect(Collectors.toList());
+    }
 
-	@Parameterized.Parameter
-	public boolean multi;
-	@Parameterized.Parameter(1)
-	public boolean unicode;
-	@Parameterized.Parameter(2)
-	public boolean map;
+    @Parameterized.Parameter
+    public boolean multi;
+    @Parameterized.Parameter(1)
+    public boolean unicode;
+    @Parameterized.Parameter(2)
+    public boolean map;
+    @Parameterized.Parameter(3)
+    public int kcat;
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
-	private void writeSection(DictionarySection sec, OutputStream stream) throws IOException {
-		((DictionarySectionPrivate) sec).save(stream, null);
-	}
+    private void writeSection(DictionarySection sec, OutputStream stream) throws IOException {
+        ((DictionarySectionPrivate) sec).save(stream, null);
+    }
 
-	private DictionarySection loadSection(InputStream stream) throws IOException {
-		PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
-		section.load(stream, null);
-		return section;
-	}
+    private DictionarySection loadSection(InputStream stream) throws IOException {
+        PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
+        section.load(stream, null);
+        return section;
+    }
 
-	private Map<? extends CharSequence, DictionarySection> loadMultiSection(List<CharSequence> seq, InputStream stream) throws IOException {
-		Map<ByteString, DictionarySection> sectionMap = new TreeMap<>();
-		for (CharSequence key : seq) {
-			PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
-			section.load(stream, null);
-			sectionMap.put(ByteString.of(key), section);
-		}
-		return sectionMap;
-	}
+    private Map<? extends CharSequence, DictionarySection> loadMultiSection(List<CharSequence> seq, InputStream stream) throws IOException {
+        Map<ByteString, DictionarySection> sectionMap = new TreeMap<>();
+        for (CharSequence key : seq) {
+            PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
+            section.load(stream, null);
+            sectionMap.put(ByteString.of(key), section);
+        }
+        return sectionMap;
+    }
 
-	@Test
-	public void mergerTest() throws ParserException, IOException, InterruptedException {
-		Path root = tempDir.getRoot().toPath();
-		try {
-			int count = 10;
-			HDTOptions spec = new HDTOptionsBase();
+    @Test
+    public void mergerTest() throws ParserException, IOException, InterruptedException {
+        Path root = tempDir.getRoot().toPath();
+        try {
+            HDTOptions spec = new HDTOptionsBase();
 
-			if (multi) {
-				spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
-				spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
-			}
+            if (multi) {
+                spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
+                spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
+            }
 
-			// create "count" fake HDTs
-			LargeFakeDataSetStreamSupplier s = LargeFakeDataSetStreamSupplier
-					.createSupplierWithMaxTriples(1000, 42)
-					.withMaxElementSplit(50)
-					.withUnicode(unicode);
+            // create "kcat" fake HDTs
+            LargeFakeDataSetStreamSupplier s = LargeFakeDataSetStreamSupplier
+                    .createSupplierWithMaxTriples(1000, 42)
+                    .withMaxElementSplit(50)
+                    .withUnicode(unicode);
 
-			List<String> hdts = new ArrayList<>();
-			for (int i = 0; i < count; i++) {
-				String location = root.resolve("hdt" + i + ".hdt").toAbsolutePath().toString();
-				hdts.add(location);
-				s.createAndSaveFakeHDT(spec, location);
-			}
+            List<String> hdts = new ArrayList<>();
+            for (int i = 0; i < kcat; i++) {
+                String location = root.resolve("hdt" + i + ".hdt").toAbsolutePath().toString();
+                hdts.add(location);
+                s.createAndSaveFakeHDT(spec, location);
+            }
 
-			// create the excepted HDT from previous algorithm
-			Path fatcathdt = root.resolve("fatcat.hdt");
-			LargeFakeDataSetStreamSupplier
-					.createSupplierWithMaxTriples(1000 * count, 42)
-					.withMaxElementSplit(50)
-					.withUnicode(unicode)
-					.createAndSaveFakeHDT(spec, fatcathdt.toAbsolutePath().toString());
+            // create the excepted HDT from previous algorithm
+            Path fatcathdt = root.resolve("fatcat.hdt");
+            LargeFakeDataSetStreamSupplier
+                    .createSupplierWithMaxTriples(1000L * kcat, 42)
+                    .withMaxElementSplit(50)
+                    .withUnicode(unicode)
+                    .createAndSaveFakeHDT(spec, fatcathdt.toAbsolutePath().toString());
 
-			// create dictionary and write sections
-			Path dictFile = root.resolve("dict");
-			List<CharSequence> sub = new ArrayList<>();
-			try (KCatImpl impl = new KCatImpl(hdts, spec, null)) {
-				try (KCatMerger merger = impl.createMerger(null)) {
-					assertEquals(multi, merger.typedHDT);
-					merger.startMerger();
-					// create
-					DictionaryPrivate dict = merger.buildDictionary();
-					try (OutputStream stream = new BufferedOutputStream(Files.newOutputStream(dictFile))) {
-						writeSection(dict.getShared(), stream);
-						writeSection(dict.getSubjects(), stream);
-						writeSection(dict.getPredicates(), stream);
-						if (multi) {
-							for (Map.Entry<? extends CharSequence, DictionarySection> e : dict.getAllObjects().entrySet()) {
-								CharSequence key = e.getKey();
-								sub.add(key);
-								DictionarySection sec = e.getValue();
-								writeSection(sec, stream);
-							}
-						} else {
-							writeSection(dict.getObjects(), stream);
-						}
-					}
+            // create dictionary and write sections
+            Path dictFile = root.resolve("dict");
+            List<CharSequence> sub = new ArrayList<>();
+            try (KCatImpl impl = new KCatImpl(hdts, spec, null)) {
+                try (KCatMerger merger = impl.createMerger(null)) {
+                    assertEquals(multi, merger.typedHDT);
+                    merger.startMerger();
+                    // create
+                    DictionaryPrivate dict = merger.buildDictionary();
+                    try (OutputStream stream = new BufferedOutputStream(Files.newOutputStream(dictFile))) {
+                        writeSection(dict.getShared(), stream);
+                        writeSection(dict.getSubjects(), stream);
+                        writeSection(dict.getPredicates(), stream);
+                        if (multi) {
+                            for (Map.Entry<? extends CharSequence, DictionarySection> e : dict.getAllObjects().entrySet()) {
+                                CharSequence key = e.getKey();
+                                sub.add(key);
+                                DictionarySection sec = e.getValue();
+                                writeSection(sec, stream);
+                            }
+                        } else {
+                            writeSection(dict.getObjects(), stream);
+                        }
+                    }
 
-					// check if all the dynamic sequences are filled
+                    // check if all the dynamic sequences are filled
 
-					SyncSeq[] sms = merger.subjectsMaps;
-					SyncSeq[] pms = merger.predicatesMaps;
-					SyncSeq[] oms = merger.objectsMaps;
+                    SyncSeq[] sms = merger.subjectsMaps;
+                    SyncSeq[] pms = merger.predicatesMaps;
+                    SyncSeq[] oms = merger.objectsMaps;
 
-					AtomicLong[] objectCounts = merger.countObject;
-					AtomicLong[] subjectCounts = merger.countSubject;
+                    AtomicLong[] objectCounts = merger.countObject;
+                    AtomicLong[] subjectCounts = merger.countSubject;
 
-					for (int hdtId = 1; hdtId <= impl.hdts.length; hdtId++) {
-						HDT hdt = impl.hdts[hdtId - 1];
-						SyncSeq sm = sms[hdtId - 1];
-						SyncSeq pm = pms[hdtId - 1];
-						SyncSeq om = oms[hdtId - 1];
+                    for (int hdtId = 1; hdtId <= impl.hdts.length; hdtId++) {
+                        HDT hdt = impl.hdts[hdtId - 1];
+                        SyncSeq sm = sms[hdtId - 1];
+                        SyncSeq pm = pms[hdtId - 1];
+                        SyncSeq om = oms[hdtId - 1];
 
-						AtomicLong objectCount = objectCounts[hdtId - 1];
-						AtomicLong subjectCount = subjectCounts[hdtId - 1];
+                        AtomicLong objectCount = objectCounts[hdtId - 1];
+                        AtomicLong subjectCount = subjectCounts[hdtId - 1];
 
-						long shared = hdt.getDictionary().getShared().getNumberOfElements();
-						long subjects = hdt.getDictionary().getSubjects().getNumberOfElements();
-						long predicates = hdt.getDictionary().getPredicates().getNumberOfElements();
-						long objects =
-								multi ? hdt.getDictionary().getAllObjects().values().stream().mapToLong(DictionarySection::getNumberOfElements).sum()
-										: hdt.getDictionary().getObjects().getNumberOfElements();
+                        long shared = hdt.getDictionary().getShared().getNumberOfElements();
+                        long subjects = hdt.getDictionary().getSubjects().getNumberOfElements();
+                        long predicates = hdt.getDictionary().getPredicates().getNumberOfElements();
+                        long objects =
+                                multi ? hdt.getDictionary().getAllObjects().values().stream().mapToLong(DictionarySection::getNumberOfElements).sum()
+                                        : hdt.getDictionary().getObjects().getNumberOfElements();
 
-						assertEquals(shared + objects, objectCount.get());
-						assertEquals(shared + subjects, subjectCount.get());
+                        assertEquals(shared + objects, objectCount.get());
+                        assertEquals(shared + subjects, subjectCount.get());
 
-						for (long i = 1; i <= shared; i++) {
-							long sv = sm.get(i);
-							long ov = om.get(i);
-							if (merger.removeHeader(sv) == 0) {
-								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing shared subject #" + i + "/" + shared + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.SUBJECT));
-							}
-							if (merger.removeHeader(ov) == 0) {
-								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing shared object #" + i + "/" + shared + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.OBJECT));
-							}
+                        for (long i = 1; i <= shared; i++) {
+                            long sv = sm.get(i);
+                            long ov = om.get(i);
+                            if (merger.removeHeader(sv) == 0) {
+                                fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing shared subject #" + i + "/" + shared + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.SUBJECT));
+                            }
+                            if (merger.removeHeader(ov) == 0) {
+                                fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing shared object #" + i + "/" + shared + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.OBJECT));
+                            }
 
-							assertEquals("shared element not mapped to the same object", ov, sv);
-							assertTrue("shared mapped element isn't shared", merger.isShared(ov));
-						}
+                            assertEquals("shared element not mapped to the same object", ov, sv);
+                            assertTrue("shared mapped element isn't shared", merger.isShared(ov));
+                        }
 
-						for (long i = 1; i <= subjects; i++) {
-							if (merger.removeHeader(sm.get(shared + i)) == 0) {
-								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing subject #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i + shared, TripleComponentRole.SUBJECT));
-							}
-						}
+                        for (long i = 1; i <= subjects; i++) {
+                            if (merger.removeHeader(sm.get(shared + i)) == 0) {
+                                fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing subject #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i + shared, TripleComponentRole.SUBJECT));
+                            }
+                        }
 
-						for (long i = 1; i <= objects; i++) {
-							if (merger.removeHeader(om.get(shared + i)) == 0) {
-								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing object #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i + shared, TripleComponentRole.OBJECT));
-							}
-						}
+                        for (long i = 1; i <= objects; i++) {
+                            if (merger.removeHeader(om.get(shared + i)) == 0) {
+                                fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing object #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i + shared, TripleComponentRole.OBJECT));
+                            }
+                        }
 
-						for (long i = 1; i <= predicates; i++) {
-							if (pm.get(i) == 0) {
-								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing predicate #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.PREDICATE));
-							}
-						}
+                        for (long i = 1; i <= predicates; i++) {
+                            if (pm.get(i) == 0) {
+                                fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing predicate #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.PREDICATE));
+                            }
+                        }
 
-					}
-				}
-			}
-			try (InputStream stream = new BufferedInputStream(Files.newInputStream(dictFile))) {
-				// read the sections
-				try (DictionarySection sh = loadSection(stream);
-					 DictionarySection su = loadSection(stream);
-					 DictionarySection pr = loadSection(stream)) {
-					Map<? extends CharSequence, DictionarySection> dictionarySectionMap;
-					DictionarySection ob;
-					if (multi) {
-						ob = null;
-						dictionarySectionMap = loadMultiSection(sub, stream);
-					} else {
-						dictionarySectionMap = Map.of();
-						ob = loadSection(stream);
-					}
-					try {
-						// map the excepted hdt
-						try (HDT exceptedHDT = HDTManager.mapHDT(fatcathdt.toAbsolutePath().toString())) {
-							Dictionary exceptedDict = exceptedHDT.getDictionary();
-							assertNotEquals("Invalid test, shared section empty", 0, exceptedHDT.getDictionary().getShared().getNumberOfElements());
-							// assert equals between the dictionaries
-							HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Shared", exceptedDict.getShared(), sh);
-							HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Subjects", exceptedDict.getSubjects(), su);
-							HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Predicates", exceptedDict.getPredicates(), pr);
-							if (multi) {
-								Map<? extends CharSequence, DictionarySection> exceptedDictSub = exceptedDict.getAllObjects();
-								dictionarySectionMap.forEach((key, sec) -> {
-									DictionarySection subSec = exceptedDictSub.get(key);
-									assertNotNull("sub#" + key + " wasn't found", subSec);
-									HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Section#" + key, subSec, sec);
-								});
-							} else {
-								assert ob != null;
-								HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Objects", exceptedDict.getObjects(), ob);
-							}
-						}
-					} finally {
-						Closer
-								.of(ob)
-								.with(dictionarySectionMap.values())
-								.close();
-					}
-				}
-			}
-		} finally {
-			PathUtils.deleteDirectory(root);
-		}
-	}
+                    }
+                }
+            }
+            try (InputStream stream = new BufferedInputStream(Files.newInputStream(dictFile))) {
+                // read the sections
+                try (DictionarySection sh = loadSection(stream);
+                     DictionarySection su = loadSection(stream);
+                     DictionarySection pr = loadSection(stream)) {
+                    Map<? extends CharSequence, DictionarySection> dictionarySectionMap;
+                    DictionarySection ob;
+                    if (multi) {
+                        ob = null;
+                        dictionarySectionMap = loadMultiSection(sub, stream);
+                    } else {
+                        dictionarySectionMap = Map.of();
+                        ob = loadSection(stream);
+                    }
+                    try {
+                        // map the excepted hdt
+                        try (HDT exceptedHDT = HDTManager.mapHDT(fatcathdt.toAbsolutePath().toString())) {
+                            Dictionary exceptedDict = exceptedHDT.getDictionary();
+                            assertNotEquals("Invalid test, shared section empty", 0, exceptedHDT.getDictionary().getShared().getNumberOfElements());
+                            // assert equals between the dictionaries
+                            HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Shared", exceptedDict.getShared(), sh);
+                            HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Subjects", exceptedDict.getSubjects(), su);
+                            HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Predicates", exceptedDict.getPredicates(), pr);
+                            if (multi) {
+                                Map<? extends CharSequence, DictionarySection> exceptedDictSub = exceptedDict.getAllObjects();
+                                dictionarySectionMap.forEach((key, sec) -> {
+                                    DictionarySection subSec = exceptedDictSub.get(key);
+                                    assertNotNull("sub#" + key + " wasn't found", subSec);
+                                    HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Section#" + key, subSec, sec);
+                                });
+                            } else {
+                                assert ob != null;
+                                HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Objects", exceptedDict.getObjects(), ob);
+                            }
+                        }
+                    } finally {
+                        Closer
+                                .of(ob)
+                                .with(dictionarySectionMap.values())
+                                .close();
+                    }
+                }
+            }
+        } finally {
+            PathUtils.deleteDirectory(root);
+        }
+    }
 
-	@Test
-	public void catTest() throws ParserException, IOException, NotFoundException {
-		Path root = tempDir.getRoot().toPath();
-		try {
-			// number of HDTs
-			int count = 10;
-			long countPerHDT = 1000;
+    @Test
+    public void catTest() throws ParserException, IOException, NotFoundException {
+        Path root = tempDir.getRoot().toPath();
+        try {
+            // number of HDTs
+            int countPerHDT = 1000;
+            Random rnd = new Random(58);
 
-			// create the config
-			HDTOptions spec = new HDTOptionsBase();
-			if (multi) {
-				spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
-				spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
-			}
+            // create the config
+            HDTOptions spec = new HDTOptionsBase();
+            if (multi) {
+                spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
+                spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
+            }
 
-			if (map) {
-				spec.set(HDTOptionsKeys.HDTCAT_FUTURE_LOCATION, root.resolve("futurehc.hdt").toAbsolutePath());
-			}
+            if (map) {
+                spec.set(HDTOptionsKeys.HDTCAT_FUTURE_LOCATION, root.resolve("futurehc.hdt").toAbsolutePath());
+            }
 
-			// create "count" fake HDTs
-			LargeFakeDataSetStreamSupplier s = LargeFakeDataSetStreamSupplier
-					.createSupplierWithMaxTriples(countPerHDT, 42)
-					.withMaxElementSplit(50)
-					.withUnicode(unicode);
+            // create "kcat" fake HDTs
+            LargeFakeDataSetStreamSupplier s = LargeFakeDataSetStreamSupplier
+                    .createInfinite(42)
+                    .withMaxElementSplit(50)
+                    .withUnicode(unicode);
 
-			List<String> hdts = new ArrayList<>();
-			for (int i = 0; i < count; i++) {
-				String location = root.resolve("hdt" + i + ".hdt").toAbsolutePath().toString();
-				hdts.add(location);
-				s.createAndSaveFakeHDT(spec, location);
-			}
+            long size = 0;
+            List<String> hdts = new ArrayList<>();
+            for (int i = 0; i < kcat; i++) {
+                String location = root.resolve("hdt" + i + ".hdt").toAbsolutePath().toString();
+                hdts.add(location);
+                int hdtSize = countPerHDT / 2 + rnd.nextInt(countPerHDT);
+                size += hdtSize;
+                s.withMaxTriples(hdtSize)
+                        .createAndSaveFakeHDT(spec, location);
+            }
 
-			// create the excepted HDT from previous algorithm
-			Path fatcathdt = root.resolve("fatcat.hdt");
-			LargeFakeDataSetStreamSupplier
-					.createSupplierWithMaxTriples(countPerHDT * count, 42)
-					.withMaxElementSplit(50)
-					.withUnicode(unicode)
-					.createAndSaveFakeHDT(spec, fatcathdt.toAbsolutePath().toString());
+            // create the excepted HDT from previous algorithm
+            Path fatcathdt = root.resolve("fatcat.hdt");
+            s.reset();
+            s.withMaxTriples(size)
+                    .createAndSaveFakeHDT(spec, fatcathdt.toAbsolutePath().toString());
 
-			// create dictionary and write sections
-			// map the excepted hdt
-			try (HDT actualHDT = HDTManager.catHDT(hdts, spec, null)) {
-				try (HDT exceptedHDT = HDTManager.mapHDT(fatcathdt.toAbsolutePath().toString())) {
-					// assert equals between the dictionaries
-					assertNotEquals(0, actualHDT.getDictionary().getShared().getNumberOfElements());
-					HDTManagerTest.HDTManagerTestBase.assertEqualsHDT(exceptedHDT, actualHDT);
-				}
-			}
-		} finally {
-			PathUtils.deleteDirectory(root);
-		}
-	}
+            // create dictionary and write sections
+            // map the excepted hdt
+            try (HDT actualHDT = HDTManager.catHDT(hdts, spec, null)) {
+                try (HDT exceptedHDT = HDTManager.mapHDT(fatcathdt.toAbsolutePath().toString())) {
+                    // assert equals between the dictionaries
+                    assertNotEquals(0, actualHDT.getDictionary().getShared().getNumberOfElements());
+                    HDTManagerTest.HDTManagerTestBase.assertEqualsHDT(exceptedHDT, actualHDT);
+                }
+            }
+        } finally {
+            PathUtils.deleteDirectory(root);
+        }
+    }
 
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMergerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMergerTest.java
@@ -1,0 +1,318 @@
+package org.rdfhdt.hdt.dictionary.impl.kcat;
+
+import org.apache.commons.io.file.PathUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.rdfhdt.hdt.compact.sequence.DynamicSequence;
+import org.rdfhdt.hdt.dictionary.Dictionary;
+import org.rdfhdt.hdt.dictionary.DictionaryPrivate;
+import org.rdfhdt.hdt.dictionary.DictionarySection;
+import org.rdfhdt.hdt.dictionary.DictionarySectionPrivate;
+import org.rdfhdt.hdt.dictionary.impl.section.PFCDictionarySection;
+import org.rdfhdt.hdt.enums.TripleComponentRole;
+import org.rdfhdt.hdt.exceptions.NotFoundException;
+import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.hdt.HDTManagerTest;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsBase;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
+import org.rdfhdt.hdt.util.LargeFakeDataSetStreamSupplier;
+import org.rdfhdt.hdt.util.concurrent.SyncSeq;
+import org.rdfhdt.hdt.util.io.AbstractMapMemoryTest;
+import org.rdfhdt.hdt.util.io.Closer;
+import org.rdfhdt.hdt.util.string.ByteString;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class KCatMergerTest extends AbstractMapMemoryTest {
+	@Parameterized.Parameters(name = "multi: {0}, unicode: {1}, map: {2}")
+	public static Collection<Object[]> params() {
+		return Stream.of(false, true).flatMap(
+				multi -> Stream.of(false, true).flatMap(
+						unicode -> Stream.of(false, true).map(
+								map -> new Object[]{multi, unicode, map}
+						)
+				)
+		).collect(Collectors.toList());
+	}
+
+	@Parameterized.Parameter
+	public boolean multi;
+	@Parameterized.Parameter(1)
+	public boolean unicode;
+	@Parameterized.Parameter(2)
+	public boolean map;
+
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	private void writeSection(DictionarySection sec, OutputStream stream) throws IOException {
+		((DictionarySectionPrivate) sec).save(stream, null);
+	}
+
+	private DictionarySection loadSection(InputStream stream) throws IOException {
+		PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
+		section.load(stream, null);
+		return section;
+	}
+
+	private Map<? extends CharSequence, DictionarySection> loadMultiSection(List<CharSequence> seq, InputStream stream) throws IOException {
+		Map<ByteString, DictionarySection> sectionMap = new TreeMap<>();
+		for (CharSequence key : seq) {
+			PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
+			section.load(stream, null);
+			sectionMap.put(ByteString.of(key), section);
+		}
+		return sectionMap;
+	}
+
+	@Test
+	public void mergerTest() throws ParserException, IOException, InterruptedException {
+		Path root = tempDir.getRoot().toPath();
+		try {
+			int count = 10;
+			HDTOptions spec = new HDTOptionsBase();
+
+			if (multi) {
+				spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
+				spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
+			}
+
+			// create "count" fake HDTs
+			LargeFakeDataSetStreamSupplier s = LargeFakeDataSetStreamSupplier
+					.createSupplierWithMaxTriples(1000, 42)
+					.withMaxElementSplit(50)
+					.withUnicode(unicode);
+
+			List<String> hdts = new ArrayList<>();
+			for (int i = 0; i < count; i++) {
+				String location = root.resolve("hdt" + i + ".hdt").toAbsolutePath().toString();
+				hdts.add(location);
+				s.createAndSaveFakeHDT(spec, location);
+			}
+
+			// create the excepted HDT from previous algorithm
+			Path fatcathdt = root.resolve("fatcat.hdt");
+			LargeFakeDataSetStreamSupplier
+					.createSupplierWithMaxTriples(1000 * count, 42)
+					.withMaxElementSplit(50)
+					.withUnicode(unicode)
+					.createAndSaveFakeHDT(spec, fatcathdt.toAbsolutePath().toString());
+
+			// create dictionary and write sections
+			Path dictFile = root.resolve("dict");
+			List<CharSequence> sub = new ArrayList<>();
+			try (KCatImpl impl = new KCatImpl(hdts, spec, null)) {
+				try (KCatMerger merger = impl.createMerger(null)) {
+					assertEquals(multi, merger.typedHDT);
+					merger.startMerger();
+					// create
+					DictionaryPrivate dict = merger.buildDictionary();
+					try (OutputStream stream = new BufferedOutputStream(Files.newOutputStream(dictFile))) {
+						writeSection(dict.getShared(), stream);
+						writeSection(dict.getSubjects(), stream);
+						writeSection(dict.getPredicates(), stream);
+						if (multi) {
+							for (Map.Entry<? extends CharSequence, DictionarySection> e : dict.getAllObjects().entrySet()) {
+								CharSequence key = e.getKey();
+								sub.add(key);
+								DictionarySection sec = e.getValue();
+								writeSection(sec, stream);
+							}
+						} else {
+							writeSection(dict.getObjects(), stream);
+						}
+					}
+
+					// check if all the dynamic sequences are filled
+
+					SyncSeq[] sms = merger.subjectsMaps;
+					SyncSeq[] pms = merger.predicatesMaps;
+					SyncSeq[] oms = merger.objectsMaps;
+
+					AtomicLong[] objectCounts = merger.countObject;
+					AtomicLong[] subjectCounts = merger.countSubject;
+
+					for (int hdtId = 1; hdtId <= impl.hdts.length; hdtId++) {
+						HDT hdt = impl.hdts[hdtId - 1];
+						SyncSeq sm = sms[hdtId - 1];
+						SyncSeq pm = pms[hdtId - 1];
+						SyncSeq om = oms[hdtId - 1];
+
+						AtomicLong objectCount = objectCounts[hdtId - 1];
+						AtomicLong subjectCount = subjectCounts[hdtId - 1];
+
+						long shared = hdt.getDictionary().getShared().getNumberOfElements();
+						long subjects = hdt.getDictionary().getSubjects().getNumberOfElements();
+						long predicates = hdt.getDictionary().getPredicates().getNumberOfElements();
+						long objects =
+								multi ? hdt.getDictionary().getAllObjects().values().stream().mapToLong(DictionarySection::getNumberOfElements).sum()
+										: hdt.getDictionary().getObjects().getNumberOfElements();
+
+						assertEquals(shared + objects, objectCount.get());
+						assertEquals(shared + subjects, subjectCount.get());
+
+						for (long i = 1; i <= shared; i++) {
+							long sv = sm.get(i);
+							long ov = om.get(i);
+							if (merger.removeHeader(sv) == 0) {
+								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing shared subject #" + i + "/" + shared + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.SUBJECT));
+							}
+							if (merger.removeHeader(ov) == 0) {
+								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing shared object #" + i + "/" + shared + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.OBJECT));
+							}
+
+							assertEquals("shared element not mapped to the same object", ov, sv);
+							assertTrue("shared mapped element isn't shared", merger.isShared(ov));
+						}
+
+						for (long i = 1; i <= subjects; i++) {
+							if (merger.removeHeader(sm.get(shared + i)) == 0) {
+								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing subject #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i + shared, TripleComponentRole.SUBJECT));
+							}
+						}
+
+						for (long i = 1; i <= objects; i++) {
+							if (merger.removeHeader(om.get(shared + i)) == 0) {
+								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing object #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i + shared, TripleComponentRole.OBJECT));
+							}
+						}
+
+						for (long i = 1; i <= predicates; i++) {
+							if (pm.get(i) == 0) {
+								fail("HDT #" + hdtId + "/" + impl.hdts.length + " Missing predicate #" + i + "/" + subjects + " for node: " + hdt.getDictionary().idToString(i, TripleComponentRole.PREDICATE));
+							}
+						}
+
+					}
+				}
+			}
+			try (InputStream stream = new BufferedInputStream(Files.newInputStream(dictFile))) {
+				// read the sections
+				try (DictionarySection sh = loadSection(stream);
+					 DictionarySection su = loadSection(stream);
+					 DictionarySection pr = loadSection(stream)) {
+					Map<? extends CharSequence, DictionarySection> dictionarySectionMap;
+					DictionarySection ob;
+					if (multi) {
+						ob = null;
+						dictionarySectionMap = loadMultiSection(sub, stream);
+					} else {
+						dictionarySectionMap = Map.of();
+						ob = loadSection(stream);
+					}
+					try {
+						// map the excepted hdt
+						try (HDT exceptedHDT = HDTManager.mapHDT(fatcathdt.toAbsolutePath().toString())) {
+							Dictionary exceptedDict = exceptedHDT.getDictionary();
+							assertNotEquals("Invalid test, shared section empty", 0, exceptedHDT.getDictionary().getShared().getNumberOfElements());
+							// assert equals between the dictionaries
+							HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Shared", exceptedDict.getShared(), sh);
+							HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Subjects", exceptedDict.getSubjects(), su);
+							HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Predicates", exceptedDict.getPredicates(), pr);
+							if (multi) {
+								Map<? extends CharSequence, DictionarySection> exceptedDictSub = exceptedDict.getAllObjects();
+								dictionarySectionMap.forEach((key, sec) -> {
+									DictionarySection subSec = exceptedDictSub.get(key);
+									assertNotNull("sub#" + key + " wasn't found", subSec);
+									HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Section#" + key, subSec, sec);
+								});
+							} else {
+								assert ob != null;
+								HDTManagerTest.HDTManagerTestBase.assertEqualsHDT("Objects", exceptedDict.getObjects(), ob);
+							}
+						}
+					} finally {
+						Closer
+								.of(ob)
+								.with(dictionarySectionMap.values())
+								.close();
+					}
+				}
+			}
+		} finally {
+			PathUtils.deleteDirectory(root);
+		}
+	}
+
+	@Test
+	public void catTest() throws ParserException, IOException, NotFoundException {
+		Path root = tempDir.getRoot().toPath();
+		try {
+			// number of HDTs
+			int count = 10;
+			long countPerHDT = 1000;
+
+			// create the config
+			HDTOptions spec = new HDTOptionsBase();
+			if (multi) {
+				spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
+				spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
+			}
+
+			if (map) {
+				spec.set(HDTOptionsKeys.HDTCAT_FUTURE_LOCATION, root.resolve("futurehc.hdt").toAbsolutePath());
+			}
+
+			// create "count" fake HDTs
+			LargeFakeDataSetStreamSupplier s = LargeFakeDataSetStreamSupplier
+					.createSupplierWithMaxTriples(countPerHDT, 42)
+					.withMaxElementSplit(50)
+					.withUnicode(unicode);
+
+			List<String> hdts = new ArrayList<>();
+			for (int i = 0; i < count; i++) {
+				String location = root.resolve("hdt" + i + ".hdt").toAbsolutePath().toString();
+				hdts.add(location);
+				s.createAndSaveFakeHDT(spec, location);
+			}
+
+			// create the excepted HDT from previous algorithm
+			Path fatcathdt = root.resolve("fatcat.hdt");
+			LargeFakeDataSetStreamSupplier
+					.createSupplierWithMaxTriples(countPerHDT * count, 42)
+					.withMaxElementSplit(50)
+					.withUnicode(unicode)
+					.createAndSaveFakeHDT(spec, fatcathdt.toAbsolutePath().toString());
+
+			// create dictionary and write sections
+			// map the excepted hdt
+			try (HDT actualHDT = HDTManager.catHDT(hdts, spec, null)) {
+				try (HDT exceptedHDT = HDTManager.mapHDT(fatcathdt.toAbsolutePath().toString())) {
+					// assert equals between the dictionaries
+					assertNotEquals(0, actualHDT.getDictionary().getShared().getNumberOfElements());
+					HDTManagerTest.HDTManagerTestBase.assertEqualsHDT(exceptedHDT, actualHDT);
+				}
+			}
+		} finally {
+			PathUtils.deleteDirectory(root);
+		}
+	}
+
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/HDTManagerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/HDTManagerTest.java
@@ -15,6 +15,7 @@ import org.rdfhdt.hdt.compact.bitmap.ModifiableBitmap;
 import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.DictionarySection;
 import org.rdfhdt.hdt.dictionary.impl.MultipleBaseDictionary;
+import org.rdfhdt.hdt.dictionary.impl.kcat.LocatedIndexedNode;
 import org.rdfhdt.hdt.enums.CompressionType;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.NotFoundException;
@@ -156,8 +157,9 @@ public class HDTManagerTest {
 
 				TripleID expectedTriple = expectedIt.next();
 				TripleID actualTriple = actualIt.next();
-				assertEquals(expectedIt.getLastTriplePosition(), actualIt.getLastTriplePosition());
-				assertEquals(expectedTriple, actualTriple);
+				long location = expectedIt.getLastTriplePosition();
+				assertEquals("The tripleID location doesn't match", location, actualIt.getLastTriplePosition());
+				assertEquals("The tripleID #" + location + " doesn't match", expectedTriple, actualTriple);
 			}
 			assertFalse(actualIt.hasNext());
 
@@ -236,11 +238,10 @@ public class HDTManagerTest {
 			});
 		}
 
-		protected static void assertEqualsHDT(String section, DictionarySection excepted, DictionarySection actual) {
+		public static void assertEqualsHDT(String section, DictionarySection excepted, DictionarySection actual) {
 			assertEquals("sizes of section " + section + " aren't the same!", excepted.getNumberOfElements(), actual.getNumberOfElements());
 			Iterator<? extends CharSequence> itEx = excepted.getSortedEntries();
 			Iterator<? extends CharSequence> itAc = actual.getSortedEntries();
-			assertEquals("dictionary section sizes don't match", excepted.getNumberOfElements(), actual.getNumberOfElements());
 
 			while (itEx.hasNext()) {
 				assertTrue("dictionary section " + section + " is less big than excepted", itAc.hasNext());

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/HDTManagerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/HDTManagerTest.java
@@ -15,11 +15,9 @@ import org.rdfhdt.hdt.compact.bitmap.ModifiableBitmap;
 import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.DictionarySection;
 import org.rdfhdt.hdt.dictionary.impl.MultipleBaseDictionary;
-import org.rdfhdt.hdt.dictionary.impl.kcat.LocatedIndexedNode;
 import org.rdfhdt.hdt.enums.CompressionType;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.NotFoundException;
-import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.exceptions.ParserException;
 import org.rdfhdt.hdt.hdt.impl.diskimport.CompressionResult;
 import org.rdfhdt.hdt.iterator.utils.PipedCopyIterator;
@@ -30,7 +28,6 @@ import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.rdf.RDFFluxStop;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.triples.IteratorTripleID;
-import org.rdfhdt.hdt.triples.IteratorTripleString;
 import org.rdfhdt.hdt.triples.TripleID;
 import org.rdfhdt.hdt.triples.TripleString;
 import org.rdfhdt.hdt.triples.impl.utils.HDTTestUtils;
@@ -47,7 +44,6 @@ import org.rdfhdt.hdt.util.string.ReplazableString;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -572,14 +568,16 @@ public class HDTManagerTest {
 	@RunWith(Parameterized.class)
 	public static class DynamicCatTreeTest extends HDTManagerTestBase {
 
-		@Parameterized.Parameters(name = "{5} - {0}")
+		@Parameterized.Parameters(name = "{5} - {0} kcat: {8}")
 		public static Collection<Object[]> params() {
 			List<Object[]> params = new ArrayList<>();
 			for (String[] dict : diskDict()) {
-				params.add(new Object[]{"base", SIZE_VALUE * 16, 20, 50, false, dict[0], dict[1], SIZE_VALUE});
-				params.add(new Object[]{"duplicates", SIZE_VALUE * 16, 10, 50, false, dict[0], dict[1], SIZE_VALUE});
-				params.add(new Object[]{"large-literals", SIZE_VALUE * 4, 20, 250, false, dict[0], dict[1], SIZE_VALUE});
-				params.add(new Object[]{"quiet", SIZE_VALUE * 16, 10, 50, false, dict[0], dict[1], SIZE_VALUE});
+				for (long kcat : new long[]{2, 10, 0}) {
+					params.add(new Object[]{"base", SIZE_VALUE * 16, 20, 50, false, dict[0], dict[1], SIZE_VALUE, kcat});
+					params.add(new Object[]{"duplicates", SIZE_VALUE * 16, 10, 50, false, dict[0], dict[1], SIZE_VALUE, kcat});
+					params.add(new Object[]{"large-literals", SIZE_VALUE * 4, 20, 250, false, dict[0], dict[1], SIZE_VALUE, kcat});
+					params.add(new Object[]{"quiet", SIZE_VALUE * 16, 10, 50, false, dict[0], dict[1], SIZE_VALUE, kcat});
+				}
 			}
 			return params;
 		}
@@ -600,11 +598,19 @@ public class HDTManagerTest {
 		public String tempDictionaryType;
 		@Parameterized.Parameter(7)
 		public long size;
+		@Parameterized.Parameter(8)
+		public long kCat;
+
 
 		@Before
 		public void setupSpecs() {
 			spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, dictionaryType);
 			spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, tempDictionaryType);
+			spec.set(HDTOptionsKeys.PROFILER_KEY, true);
+
+			if (kCat != 0) {
+				spec.set(HDTOptionsKeys.LOADER_CATTREE_KCAT, kCat);
+			}
 		}
 
 		@Test
@@ -993,11 +999,6 @@ public class HDTManagerTest {
 				System.out.println(watch.stopAndShow());
 				System.out.println(hdt.getTriples().getNumberOfElements());
 			}
-		}
-
-		@Test
-		public void zqdz() {
-			System.out.println("\255".getBytes(StandardCharsets.UTF_8)[0] & 0xFF);
 		}
 
 		@Test

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtDiff/HdtDiffTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdtDiff/HdtDiffTest.java
@@ -173,7 +173,7 @@ public class HdtDiffTest extends AbstractMapMemoryTest {
 
         try {
             its1 = hdt1.search("", "", "");
-            its2 = hdt1.search("", "", "");
+            its2 = hdt2.search("", "", "");
         } catch (NotFoundException e) {
             throw new AssertionError(e);
         }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplier.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplier.java
@@ -106,15 +106,24 @@ public class LargeFakeDataSetStreamSupplier {
 		return new LargeFakeDataSetStreamSupplier(Long.MAX_VALUE, maxTriples, seed);
 	}
 
+	/**
+	 * create a supplier without a max count
+	 *
+	 * @param seed       the seed of the supplier, the same seed will create the same supplier
+	 * @return supplier
+	 */
+	public static LargeFakeDataSetStreamSupplier createInfinite(long seed) {
+		return new LargeFakeDataSetStreamSupplier(Long.MAX_VALUE, Long.MAX_VALUE, seed);
+	}
+
 	private final long seed;
 	private Random random;
-	private final long maxSize;
-	private final long maxTriples;
+	private long maxSize;
+	private long maxTriples;
 	public int maxFakeType = 10;
 	public int maxLiteralSize = 2;
 	public int maxElementSplit = Integer.MAX_VALUE;
 	private long slowStream;
-	private boolean sameTripleString;
 	private boolean unicode;
 	private TripleString buffer;
 	private TripleString next;
@@ -212,9 +221,10 @@ public class LargeFakeDataSetStreamSupplier {
 			out = pout;
 		}
 
+		Iterator<TripleString> it = createTripleStringStream();
+
 		ExceptionThread run = new ExceptionThread(() -> {
 			try (PrintStream ps = new PrintStream(out, true)) {
-				Iterator<TripleString> it = createTripleStringStream();
 				while (it.hasNext()) {
 					it.next().dumpNtriple(ps);
 				}
@@ -328,7 +338,12 @@ public class LargeFakeDataSetStreamSupplier {
 		private long count = 0;
 		private boolean init;
 
+		private final long maxTriples;
+		private final long maxSize;
+
 		FakeStatementIterator() {
+			this.maxSize = LargeFakeDataSetStreamSupplier.this.maxSize;
+			this.maxTriples = LargeFakeDataSetStreamSupplier.this.maxTriples;
 		}
 
 		@Override
@@ -394,6 +409,26 @@ public class LargeFakeDataSetStreamSupplier {
 	}
 
 	/**
+	 * set the max size
+	 * @param maxSize max size
+	 * @return this
+	 */
+	public LargeFakeDataSetStreamSupplier withMaxSize(long maxSize) {
+		this.maxSize = maxSize;
+		return this;
+	}
+
+	/**
+	 * set the max triples count
+	 * @param maxTriples max triples count
+	 * @return this
+	 */
+	public LargeFakeDataSetStreamSupplier withMaxTriples(long maxTriples) {
+		this.maxTriples = maxTriples;
+		return this;
+	}
+
+	/**
 	 * set the maximum number of fake type
 	 *
 	 * @param maxFakeType maximum number
@@ -456,7 +491,6 @@ public class LargeFakeDataSetStreamSupplier {
 	 * @return this
 	 */
 	public LargeFakeDataSetStreamSupplier withSameTripleString(boolean sameTripleString) {
-		this.sameTripleString = sameTripleString;
 		if (sameTripleString) {
 			buffer = new TripleString();
 		} else {

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplierTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplierTest.java
@@ -9,6 +9,7 @@ import org.rdfhdt.hdt.exceptions.ParserException;
 import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.hdt.HDTManagerTest;
+import org.rdfhdt.hdt.iterator.utils.CombinedIterator;
 import org.rdfhdt.hdt.iterator.utils.PipedCopyIterator;
 import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
@@ -22,7 +23,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -59,6 +63,26 @@ public class LargeFakeDataSetStreamSupplierTest {
 	}
 
 	@Test
+	public void sameTest() {
+		long[] sizes = {50, 25, 32, 10, 0, 12};
+		LargeFakeDataSetStreamSupplier s1 = LargeFakeDataSetStreamSupplier.createInfinite(34);
+		LargeFakeDataSetStreamSupplier s2 = LargeFakeDataSetStreamSupplier.createInfinite(34);
+
+		Iterator<TripleString> it1 = CombinedIterator.combine(
+				LongStream.of(sizes)
+						.mapToObj(s -> s1.withMaxTriples(s).createTripleStringStream())
+						.collect(Collectors.toList())
+		);
+
+		Iterator<TripleString> it2 = s2.withMaxTriples(LongStream.of(sizes).sum()).createTripleStringStream();
+
+		while (it2.hasNext()) {
+			assertTrue(it1.hasNext());
+			assertEquals(it2.next(), it1.next());
+		}
+		assertFalse(it1.hasNext());
+	}
+	@Test
 	public void countTest() {
 		long size = 42;
 		Iterator<TripleString> it = LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(size, 34)
@@ -69,6 +93,81 @@ public class LargeFakeDataSetStreamSupplierTest {
 			count++;
 		}
 		assertEquals(size, count);
+	}
+	@Test
+	public void countTest2() {
+		long size = 42;
+		LargeFakeDataSetStreamSupplier supplier = LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(size, 34);
+		{
+			Iterator<TripleString> it = supplier
+					.createTripleStringStream();
+			int count = 0;
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			assertEquals(size, count);
+		}
+		{
+			Iterator<TripleString> it = supplier
+					.createTripleStringStream();
+			int count = 0;
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			assertEquals(size, count);
+		}
+		{
+			Iterator<TripleString> it = supplier
+					.createTripleStringStream();
+			int count = 0;
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			assertEquals(size, count);
+		}
+	}
+	@Test
+	public void countTest3() {
+		LargeFakeDataSetStreamSupplier supplier = LargeFakeDataSetStreamSupplier.createInfinite(34);
+		{
+			long size = 42;
+			Iterator<TripleString> it = supplier
+					.withMaxTriples(size)
+					.createTripleStringStream();
+			int count = 0;
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			assertEquals(size, count);
+		}
+		{
+			long size = 24;
+			Iterator<TripleString> it = supplier
+					.withMaxTriples(size)
+					.createTripleStringStream();
+			int count = 0;
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			assertEquals(size, count);
+		}
+		{
+			long size = 35;
+			Iterator<TripleString> it = supplier
+					.withMaxTriples(size)
+					.createTripleStringStream();
+			int count = 0;
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			assertEquals(size, count);
+		}
 	}
 
 	@Test

--- a/hdt-java-package/bin/hdtCat.bat
+++ b/hdt-java-package/bin/hdtCat.bat
@@ -1,0 +1,5 @@
+@echo off
+
+call "%~dp0\javaenv.bat"
+
+"%JAVACMD%" %JAVAOPTIONS% -classpath %~dp0\..\lib\* org.rdfhdt.hdt.tools.HDTCat %*

--- a/hdt-java-package/bin/javaenv.bat
+++ b/hdt-java-package/bin/javaenv.bat
@@ -1,2 +1,3 @@
 set JAVAOPTIONS=-Xmx1G
 set JAVACMD=java
+set RDFHDT_COLOR=false

--- a/hdt-java-package/bin/javaenv.sh
+++ b/hdt-java-package/bin/javaenv.sh
@@ -21,6 +21,11 @@ else
     JAVA="$JAVA_HOME/bin/java -server"
 fi
 
+# Set HDT Color options, set to true to allow color
+if [ "$RDFHDT_COLOR" = "" ] ; then
+    export RDFHDT_COLOR="false"
+fi
+
 # Set Java options
 if [ "$JAVA_OPTIONS" = "" ] ; then
     JAVA_OPTIONS="-Xmx1g"


### PR DESCRIPTION
Hello!

In this PR, I've implemented a version of HDTCat working whatever the input count of HDTs (for MS/4S Dictionaries), it follows the same algorithm as [HDTCat_let's_make_HDT_scale](https://www.researchgate.net/publication/327763691_HDTCat_let's_make_HDT_scale), but with multiple HDT input, except that the streams from each HDT are merged to behave like one HDT

I've added it in HDTCatTree with the option `loader.cattree.kcat` to set the number of HDT to merge at the same time

3 options are here to describe the cat:

- `hdtcat.location`: the build directory, by default a temporary location is specified
- `hdtcat.location.future`: the future location of the HDT, can't be in the build directory
- `hdtcat.deleteLocation`: if we should delete the build directory (if specified)

## API

I've added all the options in the HDTOptionsKeys class

A new method was added in HDTManager

```java
public static HDT catHDT(List<String> hdtFileNames, HDTOptions hdtFormat, ProgressListener listener) throws IOException
```

Using the old method will use the legacy algorithm

## CLI

I've added the BATCH version of hdtCat with the `hdtCat.bat`

I've added the -kcat argument to HDTCat to allow to use the new version of HDTCat with 2 HDTs, but now we can specify the number of HDTs we want

With hdtVerify, I've removed the limit of 1 hdt, I've added 2 arguments:

- `-progress` to see the progress of the verify for the current HDT
- `-equals` to see that all the HDTs specified are equals

## Core

The implementation of HDTCat, with tests

