### PR TITLE
Add Powershell scripts with autocomplete

### DIFF
--- a/hdt-java-package/README
+++ b/hdt-java-package/README
@@ -14,18 +14,19 @@ It provides several components:
 Command line tools
 ==================
 
-NOTE: Generating and loading big HDT Datasets can take a considerable amount of memory. In some cases you might need to increase the JVM heap memory using -Xmx flag according to your machine's memory in the bin/javaenv.{sh,bat} launch scripts.
+NOTE: Generating and loading big HDT Datasets can take a considerable amount of memory. In some cases you might need to increase the JVM heap memory using -Xmx flag according to your machine's memory in the bin/javaenv.{sh,bat,ps1} launch scripts or using a disk generation method.
 
-The tool provides three main command line tools:
+The tool provides multiple command line tools:
 
 ** The tool rdf2hdt converts an RDF file to HDT format. The format of the input file will be NTriples by default, although it can be set by using the "-f" flag.
-** NOTE: rdf2hdt decompresses on the fly input files that end with ".gz".
+** NOTE: rdf2hdt decompresses on the fly input files that end with ".gz", ".bz2" or "xz".
 $ Usage: rdf2hdt [options] <Input RDF> <Output HDT>
   Options:
-    -base      Base URI for the dataset
-    -config    Conversion config file
-    -options   HDT Conversion options
-    -rdftype   Type of RDF Input (ntriples, n3, rdfxml)
+    -base         Base URI for the dataset
+    -config       Conversion config file
+    -options      HDT Conversion options
+    -printoptions Print all the options
+    -rdftype      Type of RDF Input (ntriples, n3, rdfxml)
 
 
 ** The tool hdt2rdf converts an HDT file back to RDF in NTriples format.
@@ -41,6 +42,14 @@ $ hdtsparql <HDT File> <SPARQL Query>
 ** The tool hdtInfo extracts the header from an HDT file.
 $ hdtInfo <HDT File>
 
+** The tool hdtVerify allow to verify the integrity of one or multiple HDTs.
+$ hdtVerify <HDT Files>+
+
+** The tool hdtVerify can also allow to verify that multiple HDTs are equals.
+$ hdtVerify -equals <HDT Files>+
+
+** The tool hdtCat allow to merge multiple HDTs together into a new HDT.
+$ hdtCat <HDT input Files>+ <HDT output file>
 
 Tool Usage example
 ==================

--- a/hdt-java-package/bin/hdt2rdf.ps1
+++ b/hdt-java-package/bin/hdt2rdf.ps1
@@ -1,0 +1,10 @@
+param(
+    [Parameter()]
+    [Switch]
+    $version,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "org.rdfhdt.hdt.tools.HDT2RDF" -RequiredParameters $PSBoundParameters

--- a/hdt-java-package/bin/hdtCat.ps1
+++ b/hdt-java-package/bin/hdtCat.ps1
@@ -1,0 +1,28 @@
+param(
+    [Parameter()]
+    [String]
+    $options,
+    [Parameter()]
+    [String]
+    $config,
+    [Parameter()]
+    [Switch]
+    $kcat,
+    [Parameter()]
+    [Switch]
+    $index,
+    [Parameter()]
+    [Switch]
+    $version,
+    [Parameter()]
+    [Switch]
+    $quiet,
+    [Parameter()]
+    [Switch]
+    $color,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "org.rdfhdt.hdt.tools.HDTCat" -RequiredParameters $PSBoundParameters

--- a/hdt-java-package/bin/hdtInfo.ps1
+++ b/hdt-java-package/bin/hdtInfo.ps1
@@ -1,0 +1,10 @@
+param(
+    [Parameter()]
+    [Switch]
+    $version,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "org.rdfhdt.hdt.tools.HDTInfo" -RequiredParameters $PSBoundParameters

--- a/hdt-java-package/bin/hdtSearch.ps1
+++ b/hdt-java-package/bin/hdtSearch.ps1
@@ -1,0 +1,13 @@
+param(
+    [Parameter()]
+    [Switch]
+    $version,
+    [Parameter()]
+    [Switch]
+    $memory,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "org.rdfhdt.hdt.tools.HdtSearch" -RequiredParameters $PSBoundParameters

--- a/hdt-java-package/bin/hdtVerify.ps1
+++ b/hdt-java-package/bin/hdtVerify.ps1
@@ -1,0 +1,28 @@
+param(
+    [Parameter()]
+    [Switch]
+    $unicode,
+    [Parameter()]
+    [Switch]
+    $progress,
+    [Parameter()]
+    [Switch]
+    $color,
+    [Parameter()]
+    [Switch]
+    $binary,
+    [Parameter()]
+    [Switch]
+    $quiet,
+    [Parameter()]
+    [Switch]
+    $load,
+    [Parameter()]
+    [Switch]
+    $equals,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "org.rdfhdt.hdt.tools.HDTVerify" -RequiredParameters $PSBoundParameters

--- a/hdt-java-package/bin/javaenv.ps1
+++ b/hdt-java-package/bin/javaenv.ps1
@@ -1,0 +1,36 @@
+param(
+    # Java start class
+    [Parameter(Mandatory = $true)]
+    [string]
+    $JavaStartClass,
+    $RequiredParameters
+)
+
+$javaenv = @{
+    "JAVAOPTIONS"  = "-XX:NewRatio=1", "-XX:SurvivorRatio=9", "-Xmx1G"
+    "JAVACMD"      = "java"
+    "RDFHDT_COLOR" = "false"
+}
+
+
+# set the env variable for the color
+$env:RDFHDT_COLOR = $javaenv.RDFHDT_COLOR
+
+# Find libraries
+$libDir = [System.IO.Path]::Combine(((Get-Item $PSScriptRoot).Parent.FullName), "lib")
+$libs = ((Get-ChildItem $libDir).FullName) -join ([System.IO.Path]::PathSeparator)
+
+return & $javaenv.JAVACMD @($javaenv.JAVAOPTIONS) "-classpath" $libs $JavaStartClass @(
+    $RequiredParameters.Keys | ForEach-Object {
+        $it = $RequiredParameters.Item($_)
+        if ("$_" -eq "OtherParams") {
+            $it
+        }
+        else {
+            "-$_"
+            if ($it.GetType() -ne [System.Management.Automation.SwitchParameter]) { 
+                $it
+            }
+        }
+    }
+)

--- a/hdt-java-package/bin/rdf2hdt.ps1
+++ b/hdt-java-package/bin/rdf2hdt.ps1
@@ -1,0 +1,39 @@
+param(
+    [String]
+    $options,
+    [String]
+    $config,
+    [ArgumentCompleter({
+            return @("ntriples", "nt", "n3", "nq", "nquad", "rdfxml", "rdf-xml", "owl", "turtle", "rar", "tar", "tgz", "tbz", "tbz2", "zip", "list", "hdt") | ForEach-Object { $_ }
+        })]
+    $rdftype,
+    [Switch]
+    $version,
+    [string]
+    $base,
+    [Switch]
+    $index,
+    [Switch]
+    $quiet,
+    [Switch]
+    $disk,
+    [string]
+    $disklocation,
+    [Switch]
+    $color,
+    [Switch]
+    $canonicalntfile,
+    [Switch]
+    $cattree,
+    [string]
+    $cattreelocation,
+    [Switch]
+    $multithread,
+    [Switch]
+    $printoptions,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "org.rdfhdt.hdt.tools.RDF2HDT" -RequiredParameters $PSBoundParameters

--- a/hdt-java-package/src/main/assembly/assembly.xml
+++ b/hdt-java-package/src/main/assembly/assembly.xml
@@ -50,7 +50,7 @@
         <fileSet>
             <directory>examples</directory>
             <outputDirectory>examples</outputDirectory>
-        </fileSet>   
+        </fileSet>
 
         <fileSet>
             <directory>bin</directory>
@@ -59,7 +59,17 @@
                 <include>*.bat</include>
             </includes>
             <lineEnding>dos</lineEnding>
-      		<fileMode>0755</fileMode>
+            <fileMode>0755</fileMode>
+        </fileSet>
+
+        <fileSet>
+            <directory>bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>*.ps1</include>
+            </includes>
+            <lineEnding>dos</lineEnding>
+            <fileMode>0755</fileMode>
         </fileSet>
        
     </fileSets>


### PR DESCRIPTION
Hello,

This pull request give Powershell users autocompletion with the RDFHDT's CLI commands.

I tried to be as generic as possible to let non Powershell users add their parameters.

**Autocompletion for each command**

<img width="817" alt="rdf2hdt-autocomplete" src="https://user-images.githubusercontent.com/1580223/205455370-e2bb1bec-2834-4287-8472-90b6fc2b23b0.png">

**Autocompletion for RDF2HDT the `-rdftype` argument**

<img width="816" alt="rdf2hdt-type" src="https://user-images.githubusercontent.com/1580223/205455374-857e4f08-935e-4d14-825b-83efd9bef8a0.png">

I've fixed few CLI classes and added to the Readme some info.
