### PR TITLE
Async CatTree and dir parser

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/enums/RDFNotation.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/enums/RDFNotation.java
@@ -185,8 +185,12 @@ public enum RDFNotation {
 
 		throw new IllegalArgumentException("Could not guess the format for "+fileName);
 	}
-	
+
 	public static RDFNotation guess(File fileName) throws IllegalArgumentException {
-		return guess(fileName.getName());
+		return guess(fileName.getAbsolutePath());
+	}
+
+	public static RDFNotation guess(Path fileName) throws IllegalArgumentException {
+		return guess(fileName.toAbsolutePath().toString());
 	}
 }

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptions.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptions.java
@@ -31,6 +31,8 @@ import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.rdf.RDFFluxStop;
 import org.rdfhdt.hdt.util.Profiler;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.DoubleSupplier;
@@ -42,6 +44,58 @@ import java.util.function.Supplier;
  * @author mario.arias
  */
 public interface HDTOptions {
+	/**
+	 * empty option, can be used to set values
+	 */
+	HDTOptions EMPTY = new HDTOptions() {
+		@Override
+		public void clear() {
+			// already empty
+		}
+
+		@Override
+		public String get(String key) {
+			// no value for key
+			return null;
+		}
+
+		@Override
+		public void set(String key, String value) {
+			throw new NotImplementedException("set");
+		}
+	};
+
+	/**
+	 * @return create empty, modifiable options
+	 */
+	static HDTOptions of() {
+		return of(Map.of());
+	}
+
+	/**
+	 * create modifiable options starting from the copy of the data map
+	 * @param data data map
+	 * @return options
+	 */
+	static HDTOptions of(Map<String, String> data) {
+		Map<String, String> map = new HashMap<>(data);
+		return new HDTOptions() {
+			@Override
+			public void clear() {
+				map.clear();
+			}
+
+			@Override
+			public String get(String key) {
+				return map.get(key);
+			}
+
+			@Override
+			public void set(String key, String value) {
+				map.put(key, value);
+			}
+		};
+	}
 
 
 	/**

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
@@ -311,6 +311,8 @@ public class HDTOptionsKeys {
 
 	@Key(type = Key.Type.BOOLEAN, desc = "Use disk implementation to generate the hdt sub-index")
 	public static final String BITMAPTRIPLES_SEQUENCE_DISK = "bitmaptriples.sequence.disk";
+	@Key(type = Key.Type.BOOLEAN, desc = "Use disk 375 subindex implementation to generate the hdt sub-index")
+	public static final String BITMAPTRIPLES_SEQUENCE_DISK_SUBINDEX = "bitmaptriples.sequence.disk.subindex";
 
 	@Key(type = Key.Type.BOOLEAN, desc = "Disk location for the " + BITMAPTRIPLES_SEQUENCE_DISK + " option")
 	public static final String BITMAPTRIPLES_SEQUENCE_DISK_LOCATION = "bitmaptriples.sequence.disk.location";

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
@@ -224,6 +224,12 @@ public class HDTOptionsKeys {
 	@Key(type = Key.Type.BOOLEAN, desc = "Use the canonical NT file parser, removing checks")
 	public static final String NT_SIMPLE_PARSER_KEY = "parser.ntSimpleParser";
 	/**
+	 * Key for setting the maximum amount of file loaded with the directory parser, 1 for no async parsing, 0
+	 * for the number of processors, default 1. Number value
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "Use async dir parser")
+	public static final String ASYNC_DIR_PARSER_KEY = "parser.dir.async";
+	/**
 	 * Key for setting the triple order. see {@link org.rdfhdt.hdt.enums.TripleComponentOrder}'s names to have the values
 	 * default to {@link org.rdfhdt.hdt.enums.TripleComponentOrder#SPO}
 	 */

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
@@ -123,6 +123,12 @@ public class HDTOptionsKeys {
 	@Key(type = Key.Type.PATH, desc = "Path of the CatTree generation")
 	public static final String LOADER_CATTREE_LOCATION_KEY = "loader.cattree.location";
 	/**
+	 * Key to use async version of the {@link org.rdfhdt.hdt.hdt.HDTManager} catTree methods, will run the k-HDTCAT
+	 * algorithm, by default the value is false, boolean value
+	 */
+	@Key(type = Key.Type.BOOLEAN, desc = "Use async version")
+	public static final String LOADER_CATTREE_ASYNC_KEY = "loader.cattree.async";
+	/**
 	 * Same as {@link #LOADER_TYPE_KEY} for loader in the CATTREE method
 	 */
 	@Key(desc = "Loader of the hdt generation")
@@ -202,6 +208,16 @@ public class HDTOptionsKeys {
 	 */
 	@Key(type = Key.Type.PATH, desc = "Profiler output file")
 	public static final String PROFILER_OUTPUT_KEY = "profiler.output";
+	/**
+	 * Key for enabling the profiler (if implemented) for async bi tasks, default to false. Boolean value
+	 */
+	@Key(type = Key.Type.BOOLEAN, desc = "Run a second profiler for async bi tasks")
+	public static final String PROFILER_ASYNC_KEY = "profiler.async";
+	/**
+	 * Key for the profiler output (if implemented). File value
+	 */
+	@Key(type = Key.Type.PATH, desc = "Profiler output file")
+	public static final String PROFILER_ASYNC_OUTPUT_KEY = "profiler.async.output";
 	/**
 	 * Key for enabling the canonical NTriple file simple parser, default to false. Boolean value
 	 */
@@ -293,6 +309,11 @@ public class HDTOptionsKeys {
 	@Key(type = Key.Type.BOOLEAN, desc = "Delete the HDTCat temp files directory after HDTCat, default to true")
 	public static final String HDTCAT_DELETE_LOCATION = "hdtcat.deleteLocation";
 
+	@Key(type = Key.Type.BOOLEAN, desc = "Use disk implementation to generate the hdt sub-index")
+	public static final String BITMAPTRIPLES_SEQUENCE_DISK = "bitmaptriples.sequence.disk";
+
+	@Key(type = Key.Type.BOOLEAN, desc = "Disk location for the " + BITMAPTRIPLES_SEQUENCE_DISK + " option")
+	public static final String BITMAPTRIPLES_SEQUENCE_DISK_LOCATION = "bitmaptriples.sequence.disk.location";
 	// use tree-map to have a better order
 	private static final Map<String, Option> OPTION_MAP = new TreeMap<>();
 

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/rdf/RDFParserCallback.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/rdf/RDFParserCallback.java
@@ -43,6 +43,17 @@ public interface RDFParserCallback {
 	@FunctionalInterface
 	interface RDFCallback {
 		void processTriple(TripleString triple, long pos);
+
+		/**
+		 * @return an async version of this callback
+		 */
+		default RDFCallback async() {
+			return ((triple, pos) -> {
+				synchronized (this) {
+					this.processTriple(triple, pos);
+				}
+			});
+		}
 	}
 	
 	void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException;

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/util/Profiler.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/util/Profiler.java
@@ -111,11 +111,24 @@ public class Profiler implements AutoCloseable {
 	 * @return profiler
 	 */
 	public static Profiler createOrLoadSubSection(String name, HDTOptions options, boolean setId) {
+		return createOrLoadSubSection(name, options, setId, false);
+	}
+
+	/**
+	 * create or load a profiler from the options into a subsection
+	 *
+	 * @param name    name
+	 * @param options options
+	 * @param setId   set the id after loading (if required)
+	 * @param async   use async profiler
+	 * @return profiler
+	 */
+	public static Profiler createOrLoadSubSection(String name, HDTOptions options, boolean setId, boolean async) {
 		// no options, we can't create
 		if (options == null) {
-			return new Profiler(name, null);
+			return new Profiler(name, null, async);
 		}
-		String profiler = options.get(HDTOptionsKeys.PROFILER_KEY);
+		String profiler = options.get(async ? HDTOptionsKeys.PROFILER_ASYNC_KEY : HDTOptionsKeys.PROFILER_KEY);
 		if (profiler != null && profiler.length() != 0 && profiler.charAt(0) == '!') {
 			Profiler prof = getProfilerById(Long.parseLong(profiler.substring(1)));
 			if (prof != null) {
@@ -125,9 +138,9 @@ public class Profiler implements AutoCloseable {
 			}
 		}
 		// no id, not an id
-		Profiler prof = new Profiler(name, options);
+		Profiler prof = new Profiler(name, options, async);
 		if (setId) {
-			options.set(HDTOptionsKeys.PROFILER_KEY, prof);
+			options.set(async ? HDTOptionsKeys.PROFILER_ASYNC_KEY : HDTOptionsKeys.PROFILER_KEY, prof);
 		}
 		return prof;
 	}
@@ -147,7 +160,17 @@ public class Profiler implements AutoCloseable {
 	 * @param name the profiler name
 	 */
 	public Profiler(String name) {
-		this(name, null);
+		this(name, false);
+	}
+
+	/**
+	 * create a disabled profiler
+	 *
+	 * @param name  the profiler name
+	 * @param async async profiler
+	 */
+	public Profiler(String name, boolean async) {
+		this(name, null, async);
 	}
 
 	/**
@@ -157,13 +180,24 @@ public class Profiler implements AutoCloseable {
 	 * @param spec spec (nullable)
 	 */
 	public Profiler(String name, HDTOptions spec) {
+		this(name, spec, false);
+	}
+
+	/**
+	 * create a profiler from specifications
+	 *
+	 * @param name  profiler name
+	 * @param spec  spec (nullable)
+	 * @param async async profiler
+	 */
+	public Profiler(String name, HDTOptions spec, boolean async) {
 		this.id = PROFILER_IDS.incrementAndGet();
 		PROFILER.put(this.id, this);
 		this.name = Objects.requireNonNull(name, "name can't be null!");
 		if (spec != null) {
-			String b = spec.get(HDTOptionsKeys.PROFILER_KEY);
+			String b = spec.get(async ? HDTOptionsKeys.PROFILER_ASYNC_KEY : HDTOptionsKeys.PROFILER_KEY);
 			disabled = b == null || b.length() == 0 || !(b.charAt(0) == '!' || "true".equalsIgnoreCase(b));
-			String profilerOutputLocation = spec.get(HDTOptionsKeys.PROFILER_OUTPUT_KEY);
+			String profilerOutputLocation = spec.get(async ? HDTOptionsKeys.PROFILER_ASYNC_OUTPUT_KEY : HDTOptionsKeys.PROFILER_OUTPUT_KEY);
 			if (profilerOutputLocation != null && !profilerOutputLocation.isEmpty()) {
 				outputPath = Path.of(profilerOutputLocation);
 			}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375.java
@@ -34,6 +34,7 @@ import org.rdfhdt.hdt.util.io.IOUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 
 /**
  * Implements an index on top of the Bitmap64 to solve select and rank queries more efficiently.
@@ -43,7 +44,9 @@ import java.io.OutputStream;
  * select1 -&gt; O(log log n)
  *
  * @author mario.arias
+ * @deprecated Use {@link Bitmap375Big#memory(long, Path)}} instead
  */
+@Deprecated
 public class Bitmap375 extends Bitmap64 implements ModifiableBitmap {
     // Constants
     private static final int BLOCKS_PER_SUPER = 4;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Big.java
@@ -1,0 +1,455 @@
+/**
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 3.0 of the License.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * Contacting the authors:
+ * Dennis Diefenbach:         dennis.diefenbach@univ-st-etienne.fr
+ */
+
+package org.rdfhdt.hdt.compact.bitmap;
+
+import org.rdfhdt.hdt.hdt.HDTVocabulary;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.util.BitUtil;
+import org.rdfhdt.hdt.util.disk.LargeLongArray;
+import org.rdfhdt.hdt.util.disk.LongArray;
+import org.rdfhdt.hdt.util.disk.LongArrayDisk;
+import org.rdfhdt.hdt.util.disk.SimpleSplitLongArray;
+import org.rdfhdt.hdt.util.io.CloseSuppressPath;
+import org.rdfhdt.hdt.util.io.Closer;
+import org.rdfhdt.hdt.util.io.IOUtil;
+import org.visnow.jlargearrays.LongLargeArray;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Implements an index on top of the Bitmap64 to solve select and rank queries more efficiently. Can store using disk
+ * and memory implementations without any limitation in size.
+ * <p>
+ * index -&gt; O(n)
+ * rank1 -&gt; O(1)
+ * select1 -&gt; O(log log n)
+ *
+ * @author mario.arias
+ */
+public class Bitmap375Big extends Bitmap64Big {
+    /**
+     * create disk version bitmap with in memory super index
+     *
+     * @param location location
+     * @param nbits    number of bits
+     * @return bitmap
+     */
+
+    public static Bitmap375Big disk(Path location, long nbits) {
+        return disk(location, nbits, false);
+    }
+
+    /**
+     * create disk version bitmap
+     *
+     * @param location          location
+     * @param nbits             number of bits
+     * @param useDiskSuperIndex use disk super index
+     * @return bitmap
+     */
+    public static Bitmap375Big disk(Path location, long nbits, boolean useDiskSuperIndex) {
+        return new Bitmap375Big(new LongArrayDisk(location, numWords(nbits)), location, useDiskSuperIndex);
+    }
+
+    /**
+     * create memory version bitmap
+     *
+     * @param nbits number of bits
+     * @return bitmap
+     */
+    public static Bitmap375Big memory(long nbits) {
+        return memory(nbits, null);
+    }
+
+    /**
+     * create memory version bitmap with on disk super index
+     *
+     * @param nbits    number of bits
+     * @param location location for the disk super index (if on disk)
+     * @return bitmap
+     */
+    public static Bitmap375Big memory(long nbits, Path location) {
+        return new Bitmap375Big(new LargeLongArray(new LongLargeArray(numWords(nbits))), location, location != null);
+    }
+
+    // Constants
+    private static final int BLOCKS_PER_SUPER = 4;
+
+    // Variables
+    private long pop;
+    private LongArray superBlocks;
+    private LongArray blocks;
+    private boolean indexUpToDate;
+    private final boolean useDiskSuperIndex;
+    private final CloseSuppressPath superBlocksPath;
+    private final CloseSuppressPath blocksPath;
+
+
+    protected Bitmap375Big(LongArray words, Path location, boolean useDiskSuperIndex) {
+        super(words);
+        this.useDiskSuperIndex = useDiskSuperIndex;
+        if (useDiskSuperIndex) {
+            CloseSuppressPath path = CloseSuppressPath.of(location);
+            this.superBlocksPath = path.resolveSibling(path.getFileName() + ".sb");
+            this.blocksPath = path.resolveSibling(path.getFileName() + ".bp");
+        } else {
+            this.superBlocksPath = null;
+            this.blocksPath = null;
+        }
+        getCloser().with((Closeable) this::closeObject);
+    }
+
+    private void closeObject() throws IOException {
+        Closer.closeAll(superBlocks, superBlocksPath, blocks, blocksPath);
+    }
+
+
+    /**
+     * dump the bitmap in stdout
+     */
+    public void dump() {
+        long count = numWords(this.numbits);
+        for (long i = 0; i < count; i++) {
+            System.out.print(i + "\t");
+            IOUtil.printBitsln(words.get(i), 64);
+        }
+    }
+
+    /**
+     * update the index
+     */
+    public void updateIndex() {
+        trimToSize();
+        try {
+            Closer.closeAll(superBlocks, blocks, superBlocksPath, blocksPath);
+        } catch (IOException e) {
+            // ignore
+        }
+        if (useDiskSuperIndex) {
+            if (numbits > Integer.MAX_VALUE) {
+                superBlocks = SimpleSplitLongArray.int64ArrayDisk(superBlocksPath, 1 + (words.length() - 1) / BLOCKS_PER_SUPER);
+            } else {
+                superBlocks = SimpleSplitLongArray.int32ArrayDisk(superBlocksPath, 1 + (words.length() - 1) / BLOCKS_PER_SUPER);
+            }
+            blocks = SimpleSplitLongArray.int8ArrayDisk(blocksPath, words.length());
+        } else {
+            if (numbits > Integer.MAX_VALUE) {
+                superBlocks = SimpleSplitLongArray.int64Array(1 + (words.length() - 1) / BLOCKS_PER_SUPER);
+            } else {
+                superBlocks = SimpleSplitLongArray.int32Array(1 + (words.length() - 1) / BLOCKS_PER_SUPER);
+            }
+            blocks = SimpleSplitLongArray.int8Array(words.length());
+        }
+
+        long countBlock = 0, countSuperBlock = 0;
+        long blockIndex = 0, superBlockIndex = 0;
+
+        while (blockIndex < words.length()) {
+            if ((blockIndex % BLOCKS_PER_SUPER) == 0) {
+                countSuperBlock += countBlock;
+                superBlocks.set(superBlockIndex++, countSuperBlock);
+                countBlock = 0;
+            }
+            blocks.set(blockIndex, countBlock);
+            countBlock += Long.bitCount(words.get(blockIndex));
+            blockIndex++;
+        }
+        pop = countSuperBlock + countBlock;
+        indexUpToDate = true;
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#access(long)
+     */
+    @Override
+    public boolean access(long bitIndex) {
+        if (bitIndex < 0)
+            throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+
+        long wordIndex = wordIndex(bitIndex);
+        if (wordIndex >= words.length()) {
+            return false;
+        }
+
+        return (words.get(wordIndex) & (1L << bitIndex)) != 0;
+    }
+
+    @Override
+    public void set(long bitIndex, boolean value) {
+        indexUpToDate = false;
+        super.set(bitIndex, value);
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#rank1(long)
+     */
+    @Override
+    public long rank1(long pos) {
+        if (pos < 0) {
+            return 0;
+        }
+        if (!indexUpToDate) {
+            updateIndex();
+        }
+        if (pos >= numbits) {
+            return pop;
+        }
+
+        long superBlockIndex = pos / (BLOCKS_PER_SUPER * W);
+        long superBlockRank = superBlocks.get(superBlockIndex);
+
+        long blockIndex = pos / W;
+        long blockRank = 0xFF & blocks.get(blockIndex);
+
+        long chunkIndex = W - 1 - pos % W;
+        long block = words.get(blockIndex) << chunkIndex;
+        long chunkRank = Long.bitCount(block);
+
+        return superBlockRank + blockRank + chunkRank;
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#rank0(long)
+     */
+    @Override
+    public long rank0(long pos) {
+        return pos + 1L - rank1(pos);
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#select0(long)
+     */
+    @Override
+    public long select0(long x) {
+        //System.out.println("\t**Select0 for: "+ x);
+
+        if (x < 0) {
+            return -1;
+        }
+        if (!indexUpToDate) {
+            updateIndex();
+        }
+        if (x > numbits - pop) {
+            return numbits;
+        }
+
+        // Search superblock (binary Search)
+        long superBlockIndex = binarySearch0(superBlocks, 0, superBlocks.length(), x);
+        if (superBlockIndex < 0) {
+            // Not found exactly, gives the position where it should be inserted
+            superBlockIndex = -superBlockIndex - 2;
+        } else if (superBlockIndex > 0) {
+            // If found exact, we need to check previous block.
+            superBlockIndex--;
+        }
+
+        // If there is a run of many ones, two correlative superblocks may have the same value,
+        // We need to position at the first of them.
+        while (superBlockIndex > 0 && (superBlockIndex * BLOCKS_PER_SUPER * W - superBlocks.get(superBlockIndex) >= x)) {
+            superBlockIndex--;
+        }
+
+        long countdown = x - (superBlockIndex * BLOCKS_PER_SUPER * W - superBlocks.get(superBlockIndex));
+        long blockIdx = superBlockIndex * BLOCKS_PER_SUPER;
+
+        // Search block
+        while (true) {
+            if (blockIdx >= (superBlockIndex + 1) * BLOCKS_PER_SUPER || blockIdx >= blocks.length()) {
+                blockIdx--;
+                break;
+            }
+            if ((0xFF & (W * (blockIdx % BLOCKS_PER_SUPER) - (0xFF & blocks.get(blockIdx)))) >= countdown) {
+                // We found it!
+                blockIdx--;
+                break;
+            }
+            blockIdx++;
+        }
+        if (blockIdx < 0) {
+            blockIdx = 0;
+        }
+        countdown = countdown - (0xFF & ((blockIdx % BLOCKS_PER_SUPER) * W - blocks.get(blockIdx)));
+
+        // Search bit inside block
+        long bitpos = BitUtil.select0(words.get(blockIdx), (int) countdown);
+
+        return (blockIdx) * W + bitpos - 1;
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#select1(long)
+     */
+    @Override
+    public long select1(long x) {
+        //System.out.println("\t**Select1 for: "+ x);
+
+        if (x < 0) {
+            return -1;
+        }
+        if (!indexUpToDate) {
+            updateIndex();
+        }
+        if (x > pop) {
+            return numbits;
+        }
+        if (numbits == 0) {
+            return 0;
+        }
+        // Search superblock (binary Search)
+        long superBlockIndex = binarySearch(superBlocks, x);
+
+        // If there is a run of many zeros, two correlative superblocks may have the same value,
+        // We need to position at the first of them.
+
+        while (superBlockIndex > 0 && (superBlocks.get(superBlockIndex) >= x)) {
+            superBlockIndex--;
+
+        }
+
+        long countdown = x - superBlocks.get(superBlockIndex);
+
+        long blockIdx = superBlockIndex * BLOCKS_PER_SUPER;
+
+        // Search block
+        while (true) {
+            if (blockIdx >= (superBlockIndex + 1) * BLOCKS_PER_SUPER || blockIdx >= blocks.length()) {
+                blockIdx--;
+                break;
+            }
+            if ((0xFF & blocks.get(blockIdx)) >= countdown) {
+                // We found it!
+                blockIdx--;
+                break;
+            }
+            blockIdx++;
+        }
+        if (blockIdx < 0) {
+            blockIdx = 0;
+        }
+        countdown = countdown - (0xFF & blocks.get(blockIdx));
+
+        // Search bit inside block
+        int bitpos = BitUtil.select1(words.get(blockIdx), (int) countdown);
+
+        return blockIdx * W + bitpos - 1;
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#countOnes()
+     */
+    @Override
+    public long countOnes() {
+        return rank1(numbits);
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#countZeros()
+     */
+    @Override
+    public long countZeros() {
+        return numbits - countOnes();
+    }
+
+    @Override
+    public long getRealSizeBytes() {
+        updateIndex();
+
+        return super.getRealSizeBytes()
+                + blocks.length() * blocks.sizeOf() / 8
+                + superBlocks.length() * superBlocks.sizeOf() / 8;
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#getType()
+     */
+    @Override
+    public String getType() {
+        return HDTVocabulary.BITMAP_TYPE_PLAIN;
+    }
+
+    /* (non-Javadoc)
+     * @see hdt.compact.bitmap.Bitmap#load(java.io.InputStream, hdt.listener.ProgressListener)
+     */
+    @Override
+    public void load(InputStream input, ProgressListener listener) throws IOException {
+        super.load(input, listener);
+        updateIndex();
+    }
+
+
+    /**
+     * run a binary search in an array with the 0 values
+     *
+     * @param arr       array
+     * @param fromIndex start index (inclusive)
+     * @param toIndex   max index (exclusive)
+     * @param key       key to search
+     * @return index
+     */
+    public static long binarySearch0(LongArray arr, long fromIndex, long toIndex, long key) {
+        long low = fromIndex;
+        long high = toIndex - 1;
+
+        while (low <= high) {
+            long mid = (low + high) >>> 1;
+            long midVal = mid * BLOCKS_PER_SUPER * W - arr.get(mid);
+
+            if (midVal < key) {
+                low = mid + 1;
+            } else if (midVal > key) {
+                high = mid - 1;
+            } else {
+                return mid; // key found
+            }
+        }
+        return -(low + 1);  // key not found.
+    }
+
+    /**
+     * binary search val index into arr
+     *
+     * @param arr arr
+     * @param val val
+     * @return index
+     */
+    public static long binarySearch(LongArray arr, long val) {
+        long min = 0, max = arr.length(), mid;
+
+        while (min + 1 < max) {
+            mid = (min + max) / 2;
+
+            if (arr.get(mid) >= val) {
+                max = mid;
+            } else {
+                min = mid;
+            }
+        }
+
+        return min;
+    }
+
+    public CloseSuppressPath getBlocksPath() {
+        return blocksPath;
+    }
+
+    public CloseSuppressPath getSuperBlocksPath() {
+        return superBlocksPath;
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Disk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Disk.java
@@ -3,425 +3,67 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation;
  * version 3.0 of the License.
- *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * Contacting the authors:
- *   Dennis Diefenbach:         dennis.diefenbach@univ-st-etienne.fr
+ * Dennis Diefenbach:         dennis.diefenbach@univ-st-etienne.fr
  */
 
 package org.rdfhdt.hdt.compact.bitmap;
 
-import org.rdfhdt.hdt.hdt.HDTVocabulary;
-import org.rdfhdt.hdt.listener.ProgressListener;
-import org.rdfhdt.hdt.util.BitUtil;
-import org.rdfhdt.hdt.util.io.IOUtil;
+import org.rdfhdt.hdt.util.disk.LongArrayDisk;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Path;
-import java.util.Arrays;
 
 /**
- * Bitmap375 version that is backed up on disk
+ * Implements an index on top of the Bitmap64 to solve select and rank queries more efficiently.
+ * <p>
+ * index -&gt; O(n)
+ * rank1 -&gt; O(1)
+ * select1 -&gt; O(log log n)
+ *
+ * @author mario.arias
+ * @deprecated Use {@link Bitmap375Big#disk(Path, long, boolean)} instead
  */
-public class Bitmap375Disk extends Bitmap64Disk implements ModifiableBitmap {
-    // Constants
-    private static final int BLOCKS_PER_SUPER = 4;
-
-    // Variables
-    private long pop;
-    private long [] superBlocksLong;
-    private int [] superBlocksInt;
-    private byte [] blocks;
-    private boolean indexUpToDate;
+@Deprecated
+public class Bitmap375Disk extends Bitmap375Big {
 
     public Bitmap375Disk(String location) {
-        super(location);
-    }
-
-    public Bitmap375Disk(String location, long nbits) {
-        super(location, nbits);
+        this(location, W);
     }
 
     public Bitmap375Disk(Path location) {
-        super(location);
+        this(location, W);
+    }
+
+    public Bitmap375Disk(String location, long nbits) {
+        this(location, nbits, false);
     }
 
     public Bitmap375Disk(Path location, long nbits) {
-        super(location, nbits);
+        this(location, nbits, false);
     }
 
-    public void dump() {
-        int count = (int) numWords(this.numbits);
-        for(int i=0;i<count;i++) {
-            System.out.print(i+"\t");
-            IOUtil.printBitsln(words.get(i), 64);
-        }
+    public Bitmap375Disk(String location, boolean useDiskSuperIndex) {
+        this(location, W, useDiskSuperIndex);
     }
 
-    public void updateIndex() {
-        trimToSize();
-        if(numbits>Integer.MAX_VALUE) {
-            superBlocksLong = new long[1+((int)words.length()-1)/BLOCKS_PER_SUPER];
-        } else {
-            superBlocksInt = new int[1+((int)words.length()-1)/BLOCKS_PER_SUPER];
-        }
-        blocks = new byte[(int)words.length()];
-
-        long countBlock=0, countSuperBlock=0;
-        int blockIndex=0, superBlockIndex=0;
-
-        while(blockIndex<(int)words.length()) {
-            if((blockIndex%BLOCKS_PER_SUPER)==0) {
-                countSuperBlock += countBlock;
-                if(superBlocksLong!=null) {
-                    if(superBlockIndex<superBlocksLong.length) {
-                        superBlocksLong[superBlockIndex++] = countSuperBlock;
-                    }
-                } else {
-                    if(superBlockIndex<superBlocksInt.length) {
-                        superBlocksInt[superBlockIndex++] = (int)countSuperBlock;
-                    }
-                }
-                countBlock = 0;
-            }
-            blocks[blockIndex] = (byte) countBlock;
-            countBlock += Long.bitCount(words.get(blockIndex));
-            blockIndex++;
-        }
-        pop = countSuperBlock+countBlock;
-        indexUpToDate = true;
-
-//		for(int i=0;i<words.length;i++) {
-//			if((i%BLOCKS_PER_SUPER)==0) {
-//				int superB = i/BLOCKS_PER_SUPER;
-//				System.out.println("Super: "+superB+ " rank1: "+superBlocks[superB]+" Rank0: "+(superB*BLOCKS_PER_SUPER*W-superBlocks[superB])+" Bits: "+(superB*BLOCKS_PER_SUPER*W));
-//			}
-//			System.out.println("\tWord: "+i+ " Rank1: "+blocks[i]+ " Rank0: "+ (W*(i%BLOCKS_PER_SUPER)-blocks[i]) + " Bits: "+(W*i));
-//			System.out.print("\t\t"); IOUtil.printBits(words[i], W); System.out.println(" "+Long.bitCount(words[i]));
-//		}
-        //System.out.println("Bitmap with "+numbits+" bits. Data size: "+(words.length*8)+" Index Size: "+ (superBlocks.length*4+blocks.length));
+    public Bitmap375Disk(Path location, boolean useDiskSuperIndex) {
+        this(location, W, useDiskSuperIndex);
     }
 
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#access(long)
-     */
-    @Override
-    public boolean access(long bitIndex) {
-        if (bitIndex < 0)
-            throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
-
-        long wordIndex = wordIndex(bitIndex);
-        if(wordIndex>=words.length()) {
-            return false;
-        }
-
-        return (words.get(wordIndex) & (1L << bitIndex)) != 0;
+    public Bitmap375Disk(String location, long nbits, boolean useDiskSuperIndex) {
+        this(Path.of(location), nbits, useDiskSuperIndex);
     }
 
-    @Override
-    public void set(long bitIndex, boolean value) {
-        indexUpToDate=false;
-        super.set(bitIndex, value);
+    public Bitmap375Disk(Path location, long nbits, boolean useDiskSuperIndex) {
+        super(new LongArrayDisk(location, numWords(nbits)), location, useDiskSuperIndex);
     }
 
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#rank1(long)
-     */
-    @Override
-    public long rank1(long pos) {
-        if(pos<0) {
-            return 0;
-        }
-        if(!indexUpToDate) {
-            updateIndex();
-        }
-        if(pos>=numbits) {
-            return pop;
-        }
 
-        long superBlockIndex = pos/(BLOCKS_PER_SUPER*W);
-        long superBlockRank;
-        if(superBlocksLong!=null) {
-            superBlockRank = superBlocksLong[(int)superBlockIndex];
-        } else {
-            superBlockRank = superBlocksInt[(int)superBlockIndex];
-        }
-
-        long blockIndex = pos/W;
-        long blockRank = 0xFF & blocks[(int)blockIndex];
-
-        long chunkIndex = W-1-pos%W;
-        long block = words.get((int)blockIndex) << chunkIndex;
-        long chunkRank = Long.bitCount(block);
-
-        return superBlockRank + blockRank + chunkRank;
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#rank0(long)
-     */
-    @Override
-    public long rank0(long pos) {
-        return pos+1L-rank1(pos);
-    }
-
-    private static int binarySearch0(long[] a, int fromIndex, int toIndex, long key) {
-        int low = fromIndex;
-        int high = toIndex - 1;
-
-        while (low <= high) {
-            int mid = (low + high) >>> 1;
-            long midVal = mid * BLOCKS_PER_SUPER * W-a[mid];
-
-            if (midVal < key)
-                low = mid + 1;
-            else if (midVal > key)
-                high = mid - 1;
-            else
-                return mid; // key found
-        }
-        return -(low + 1);  // key not found.
-    }
-
-    private static int binarySearch0(int[] a, int fromIndex, int toIndex, long key) {
-        int low = fromIndex;
-        int high = toIndex - 1;
-
-        while (low <= high) {
-            int mid = (low + high) >>> 1;
-            long midVal = mid * BLOCKS_PER_SUPER * W-a[mid];
-
-            if (midVal < key)
-                low = mid + 1;
-            else if (midVal > key)
-                high = mid - 1;
-            else
-                return mid; // key found
-        }
-        return -(low + 1);  // key not found.
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#select0(long)
-     */
-    @Override
-    public long select0(long x) {
-        //System.out.println("\t**Select0 for: "+ x);
-
-        if(x<0) {
-            return -1;
-        }
-        if(!indexUpToDate) {
-            updateIndex();
-        }
-        if(x>numbits-pop) {
-            return numbits;
-        }
-
-        // Search superblock (binary Search)
-        int superBlockIndex;
-        if(superBlocksLong!=null) {
-            superBlockIndex = binarySearch0(superBlocksLong, 0, superBlocksLong.length, x);
-        } else {
-            superBlockIndex = binarySearch0(superBlocksInt, 0, superBlocksInt.length, x);
-        }
-        if(superBlockIndex<0) {
-            // Not found exactly, gives the position where it should be inserted
-            superBlockIndex = -superBlockIndex-2;
-        } else if(superBlockIndex>0){
-            // If found exact, we need to check previous block.
-            superBlockIndex--;
-        }
-
-        long countdown;
-
-        if(superBlocksLong!=null) {
-            // If there is a run of many ones, two correlative superblocks may have the same value,
-            // We need to position at the first of them.
-            while(superBlockIndex>0 && (superBlockIndex*BLOCKS_PER_SUPER*W-superBlocksLong[superBlockIndex]>=x)) {
-                superBlockIndex--;
-            }
-
-            countdown = x-(superBlockIndex*BLOCKS_PER_SUPER*W-superBlocksLong[superBlockIndex]);
-        } else {
-            // If there is a run of many ones, two correlative superblocks may have the same value,
-            // We need to position at the first of them.
-            while(superBlockIndex>0 && (superBlockIndex*BLOCKS_PER_SUPER*W-superBlocksInt[superBlockIndex]>=x)) {
-                superBlockIndex--;
-            }
-
-            countdown = x-(superBlockIndex*BLOCKS_PER_SUPER*W-superBlocksInt[superBlockIndex]);
-        }
-        int blockIdx = superBlockIndex * BLOCKS_PER_SUPER;
-
-        // Search block
-        while(true) {
-            if(blockIdx>= (superBlockIndex+1) * BLOCKS_PER_SUPER || blockIdx>=blocks.length) {
-                blockIdx--;
-                break;
-            }
-            if((0xFF & (W*(blockIdx%BLOCKS_PER_SUPER) - blocks[blockIdx]))>=countdown) {
-                // We found it!
-                blockIdx--;
-                break;
-            }
-            blockIdx++;
-        }
-        if(blockIdx<0) {
-            blockIdx=0;
-        }
-        countdown = countdown - (0xFF & ((blockIdx%BLOCKS_PER_SUPER)*W - blocks[blockIdx]));
-
-        // Search bit inside block
-        int bitpos = BitUtil.select0(words.get(blockIdx), (int)countdown);
-
-        return ((long)blockIdx) * W + bitpos - 1;
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#select1(long)
-     */
-    @Override
-    public long select1(long x) {
-        //System.out.println("\t**Select1 for: "+ x);
-
-        if(x<0) {
-            return -1;
-        }
-        if(!indexUpToDate) {
-            updateIndex();
-        }
-        if(x>pop) {
-            return numbits;
-        }
-        if(numbits==0) {
-            return 0;
-        }
-
-        // Search superblock (binary Search)
-        int superBlockIndex;
-        if(superBlocksLong!=null) {
-            superBlockIndex = Arrays.binarySearch(superBlocksLong, x);
-        } else {
-            superBlockIndex = Arrays.binarySearch(superBlocksInt, (int)x);
-        }
-        if(superBlockIndex<0) {
-            // Not found exactly, gives the position where it should be inserted
-            superBlockIndex = -superBlockIndex-2;
-        } else if(superBlockIndex>0){
-            // If found exact, we need to check previous block.
-            superBlockIndex--;
-        }
-
-        long countdown;
-        if(superBlocksLong!=null) {
-            // If there is a run of many zeros, two correlative superblocks may have the same value,
-            // We need to position at the first of them.
-            while(superBlockIndex>0 && (superBlocksLong[superBlockIndex]>=x)) {
-                superBlockIndex--;
-            }
-            countdown = x-superBlocksLong[superBlockIndex];
-        } else {
-            // If there is a run of many zeros, two correlative superblocks may have the same value,
-            // We need to position at the first of them.
-            while(superBlockIndex>0 && (superBlocksInt[superBlockIndex]>=x)) {
-                superBlockIndex--;
-            }
-            countdown = x-superBlocksInt[superBlockIndex];
-        }
-        int blockIdx = superBlockIndex * BLOCKS_PER_SUPER;
-
-        // Search block
-        while(true) {
-            if(blockIdx>= (superBlockIndex+1) * BLOCKS_PER_SUPER || blockIdx>=blocks.length) {
-                blockIdx--;
-                break;
-            }
-            if((0xFF & blocks[blockIdx])>=countdown) {
-                // We found it!
-                blockIdx--;
-                break;
-            }
-            blockIdx++;
-        }
-        if(blockIdx<0) {
-            blockIdx=0;
-        }
-        countdown = countdown - (0xFF & blocks[blockIdx]);
-
-        // Search bit inside block
-        int bitpos = BitUtil.select1(words.get(blockIdx), (int)countdown);
-
-        return ((long)blockIdx) * W + bitpos - 1;
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#countOnes()
-     */
-    @Override
-    public long countOnes() {
-        return rank1(numbits);
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#countZeros()
-     */
-    @Override
-    public long countZeros() {
-        return numbits-countOnes();
-    }
-
-    @Override
-    public long getRealSizeBytes() {
-        updateIndex();
-
-        long accum = super.getRealSizeBytes();
-
-        if(superBlocksLong!=null) {
-            accum+=superBlocksLong.length*8;
-        }
-
-        if(superBlocksInt!=null) {
-            accum+=superBlocksInt.length*4;
-        }
-
-        accum+=blocks.length;
-
-        return accum;
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#getType()
-     */
-    @Override
-    public String getType() {
-        return HDTVocabulary.BITMAP_TYPE_PLAIN;
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#save(java.io.OutputStream, hdt.listener.ProgressListener)
-     */
-    @Override
-    public void save(OutputStream output, ProgressListener listener) throws IOException {
-        super.save(output, listener);
-    }
-
-    /* (non-Javadoc)
-     * @see hdt.compact.bitmap.Bitmap#load(java.io.InputStream, hdt.listener.ProgressListener)
-     */
-    @Override
-    public void load(InputStream input, ProgressListener listener) throws IOException {
-        super.load(input, listener);
-        updateIndex();
-    }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64.java
@@ -49,8 +49,9 @@ import org.rdfhdt.hdt.util.io.IOUtil;
  * The first bit is the lowest significative bit of word zero, and so on.
  * 
  * @author mario.arias
- *
+ * @deprecated use {@link Bitmap64Big#memory(long)} instead
  */
+@Deprecated
 public class Bitmap64 implements ModifiableBitmap{
 	
 	// Constants

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/BitmapFactoryImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/BitmapFactoryImpl.java
@@ -38,12 +38,12 @@ import org.rdfhdt.hdt.hdt.HDTVocabulary;
  *
  */
 public class BitmapFactoryImpl extends BitmapFactory {
-	private final Bitmap EMPTY = new Bitmap64(0);
+	private final Bitmap EMPTY = Bitmap64Big.memory(0);
 
 	@Override
 	protected ModifiableBitmap doCreateModifiableBitmap(String type) {
 		if (type == null || type.equals(HDTVocabulary.BITMAP_TYPE_PLAIN)) {
-			return new Bitmap375();
+			return Bitmap375Big.memory(0);
 		} else {
 			throw new IllegalArgumentException("Implementation not found for Bitmap with type " + type);
 		}
@@ -55,14 +55,14 @@ public class BitmapFactoryImpl extends BitmapFactory {
 		int value = input.read();
 		input.reset();
 		if (value == TYPE_BITMAP_PLAIN) {
-			return new Bitmap375();
+			return Bitmap375Big.memory(0);
 		}
 		throw new IllegalFormatException("Implementation not found for Bitmap with code " + value);
 	}
 
 	@Override
 	protected ModifiableBitmap doCreateRWModifiableBitmap(long size) {
-		return new Bitmap64(size);
+		return Bitmap64Big.memory(size);
 	}
 
 	@Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/DynamicSequence.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/DynamicSequence.java
@@ -57,5 +57,6 @@ public interface DynamicSequence extends Sequence, LongArray {
 		return getNumberOfElements();
 	}
 
+	@Override
 	void resize(long size);
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
@@ -110,7 +110,12 @@ public class SequenceInt32 implements DynamicSequence {
 		data[(int)position] = (int)value;
 		numelements = (int) Math.max(numelements, position+1);
 	}
-	
+
+	@Override
+	public int sizeOf() {
+		return 32;
+	}
+
 	@Override
     public void append(long value) {
 		assert value>=0 && value<=Integer.MAX_VALUE;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
@@ -108,7 +108,12 @@ public class SequenceInt64 implements DynamicSequence {
 		data[(int)position] = value;
 		numelements = (int) Math.max(numelements, position+1);
 	}
-	
+
+	@Override
+	public int sizeOf() {
+		return 64;
+	}
+
 	@Override
     public void append(long value) {
 		assert value>=0;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
@@ -233,7 +233,12 @@ public class SequenceLog64 implements DynamicSequence {
 		}
 		setField(data, numbits, position, value);
 	}
-	
+
+	@Override
+	public int sizeOf() {
+		return numbits;
+	}
+
 	@Override
     public void append(long value) {
 		if(value<0 || value>maxvalue) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Big.java
@@ -244,7 +244,12 @@ public class SequenceLog64Big implements DynamicSequence {
 		//}
 		setField(data, numbits, position, value);
 	}
-	
+
+	@Override
+	public int sizeOf() {
+		return numbits;
+	}
+
 	@Override
     public void append(long value) {
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64BigDisk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64BigDisk.java
@@ -73,11 +73,14 @@ public class SequenceLog64BigDisk implements DynamicSequence, Closeable {
     }
 
     public SequenceLog64BigDisk(Path location, int numbits, long capacity, boolean initialize) {
+        this(location, numbits, capacity, initialize, true);
+    }
+    public SequenceLog64BigDisk(Path location, int numbits, long capacity, boolean initialize, boolean overwrite) {
         this.numentries = 0;
         this.numbits = numbits;
         this.maxvalue = BitUtil.maxVal(numbits);
         long size = numWordsFor(numbits, capacity);
-        data = new LongArrayDisk(location, Math.max(size,1));
+        data = new LongArrayDisk(location, Math.max(size,1), overwrite);
         if (initialize) {
             numentries = capacity;
         }
@@ -182,6 +185,11 @@ public class SequenceLog64BigDisk implements DynamicSequence, Closeable {
         }
         //System.out.println("numbits "+this.numbits);
         setField(data, numbits, position, value);
+    }
+
+    @Override
+    public int sizeOf() {
+        return numbits;
     }
 
     @Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTManagerImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTManagerImpl.java
@@ -49,11 +49,6 @@ import java.util.stream.Collectors;
 public class HDTManagerImpl extends HDTManager {
 	private static final Logger logger = LoggerFactory.getLogger(HDTManagerImpl.class);
 
-	private boolean useSimple(HDTOptions spec) {
-		String value = spec.get(HDTOptionsKeys.NT_SIMPLE_PARSER_KEY);
-		return value != null && !value.isEmpty() && !value.equals("false");
-	}
-
 	@Override
 	public HDTOptions doReadOptions(String file) throws IOException {
 		return new HDTSpecification(file);
@@ -161,13 +156,13 @@ public class HDTManagerImpl extends HDTManager {
 		} else if (HDTOptionsKeys.LOADER_TYPE_VALUE_CAT.equals(loaderType)) {
 			return doHDTCatTree(readFluxStopOrSizeLimit(spec), HDTSupplier.fromSpec(spec), rdfFileName, baseURI, rdfNotation, spec, listener);
 		} else if (HDTOptionsKeys.LOADER_TYPE_VALUE_TWO_PASS.equals(loaderType)) {
-			loader = new TempHDTImporterTwoPass(useSimple(spec));
+			loader = new TempHDTImporterTwoPass(spec);
 		} else {
 			if (loaderType != null && !HDTOptionsKeys.LOADER_TYPE_VALUE_ONE_PASS.equals(loaderType)) {
 				logger.warn("Used the option {} with value {}, which isn't recognize, using default value {}",
 						HDTOptionsKeys.LOADER_TYPE_KEY, loaderType, HDTOptionsKeys.LOADER_TYPE_VALUE_ONE_PASS);
 			}
-			loader = new TempHDTImporterOnePass(useSimple(spec));
+			loader = new TempHDTImporterOnePass(spec);
 		}
 
 		// Create TempHDT
@@ -229,7 +224,7 @@ public class HDTManagerImpl extends HDTManager {
 							HDTOptionsKeys.LOADER_TYPE_KEY, loaderType, HDTOptionsKeys.LOADER_TYPE_VALUE_ONE_PASS);
 				}
 			}
-			loader = new TempHDTImporterOnePass(useSimple(spec));
+			loader = new TempHDTImporterOnePass(spec);
 		}
 
 		// Create TempHDT
@@ -264,7 +259,7 @@ public class HDTManagerImpl extends HDTManager {
 		// uncompress the stream if required
 		fileStream = IOUtil.asUncompressed(fileStream, compressionType);
 		// create a parser for this rdf stream
-		RDFParserCallback parser = RDFParserFactory.getParserCallback(rdfNotation, useSimple(hdtFormat));
+		RDFParserCallback parser = RDFParserFactory.getParserCallback(rdfNotation, hdtFormat);
 		// read the stream as triples
 		try (PipedCopyIterator<TripleString> iterator = RDFParserFactory.readAsIterator(parser, fileStream, baseURI, true, rdfNotation)) {
 			return doGenerateHDTDisk0(iterator, true, baseURI, hdtFormat, listener);
@@ -380,7 +375,7 @@ public class HDTManagerImpl extends HDTManager {
 
 	@Override
 	protected HDT doHDTCatTree(RDFFluxStop fluxStop, HDTSupplier supplier, InputStream stream, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		RDFParserCallback parser = RDFParserFactory.getParserCallback(rdfNotation, useSimple(hdtFormat));
+		RDFParserCallback parser = RDFParserFactory.getParserCallback(rdfNotation, hdtFormat);
 		try (PipedCopyIterator<TripleString> iterator = RDFParserFactory.readAsIterator(parser, stream, baseURI, true, rdfNotation)) {
 			return doHDTCatTree(fluxStop, supplier, iterator, baseURI, hdtFormat, listener);
 		}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -440,8 +440,7 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 			return;
 		}
 		isClosed=true;
-		dictionary.close();
-		triples.close();
+		IOUtil.closeAll(dictionary, triples);
 	}
 	
 	// For debugging

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterOnePass.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterOnePass.java
@@ -73,17 +73,17 @@ public class TempHDTImporterOnePass implements TempHDTImporter {
 		}
 	}
 
-	private final boolean useSimple;
+	private final HDTOptions spec;
 
-	public TempHDTImporterOnePass(boolean useSimple) {
-		this.useSimple = useSimple;
+	public TempHDTImporterOnePass(HDTOptions spec) {
+		this.spec = spec;
 	}
 
 	@Override
 	public TempHDT loadFromRDF(HDTOptions specs, String filename, String baseUri, RDFNotation notation, ProgressListener listener)
 			throws ParserException {
 		
-		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation, useSimple);
+		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation, spec);
 
 		// Create Modifiable Instance
 		TempHDT modHDT = new TempHDTImpl(specs, baseUri, ModeOfLoading.ONE_PASS);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterTwoPass.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/TempHDTImporterTwoPass.java
@@ -99,17 +99,17 @@ public class TempHDTImporterTwoPass implements TempHDTImporter {
 		}
 	}
 
-	private final boolean useSimple;
+	private final HDTOptions spec;
 
-	public TempHDTImporterTwoPass(boolean useSimple) {
-		this.useSimple = useSimple;
+	public TempHDTImporterTwoPass(HDTOptions spec) {
+		this.spec = spec;
 	}
 
 	@Override
 	public TempHDT loadFromRDF(HDTOptions specs, String filename, String baseUri, RDFNotation notation, ProgressListener listener)
 			throws ParserException {
 		
-		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation, useSimple);
+		RDFParserCallback parser = RDFParserFactory.getParserCallback(notation, spec);
 
 		// Create Modifiable Instance and parser
 		TempHDT modHDT = new TempHDTImpl(specs, baseUri, ModeOfLoading.TWO_PASS);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskimport/AsyncCatTreeWorker.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskimport/AsyncCatTreeWorker.java
@@ -1,0 +1,250 @@
+package org.rdfhdt.hdt.hdt.impl.diskimport;
+
+import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTFactory;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.hdt.HDTSupplier;
+import org.rdfhdt.hdt.iterator.utils.FluxStopTripleStringIterator;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
+import org.rdfhdt.hdt.options.HideHDTOptions;
+import org.rdfhdt.hdt.rdf.RDFFluxStop;
+import org.rdfhdt.hdt.triples.TripleString;
+import org.rdfhdt.hdt.util.Profiler;
+import org.rdfhdt.hdt.util.concurrent.ExceptionThread;
+import org.rdfhdt.hdt.util.concurrent.HeightTree;
+import org.rdfhdt.hdt.util.listener.PrefixListener;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class AsyncCatTreeWorker implements Closeable {
+	private final CatTreeImpl impl;
+	private final ExceptionThread mergeThread;
+
+	private final FluxStopTripleStringIterator it;
+	private final int kcat;
+	private final HDTSupplier supplier;
+	private final String baseURI;
+	private final ProgressListener listener;
+	private final Profiler catProfiler;
+	private final Profiler profiler;
+	private final HeightTree<CatTreeImpl.HDTFile> tree = new HeightTree<>();
+	private boolean endread;
+	private final Path hdtStore;
+	private final Path hdtCatLocationPath;
+	private HDT hdt;
+
+	public AsyncCatTreeWorker(CatTreeImpl impl, RDFFluxStop fluxStop, HDTSupplier supplier, Iterator<TripleString> iterator, String baseURI, ProgressListener listener) throws IOException {
+		this.impl = impl;
+		kcat = impl.getkHDTCat();
+		this.it = new FluxStopTripleStringIterator(iterator, fluxStop);
+		this.supplier = supplier;
+		this.baseURI = baseURI;
+		this.listener = listener;
+		this.catProfiler = Profiler.createOrLoadSubSection("asynccatloader", impl.getHdtFormat(), false, true);
+		profiler = impl.getProfiler();
+
+		hdtStore = impl.getBasePath().resolve("hdt-store");
+		hdtCatLocationPath = impl.getBasePath().resolve("cat");
+
+		Files.createDirectories(hdtStore);
+		Files.createDirectories(hdtCatLocationPath);
+
+		this.mergeThread = new ExceptionThread(this::runMergeThread, "CatTreeMergeThread")
+				.attach(new ExceptionThread(this::runGenThread, "CatTreeGenThread"));
+	}
+
+	public void start() {
+		mergeThread.startAll();
+	}
+
+	public HDT buildHDT() throws ParserException, IOException {
+		try {
+			mergeThread.joinAndCrashIfRequired();
+		} catch (InterruptedException e) {
+			throw new ParserException(e);
+		} catch (ExceptionThread.ExceptionThreadException e) {
+			if (e.getCause() instanceof IOException) {
+				throw (IOException) e.getCause();
+			}
+			if (e.getCause() instanceof ParserException) {
+				throw (ParserException) e.getCause();
+			}
+			if (e.getCause() instanceof RuntimeException) {
+				throw (RuntimeException) e.getCause();
+			}
+			if (e.getCause() instanceof Error) {
+				throw (Error) e.getCause();
+			}
+			throw e;
+		}
+
+		return hdt;
+	}
+
+	private void runGenThread() throws IOException, ParserException {
+
+		long gen = 0;
+		boolean nextFile;
+		do {
+			// generate the hdt
+			gen++;
+			profiler.pushSection("generateHDT #" + gen);
+			PrefixListener il = PrefixListener.of("gen#" + gen, listener);
+			Path hdtLocation = hdtStore.resolve("hdt-" + gen + ".hdt");
+			// help memory flooding algorithm
+			System.gc();
+			supplier.doGenerateHDT(it, baseURI, impl.getHdtFormat(), il, hdtLocation);
+			il.clearThreads();
+
+			nextFile = it.hasNextFlux();
+			synchronized (tree) {
+				tree.addElement(new CatTreeImpl.HDTFile(hdtLocation, 1), 1);
+				endread = !nextFile;
+				tree.notifyAll();
+			}
+			profiler.popSection();
+		} while (nextFile);
+	}
+
+	private void runMergeThread() throws IOException, InterruptedException {
+		long cat = 0;
+
+		HideHDTOptions spec = new HideHDTOptions(impl.getHdtFormat(), Function.identity());
+
+		spec.set(HDTOptionsKeys.HDTCAT_LOCATION, hdtCatLocationPath);
+
+		while (!endread) {
+			List<CatTreeImpl.HDTFile> lst;
+			synchronized (tree) {
+				while (true) {
+					lst = tree.getMax(kcat);
+					if (lst == null && !endread) {
+						tree.wait();
+					} else {
+						break;
+					}
+				}
+			}
+
+			if (lst == null) {
+				break; // end read
+			}
+
+			List<String> gen = lst.stream()
+					.map(CatTreeImpl.HDTFile::getHdtFile)
+					.map(Path::toAbsolutePath)
+					.map(Path::toString)
+					.collect(Collectors.toList());
+
+			cat++;
+			profiler.pushSection("catHDT #" + cat);
+			PrefixListener ilc = PrefixListener.of("cat#" + cat, listener);
+			Path hdtCatFileLocation = hdtStore.resolve("hdtcat-" + cat + ".hdt");
+
+			// override the value to create the cat into hdtCatFileLocation
+			spec.overrideValue(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY, hdtCatFileLocation.toAbsolutePath());
+
+			try (HDT abcat = HDTManager.catHDT(
+					gen,
+					spec,
+					ilc)) {
+				abcat.saveToHDT(hdtCatFileLocation.toAbsolutePath().toString(), ilc);
+			}
+
+			spec.overrideValue(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY, null);
+
+			ilc.clearThreads();
+
+			// delete previous chunks
+			for (CatTreeImpl.HDTFile nextHDT : lst) {
+				Files.delete(nextHDT.getHdtFile());
+			}
+			// note the new hdt file and the number of chunks
+			int chunks = (int) lst.stream().mapToLong(CatTreeImpl.HDTFile::getChunks).max().orElseThrow() + 1;
+			synchronized (tree) {
+				tree.addElement(new CatTreeImpl.HDTFile(hdtCatFileLocation, chunks), chunks);
+			}
+
+			profiler.popSection();
+		}
+		// end read, we can merge everything we can
+
+		while (tree.size() > 1) {
+			List<CatTreeImpl.HDTFile> lst = tree.getAll(kcat);
+
+			List<String> gen = lst.stream()
+					.map(CatTreeImpl.HDTFile::getHdtFile)
+					.map(Path::toAbsolutePath)
+					.map(Path::toString)
+					.collect(Collectors.toList());
+
+			cat++;
+			profiler.pushSection("catHDT #" + cat);
+			PrefixListener ilc = PrefixListener.of("cat#" + cat, listener);
+			Path hdtCatFileLocation = hdtStore.resolve("hdtcat-" + cat + ".hdt");
+
+			// override the value to create the cat into hdtCatFileLocation
+			spec.overrideValue(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY, hdtCatFileLocation.toAbsolutePath());
+
+			try (HDT abcat = HDTManager.catHDT(
+					gen,
+					spec,
+					ilc)) {
+				abcat.saveToHDT(hdtCatFileLocation.toAbsolutePath().toString(), ilc);
+			}
+
+			spec.overrideValue(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY, null);
+
+			ilc.clearThreads();
+
+			// delete previous chunks
+			for (CatTreeImpl.HDTFile nextHDT : lst) {
+				Files.delete(nextHDT.getHdtFile());
+			}
+			// note the new hdt file and the number of chunks
+			int chunks = (int) lst.stream().mapToLong(CatTreeImpl.HDTFile::getChunks).max().orElseThrow() + 1;
+			tree.addElement(new CatTreeImpl.HDTFile(hdtCatFileLocation, chunks), chunks);
+		}
+
+		if (tree.size() == 0) {
+			// empty hdt
+			hdt = HDTFactory.createHDT();
+		} else {
+			List<CatTreeImpl.HDTFile> hdts = tree.getAll(1);
+			assert hdts.size() == 1;
+
+			Path hdtFile = hdts.get(0).getHdtFile();
+
+			try {
+				// if a future HDT location has been asked, move to it and map the HDT
+				if (impl.getFutureHDTLocation() != null) {
+					Files.createDirectories(impl.getFutureHDTLocation().toAbsolutePath().getParent());
+					Files.deleteIfExists(impl.getFutureHDTLocation());
+					Files.move(hdtFile, impl.getFutureHDTLocation());
+					hdt = new MapOnCallHDT(impl.getFutureHDTLocation());
+				} else {
+					// if no future location has been asked, load the HDT and delete it after
+					hdt = HDTManager.loadHDT(hdtFile.toAbsolutePath().toString());
+				}
+			} finally {
+				Files.deleteIfExists(hdtFile);
+				profiler.stop();
+				profiler.writeProfiling();
+			}
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		catProfiler.close();
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskimport/CatTreeImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskimport/CatTreeImpl.java
@@ -1,0 +1,383 @@
+package org.rdfhdt.hdt.hdt.impl.diskimport;
+
+import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.hdt.HDT;
+import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.hdt.HDTSupplier;
+import org.rdfhdt.hdt.iterator.utils.FluxStopTripleStringIterator;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
+import org.rdfhdt.hdt.options.HideHDTOptions;
+import org.rdfhdt.hdt.rdf.RDFFluxStop;
+import org.rdfhdt.hdt.triples.TripleString;
+import org.rdfhdt.hdt.util.Profiler;
+import org.rdfhdt.hdt.util.io.Closer;
+import org.rdfhdt.hdt.util.listener.PrefixListener;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * code for managing the Cat-Tree disk generation
+ *
+ * @author Antoine Willerval
+ */
+public class CatTreeImpl implements Closeable {
+    private final HideHDTOptions hdtFormat;
+    private final int kHDTCat;
+    private final Path basePath;
+    private final Path futureHDTLocation;
+    private final Closer closer = Closer.of();
+    private final Profiler profiler;
+    private final boolean async;
+
+    /**
+     * create implementation
+     *
+     * @param hdtFormat hdt format
+     * @throws IOException io exception
+     */
+    public CatTreeImpl(HDTOptions hdtFormat) throws IOException {
+        try {
+
+            long khdtCatOpt = hdtFormat.getInt(HDTOptionsKeys.LOADER_CATTREE_KCAT, 1);
+
+
+            if (khdtCatOpt > 0 && khdtCatOpt < Integer.MAX_VALUE - 6) {
+                kHDTCat = (int) khdtCatOpt;
+            } else {
+                throw new IllegalArgumentException("Invalid kcat value: " + khdtCatOpt);
+            }
+
+            String baseNameOpt = hdtFormat.get(HDTOptionsKeys.LOADER_CATTREE_LOCATION_KEY);
+
+            if (baseNameOpt == null || baseNameOpt.isEmpty()) {
+                basePath = Files.createTempDirectory("hdt-java-cat-tree");
+            } else {
+                basePath = Path.of(baseNameOpt);
+            }
+
+
+            futureHDTLocation = Optional.ofNullable(hdtFormat.get(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY)).map(Path::of).orElse(null);
+
+            boolean async = hdtFormat.getBoolean(HDTOptionsKeys.LOADER_CATTREE_ASYNC_KEY, false);
+            // hide the loader type to avoid infinite recursion
+            this.hdtFormat = new HideHDTOptions(hdtFormat, this::mapHiddenKeys);
+
+            if (async) {
+                long worker = hdtFormat.getInt(HDTOptionsKeys.LOADER_DISK_COMPRESSION_WORKER_KEY, -1);
+
+                int processors;
+                if (worker == -1) {
+                    processors = Runtime.getRuntime().availableProcessors();
+                } else if (worker >= 0 && worker < Integer.MAX_VALUE) {
+                    processors = (int) worker;
+                } else {
+                    throw new IllegalArgumentException("Bad worker count: " + worker);
+                }
+                if (processors >= 2) {
+                    // use one thread to merge the HDTs
+                    this.hdtFormat.overrideValue(HDTOptionsKeys.LOADER_DISK_COMPRESSION_WORKER_KEY, processors - 1);
+                    this.async = true;
+                } else {
+                    // not enough processor to run async
+                    this.async = false;
+                }
+            } else {
+                this.async = false;
+            }
+
+            profiler = Profiler.createOrLoadSubSection("doHDTCatTree", hdtFormat, true);
+            closer.with((Closeable) profiler::close);
+
+        } catch (Throwable t) {
+            try {
+                throw t;
+            } finally {
+                close();
+            }
+        }
+    }
+
+    private String mapHiddenKeys(String key) {
+        if (HDTOptionsKeys.LOADER_TYPE_KEY.equals(key)) {
+            return HDTOptionsKeys.LOADER_CATTREE_LOADERTYPE_KEY;
+        }
+        return key;
+    }
+
+    /**
+     * get the previous HDTs to merge with current
+     *
+     * @param nextFile if we can create a new HDT after this one
+     * @param files    hdt files to merge
+     * @param current  current created HDT
+     * @param maxFiles max file to merge
+     * @return list of HDT to merge with current, mi
+     */
+    private List<HDTFile> getNextHDTs(boolean nextFile, List<HDTFile> files, HDTFile current, int maxFiles) {
+        if (files.isEmpty()) {
+            return List.of();
+        }
+        List<HDTFile> next = new ArrayList<>();
+        if (nextFile || files.size() > maxFiles) {
+            for (int i = 1; i < maxFiles && i <= files.size(); i++) {
+                HDTFile old = files.get(files.size() - i);
+
+                // check if the chunks are matching
+                if (nextFile && old.getChunks() > current.getChunks()) {
+                    break;
+                }
+
+                next.add(old);
+            }
+            if (!nextFile || next.size() == maxFiles - 1) {
+                // we have all the elements, or we have enough file
+                // we remove the elements from the files
+                for (int i = 0; i < next.size(); i++) {
+                    files.remove(files.size() - 1);
+                }
+            } else {
+                return List.of();
+            }
+        } else {
+            next.addAll(files);
+            files.clear();
+        }
+        next.add(current);
+        return next;
+    }
+
+    /**
+     * generate the HDT from the stream
+     *
+     * @param fluxStop flux stop
+     * @param supplier hdt supplier
+     * @param iterator triple string stream
+     * @param baseURI  base URI
+     * @param listener progression listener
+     * @return hdt
+     * @throws IOException     io exception
+     * @throws ParserException parsing exception returned by the hdt supplier
+     */
+    public HDT doGeneration(RDFFluxStop fluxStop, HDTSupplier supplier, Iterator<TripleString> iterator, String baseURI, ProgressListener listener) throws IOException, ParserException {
+        if (async && kHDTCat > 1) {
+            return doGenerationAsync(fluxStop, supplier, iterator, baseURI, listener);
+        } else {
+            return doGenerationSync(fluxStop, supplier, iterator, baseURI, listener);
+        }
+    }
+
+    /**
+     * generate the HDT from the stream using ASYNC algorithm
+     *
+     * @param fluxStop flux stop
+     * @param supplier hdt supplier
+     * @param iterator triple string stream
+     * @param baseURI  base URI
+     * @param listener progression listener
+     * @return hdt
+     * @throws IOException     io exception
+     * @throws ParserException parsing exception returned by the hdt supplier
+     */
+    public HDT doGenerationAsync(RDFFluxStop fluxStop, HDTSupplier supplier, Iterator<TripleString> iterator, String baseURI, ProgressListener listener) throws IOException, ParserException {
+        try (AsyncCatTreeWorker worker = new AsyncCatTreeWorker(this, fluxStop, supplier, iterator, baseURI, listener)) {
+            worker.start();
+            return worker.buildHDT();
+        }
+    }
+
+    /**
+     * generate the HDT from the stream using SYNC algorithm
+     *
+     * @param fluxStop flux stop
+     * @param supplier hdt supplier
+     * @param iterator triple string stream
+     * @param baseURI  base URI
+     * @param listener progression listener
+     * @return hdt
+     * @throws IOException     io exception
+     * @throws ParserException parsing exception returned by the hdt supplier
+     */
+    public HDT doGenerationSync(RDFFluxStop fluxStop, HDTSupplier supplier, Iterator<TripleString> iterator, String baseURI, ProgressListener listener) throws IOException, ParserException {
+        FluxStopTripleStringIterator it = new FluxStopTripleStringIterator(iterator, fluxStop);
+
+        List<HDTFile> files = new ArrayList<>();
+
+        long gen = 0;
+        long cat = 0;
+
+        Path hdtStore = basePath.resolve("hdt-store");
+        Path hdtCatLocationPath = basePath.resolve("cat");
+        String hdtCatLocation = hdtCatLocationPath.toAbsolutePath().toString();
+
+        Files.createDirectories(hdtStore);
+        Files.createDirectories(hdtCatLocationPath);
+
+        boolean nextFile;
+        do {
+            // generate the hdt
+            gen++;
+            profiler.pushSection("generateHDT #" + gen);
+            PrefixListener il = PrefixListener.of("gen#" + gen, listener);
+            Path hdtLocation = hdtStore.resolve("hdt-" + gen + ".hdt");
+            // help memory flooding algorithm
+            System.gc();
+            supplier.doGenerateHDT(it, baseURI, hdtFormat, il, hdtLocation);
+            il.clearThreads();
+
+            nextFile = it.hasNextFlux();
+            HDTFile hdtFile = new HDTFile(hdtLocation, 1);
+            profiler.popSection();
+
+            // merge the generated hdt with each block with enough size
+            if (kHDTCat == 1) { // default impl
+                while (!files.isEmpty() && (!nextFile || (files.get(files.size() - 1)).getChunks() <= hdtFile.getChunks())) {
+                    HDTFile lastHDTFile = files.remove(files.size() - 1);
+                    cat++;
+                    profiler.pushSection("catHDT #" + cat);
+                    PrefixListener ilc = PrefixListener.of("cat#" + cat, listener);
+                    Path hdtCatFileLocation = hdtStore.resolve("hdtcat-" + cat + ".hdt");
+                    try (HDT abcat = HDTManager.catHDT(
+                            hdtCatLocation,
+                            lastHDTFile.getHdtFile().toAbsolutePath().toString(),
+                            hdtFile.getHdtFile().toAbsolutePath().toString(),
+                            hdtFormat, ilc)) {
+                        abcat.saveToHDT(hdtCatFileLocation.toAbsolutePath().toString(), ilc);
+                    }
+                    ilc.clearThreads();
+                    // delete previous chunks
+                    Files.delete(lastHDTFile.getHdtFile());
+                    Files.delete(hdtFile.getHdtFile());
+                    // note the new hdt file and the number of chunks
+                    hdtFile = new HDTFile(hdtCatFileLocation, lastHDTFile.getChunks() + hdtFile.getChunks());
+
+                    profiler.popSection();
+                }
+            } else { // kcat
+                List<HDTFile> nextHDTs;
+
+                while (!(nextHDTs = getNextHDTs(nextFile, files, hdtFile, kHDTCat)).isEmpty()) {
+                    // merge all the files
+                    cat++;
+                    profiler.pushSection("catHDT #" + cat);
+                    PrefixListener ilc = PrefixListener.of("cat#" + cat, listener);
+                    Path hdtCatFileLocation = hdtStore.resolve("hdtcat-" + cat + ".hdt");
+
+                    assert nextHDTs.size() > 1;
+
+                    // override the value to create the cat into hdtCatFileLocation
+                    hdtFormat.overrideValue(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY, hdtCatFileLocation.toAbsolutePath());
+
+                    try (HDT abcat = HDTManager.catHDT(
+                            nextHDTs.stream().map(f -> f.getHdtFile().toAbsolutePath().toString()).collect(Collectors.toList()),
+                            hdtFormat,
+                            ilc)) {
+                        abcat.saveToHDT(hdtCatFileLocation.toAbsolutePath().toString(), ilc);
+                    }
+
+                    hdtFormat.overrideValue(HDTOptionsKeys.LOADER_CATTREE_FUTURE_HDT_LOCATION_KEY, null);
+
+                    ilc.clearThreads();
+
+                    // delete previous chunks
+                    for (HDTFile nextHDT : nextHDTs) {
+                        Files.delete(nextHDT.getHdtFile());
+                    }
+                    // note the new hdt file and the number of chunks
+                    long chunks = nextHDTs.stream().mapToLong(HDTFile::getChunks).sum();
+                    hdtFile = new HDTFile(hdtCatFileLocation, chunks);
+
+                    profiler.popSection();
+                }
+            }
+            assert nextFile || files.isEmpty() : "no data remaining, but contains files";
+            files.add(hdtFile);
+        } while (nextFile);
+
+        listener.notifyProgress(100, "done, loading HDT");
+
+        Path hdtFile = files.get(0).hdtFile;
+
+        assert files.size() == 1 : "more than 1 file: " + files;
+        assert cat < gen : "more cat than gen";
+        assert files.get(0).getChunks() == gen : "gen size isn't the same as excepted: " + files.get(0).getChunks() + " != " + gen;
+
+        try {
+            // if a future HDT location has been asked, move to it and map the HDT
+            if (futureHDTLocation != null) {
+                Files.createDirectories(futureHDTLocation.toAbsolutePath().getParent());
+                Files.deleteIfExists(futureHDTLocation);
+                Files.move(hdtFile, futureHDTLocation);
+                return new MapOnCallHDT(futureHDTLocation);
+            }
+
+            // if no future location has been asked, load the HDT and delete it after
+            return HDTManager.loadHDT(hdtFile.toAbsolutePath().toString());
+        } finally {
+            Files.deleteIfExists(hdtFile);
+            profiler.stop();
+            profiler.writeProfiling();
+        }
+    }
+
+    public HideHDTOptions getHdtFormat() {
+        return hdtFormat;
+    }
+
+    public Path getFutureHDTLocation() {
+        return futureHDTLocation;
+    }
+
+    public Profiler getProfiler() {
+        return profiler;
+    }
+
+    public int getkHDTCat() {
+        return kHDTCat;
+    }
+
+    public Path getBasePath() {
+        return basePath;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closer.close();
+    }
+
+
+    static class HDTFile {
+        private final Path hdtFile;
+        private final long chunks;
+
+        public HDTFile(Path hdtFile, long chunks) {
+            this.hdtFile = hdtFile;
+            this.chunks = chunks;
+        }
+
+        public long getChunks() {
+            return chunks;
+        }
+
+        public Path getHdtFile() {
+            return hdtFile;
+        }
+
+        @Override
+        public String toString() {
+            return "HDTFile{" +
+                    "hdtFile=" + hdtFile +
+                    ", chunks=" + chunks +
+                    '}';
+        }
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/RDFParserFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/RDFParserFactory.java
@@ -30,6 +30,8 @@ package org.rdfhdt.hdt.rdf;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.iterator.utils.PipedCopyIterator;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.rdf.parsers.RDFParserDir;
 import org.rdfhdt.hdt.rdf.parsers.RDFParserHDT;
 import org.rdfhdt.hdt.rdf.parsers.RDFParserList;
@@ -40,23 +42,23 @@ import org.rdfhdt.hdt.rdf.parsers.RDFParserTar;
 import org.rdfhdt.hdt.rdf.parsers.RDFParserZip;
 import org.rdfhdt.hdt.triples.TripleString;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Iterator;
 
 /**
  * @author mario.arias
  *
  */
 public class RDFParserFactory {
-	public static RDFParserCallback getParserCallback(RDFNotation notation) {
-		return getParserCallback(notation, false);
+	public static boolean useSimple(HDTOptions options) {
+		return options != null && options.getBoolean(HDTOptionsKeys.NT_SIMPLE_PARSER_KEY, false);
 	}
-	public static RDFParserCallback getParserCallback(RDFNotation notation, boolean useSimple) {
+	public static RDFParserCallback getParserCallback(RDFNotation notation) {
+		return getParserCallback(notation, HDTOptions.EMPTY);
+	}
+	public static RDFParserCallback getParserCallback(RDFNotation notation, HDTOptions spec) {
 		switch(notation) {
 			case NTRIPLES:
-				if (useSimple) {
+				if (useSimple(spec)) {
 					return new RDFParserSimple();
 				}
 			case NQUAD:
@@ -65,15 +67,15 @@ public class RDFParserFactory {
 			case RDFXML:
 				return new RDFParserRIOT();
 			case DIR:
-				return new RDFParserDir(useSimple);
+				return new RDFParserDir(spec);
 			case LIST:
-				return new RDFParserList();
+				return new RDFParserList(spec);
 			case ZIP:
-				return new RDFParserZip(useSimple);
+				return new RDFParserZip(spec);
 			case TAR:
-				return new RDFParserTar(useSimple);
+				return new RDFParserTar(spec);
 			case RAR:
-				return new RDFParserRAR(useSimple);
+				return new RDFParserRAR(spec);
 			case HDT:
 				return new RDFParserHDT();
 			case JSONLD:

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserDir.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserDir.java
@@ -3,6 +3,8 @@ package org.rdfhdt.hdt.rdf.parsers;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.util.ContainerException;
@@ -14,20 +16,35 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.stream.Stream;
 
 /**
  * @author Antoine Willerval
  */
 public class RDFParserDir implements RDFParserCallback {
 	private static final Logger log = LoggerFactory.getLogger(RDFParserDir.class);
-	private final boolean simple;
+	private final HDTOptions spec;
+	final int async;
 
-	public RDFParserDir(boolean simple) {
-		this.simple = simple;
+	public RDFParserDir(HDTOptions spec) {
+		this.spec = spec;
+		long dirAsyncValue = spec.getInt(HDTOptionsKeys.ASYNC_DIR_PARSER_KEY, 1);
+		if (dirAsyncValue == 0) {
+			// use processor count for 0 to be full parallel
+			async = Runtime.getRuntime().availableProcessors();
+		} else if (dirAsyncValue < 0 || dirAsyncValue >= Integer.MAX_VALUE - 5) {
+			throw new IllegalArgumentException("Invalid value for " + HDTOptionsKeys.ASYNC_DIR_PARSER_KEY + ": " + dirAsyncValue);
+		} else {
+			async = (int) dirAsyncValue;
+		}
+
 	}
 
 	public RDFParserDir() {
-		this(false);
+		this(HDTOptions.EMPTY);
 	}
 
 	@Override
@@ -39,43 +56,175 @@ public class RDFParserDir implements RDFParserCallback {
 		}
 	}
 
-	private void doParse(Path p, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
+	private void doParse(Path path, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		if (notation != RDFNotation.DIR) {
 			throw new IllegalArgumentException("Can't parse notation different than " + RDFNotation.DIR + "!");
 		}
-		try {
-			Files.list(p).forEach(child -> {
-				try {
-					if (Files.isDirectory(child)) {
-						doParse(child, baseUri, RDFNotation.DIR, keepBNode, callback);
-						return;
-					}
-					RDFParserCallback rdfParserCallback;
-					RDFNotation childNotation;
+
+		if (async == 1) {
+			// no async parser, faster to use recursion
+			try (Stream<Path> subFiles = Files.list(path)) {
+				subFiles.forEach(child -> {
 					try {
-						// get the notation of the file
-						childNotation = RDFNotation.guess(child.toFile());
-						rdfParserCallback = RDFParserFactory.getParserCallback(childNotation, simple);
-					} catch (IllegalArgumentException e) {
-						log.warn("Ignore file {}", child, e);
-						return;
+						if (Files.isDirectory(child)) {
+							doParse(child, baseUri, RDFNotation.DIR, keepBNode, callback);
+							return;
+						}
+						RDFParserCallback rdfParserCallback;
+						RDFNotation childNotation;
+						try {
+							// get the notation of the file
+							childNotation = RDFNotation.guess(child.toFile());
+							rdfParserCallback = RDFParserFactory.getParserCallback(childNotation, spec);
+						} catch (IllegalArgumentException e) {
+							log.warn("Ignore file {}", child, e);
+							return;
+						}
+						log.debug("parse {}", child);
+						// we can parse it, parsing it
+						rdfParserCallback.doParse(child.toAbsolutePath().toString(), baseUri, childNotation, keepBNode, callback);
+					} catch (ParserException e) {
+						throw new ContainerException(e);
 					}
-					log.debug("parse {}", child);
-					// we can parse it, parsing it
-					rdfParserCallback.doParse(child.toAbsolutePath().toString(), baseUri, childNotation, keepBNode, callback);
-				} catch (ParserException e) {
-					throw new ContainerException(e);
-				}
-			});
-		} catch (IOException | SecurityException e) {
-			throw new ParserException(e);
-		} catch (ContainerException e) {
-			throw (ParserException) e.getCause();
+				});
+			} catch (IOException | SecurityException e) {
+				throw new ParserException(e);
+			} catch (ContainerException e) {
+				throw (ParserException) e.getCause();
+			}
+		} else {
+			// use async parser because we will need to call it from multiple threads
+			RDFCallback asyncRdfCallback = callback.async();
+			// create the pool
+			ExecutorService executorService = Executors.newFixedThreadPool(async);
+			// list of all the future loaded by the parser
+			FutureList list = new FutureList();
+			// send the first task with the root directory
+			list.add(executorService.submit(new LoadTask(executorService, path, baseUri, RDFNotation.DIR, keepBNode, asyncRdfCallback)));
+
+			// wait for end of all the futures
+			try {
+				list.await();
+			} catch (ExecutionException e) {
+				throw new ParserException(e.getCause());
+			} catch (InterruptedException e) {
+				throw new ParserException(e);
+			} finally {
+				// close the service
+				executorService.shutdown();
+			}
 		}
 	}
 
 	@Override
 	public void doParse(InputStream in, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
 		throw new NotImplementedException("Can't parse a stream of directory!");
+	}
+
+	private static class FutureList {
+		private final List<Future<FutureList>> list;
+
+		private FutureList() {
+			this.list = new ArrayList<>();
+		}
+
+		public void add(Future<FutureList> e) {
+			list.add(e);
+		}
+
+		/**
+		 * await all the futures
+		 *
+		 * @throws ExecutionException exception while running the method
+		 * @throws InterruptedException interruption of the thread
+		 */
+		public void await() throws ExecutionException, InterruptedException {
+			while (!list.isEmpty()) {
+				Future<FutureList> future = list.remove(list.size() - 1);
+
+				try {
+					// get the next futures
+					mergeWith(future.get());
+				} catch (InterruptedException e) {
+					if (Thread.interrupted()) {
+						throw e;
+					}
+				}
+			}
+		}
+
+		/**
+		 * merge this list with another one
+		 * @param other other
+		 */
+		public void mergeWith(FutureList other) {
+			this.list.addAll(other.list);
+		}
+	}
+
+	private class LoadTask implements Callable<FutureList> {
+		private final ExecutorService executorService;
+		private final Path path;
+		private final String baseUri;
+		private final RDFNotation notation;
+		private final boolean keepBNode;
+		private final RDFCallback callback;
+
+		private LoadTask(ExecutorService executorService, Path path, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) {
+			this.executorService = executorService;
+			this.path = path;
+			this.baseUri = baseUri;
+			this.notation = notation;
+			this.keepBNode = keepBNode;
+			this.callback = callback;
+		}
+
+		@Override
+		public FutureList call() throws ParserException {
+			FutureList list = new FutureList();
+			if (notation == RDFNotation.DIR) {
+				try (Stream<Path> subFiles = Files.list(path)) {
+					subFiles.forEach(child -> {
+						if (Files.isDirectory(child)) {
+							list.add(executorService.submit(
+									new LoadTask(executorService, child, baseUri, RDFNotation.DIR, keepBNode, callback)
+							));
+							return;
+						}
+						RDFNotation childNotation;
+						try {
+							// get the notation of the file
+							childNotation = RDFNotation.guess(child.toFile());
+						} catch (IllegalArgumentException e) {
+							log.warn("Ignore file {}", child, e);
+							return;
+						}
+						log.debug("parse {}", child);
+						// we can parse it, parsing it
+						list.add(executorService.submit(
+								new LoadTask(executorService, child, baseUri, childNotation, keepBNode, callback)
+						));
+					});
+				} catch (IOException | SecurityException e) {
+					throw new ParserException(e);
+				} catch (ContainerException e) {
+					throw (ParserException) e.getCause();
+				}
+			} else {
+				RDFParserCallback rdfParserCallback;
+				try {
+					// get the parser for the file
+					rdfParserCallback = RDFParserFactory.getParserCallback(notation, spec);
+				} catch (IllegalArgumentException | NotImplementedException e) {
+					log.warn("Ignore file {}", path, e);
+					return list;
+				}
+
+				log.debug("parse {}", path);
+				rdfParserCallback.doParse(path.toAbsolutePath().toString(), baseUri, notation, keepBNode, callback);
+			}
+
+			return list;
+		}
 	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserList.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserList.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.util.io.IOUtil;
@@ -45,14 +46,14 @@ import org.rdfhdt.hdt.util.io.IOUtil;
  *
  */
 public class RDFParserList implements RDFParserCallback {
-	private final boolean simple;
+	private final HDTOptions spec;
 
-	public RDFParserList(boolean simple) {
-		this.simple = simple;
+	public RDFParserList(HDTOptions spec) {
+		this.spec = spec;
 	}
 
 	public RDFParserList() {
-		this(false);
+		this(HDTOptions.EMPTY);
 	}
 
 	/* (non-Javadoc)
@@ -82,7 +83,7 @@ public class RDFParserList implements RDFParserCallback {
 		} finally {
 			try {
 				reader.close();
-			} catch (IOException e) {
+			} catch (IOException ignore) {
 			}
 		}
 	}
@@ -97,7 +98,7 @@ public class RDFParserList implements RDFParserCallback {
 
 					RDFNotation guessnot = RDFNotation.guess(line);
 					System.out.println("Parse from list: "+line+" as "+guessnot);
-					RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, simple);
+					RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, spec);
 
 					parser.doParse(line, baseUri, guessnot, keepBNode, callback);
 				}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRAR.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRAR.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.slf4j.Logger;
@@ -29,13 +30,13 @@ public class RDFParserRAR implements RDFParserCallback {
 	private final static String [] cmdList = { "unrar", "vb" , "<RAR>"};
 	private final static String [] cmdExtractFile = { "unrar", "p", "-inul", "<RAR>", "<FILE>" };
 	private static Boolean available;
-	private final boolean simple;
+	private final HDTOptions spec;
 
-	public RDFParserRAR(boolean simple) {
-		this.simple = simple;
+	public RDFParserRAR(HDTOptions spec) {
+		this.spec = spec;
 	}
 	public RDFParserRAR() {
-		this(false);
+		this(HDTOptions.EMPTY);
 	}
 
 	// List files in rar
@@ -88,7 +89,7 @@ public class RDFParserRAR implements RDFParserCallback {
 				if(guessnot!=null) {
 					// Create 
 					log.info("Parse from rar: {} as {}", fileName, guessnot);
-					RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, simple);
+					RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, spec);
 
 					cmdExtract[4]=fileName;
 					ProcessBuilder extractProcessBuilder = new ProcessBuilder(cmdExtract);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserTar.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserTar.java
@@ -5,6 +5,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.util.io.IOUtil;
@@ -26,14 +27,14 @@ import java.io.InputStream;
 
 public class RDFParserTar implements RDFParserCallback {
 	private static final Logger log = LoggerFactory.getLogger(RDFParserTar.class);
-	private final boolean simple;
+	private final HDTOptions spec;
 
-	public RDFParserTar(boolean simple) {
-		this.simple = simple;
+	public RDFParserTar(HDTOptions spec) {
+		this.spec = spec;
 	}
 
 	public RDFParserTar() {
-		this(false);
+		this(HDTOptions.EMPTY);
 	}
 
 	/* (non-Javadoc)
@@ -67,7 +68,7 @@ public class RDFParserTar implements RDFParserCallback {
 					try {
 						RDFNotation guessnot = RDFNotation.guess(entry.getName());
 						log.info("Parse from tar: {} as {}", entry.getName(), guessnot);
-						RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, simple);
+						RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, spec);
 
 						parser.doParse(nonCloseIn, baseUri, guessnot, keepBNode, callback);
 					}catch (IllegalArgumentException | ParserException e1) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserZip.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserZip.java
@@ -7,6 +7,7 @@ import java.util.zip.ZipInputStream;
 
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.util.io.IOUtil;
@@ -24,14 +25,14 @@ import org.rdfhdt.hdt.util.io.NonCloseInputStream;
 
 public class RDFParserZip implements RDFParserCallback {
 
-	private final boolean simple;
+	private final HDTOptions spec;
 
-	public RDFParserZip(boolean simple) {
-		this.simple = simple;
+	public RDFParserZip(HDTOptions spec) {
+		this.spec = spec;
 	}
 
 	public RDFParserZip() {
-		this(false);
+		this(HDTOptions.EMPTY);
 	}
 
 	/* (non-Javadoc)
@@ -63,7 +64,7 @@ public class RDFParserZip implements RDFParserCallback {
 					try {
 						RDFNotation guessnot = RDFNotation.guess(zipEntry.getName());
 						System.out.println("Parse from zip: "+zipEntry.getName()+" as "+guessnot);
-						RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, simple);
+						RDFParserCallback parser = RDFParserFactory.getParserCallback(guessnot, spec);
 
 						parser.doParse(nonCloseIn, baseUri, guessnot, keepBNode, callback);
 					} catch (IllegalArgumentException | ParserException e1) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesCat.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesCat.java
@@ -20,13 +20,12 @@
 package org.rdfhdt.hdt.triples.impl;
 
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.rdfhdt.hdt.compact.bitmap.Bitmap375;
+import org.rdfhdt.hdt.compact.bitmap.Bitmap375Big;
 import org.rdfhdt.hdt.compact.bitmap.ModifiableBitmap;
 import org.rdfhdt.hdt.compact.sequence.SequenceLog64BigDisk;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
@@ -54,8 +53,8 @@ public class BitmapTriplesCat {
         long number = it.estimatedNumResults();
         SequenceLog64BigDisk vectorY = new SequenceLog64BigDisk(location + "vectorY", BitUtil.log2(number), number);
         SequenceLog64BigDisk vectorZ = new SequenceLog64BigDisk(location + "vectorZ",BitUtil.log2(number), number);
-        ModifiableBitmap bitY = new Bitmap375();//Disk(location + "bitY",number);
-        ModifiableBitmap bitZ = new Bitmap375();//Disk(location + "bitZ",number);
+        ModifiableBitmap bitY = Bitmap375Big.memory(0);//Disk(location + "bitY",number);
+        ModifiableBitmap bitZ = Bitmap375Big.memory(0);//Disk(location + "bitZ",number);
 
         long lastX=0, lastY=0, lastZ=0;
         long x, y, z;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 
 import org.rdfhdt.hdt.compact.bitmap.Bitmap;
 import org.rdfhdt.hdt.compact.bitmap.Bitmap375;
@@ -15,6 +16,7 @@ import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.util.BitUtil;
 import org.rdfhdt.hdt.util.StopWatch;
+import org.rdfhdt.hdt.util.io.Closer;
 import org.rdfhdt.hdt.util.io.CountInputStream;
 import org.rdfhdt.hdt.util.io.IOUtil;
 import org.rdfhdt.hdt.util.listener.IntermediateListener;
@@ -68,66 +70,87 @@ class PredicateIndexArray implements PredicateIndex {
 
 	@Override
 	public void generate(ProgressListener listener, HDTOptions specIndex) {
-
 		IntermediateListener iListener = new IntermediateListener(listener);
 		StopWatch st = new StopWatch();
-		@SuppressWarnings("resource")
-		DynamicSequence predCount = new SequenceLog64Big(BitUtil.log2(triples.getSeqY().getNumberOfElements()));
 
-	    long maxCount = 0;
-	    for(long i=0;i<triples.getSeqY().getNumberOfElements(); i++) {
-	        // Read value
-	        long val = triples.getSeqY().get(i);
+		Path diskLocation;
+		if (triples.isUsingDiskSequence()) {
+			try {
+				diskLocation = triples.getDiskSequenceLocation().createOrGetPath();
+			} catch (IOException e) {
+				throw new RuntimeException("Can't create disk sequence", e);
+			}
+		} else {
+			diskLocation = null;
+		}
+		ModifiableBitmap bitmap;
 
-	        // Grow if necessary
-	        if(predCount.getNumberOfElements()<val) {
-	            predCount.resize(val);
-	        }
+		DynamicSequence predCount = triples.createSequence64(diskLocation, "predCount", BitUtil.log2(triples.getSeqY().getNumberOfElements()), 0);
+		try {
+			long maxCount = 0;
+			for (long i = 0; i < triples.getSeqY().getNumberOfElements(); i++) {
+				// Read value
+				long val = triples.getSeqY().get(i);
 
-	        // Increment
-	        long count = predCount.get(val-1)+1;
-	        maxCount = count>maxCount ? count : maxCount;
-	        predCount.set(val-1, count);
+				// Grow if necessary
+				if (predCount.getNumberOfElements() < val) {
+					predCount.resize(val);
+				}
 
-	        ListenerUtil.notifyCond(iListener,  "Counting appearances of predicates", i, triples.getSeqY().getNumberOfElements(), 20000);
-	    }
-	    predCount.aggressiveTrimToSize();
+				// Increment
+				long count = predCount.get(val - 1) + 1;
+				maxCount = Math.max(count, maxCount);
+				predCount.set(val - 1, count);
 
-	    // Convert predicate count to bitmap
-	    ModifiableBitmap bitmap = new Bitmap375(triples.getSeqY().getNumberOfElements());
-	    long tempCountPred=0;
-	    for(long i=0;i<predCount.getNumberOfElements();i++) {
-	        tempCountPred += predCount.get(i);
-	        bitmap.set(tempCountPred-1,true);
-	        ListenerUtil.notifyCond(iListener, "Creating Predicate bitmap", i, predCount.getNumberOfElements(), 100000);
-	    }
-	    bitmap.set(triples.getSeqY().getNumberOfElements()-1, true);
-        log.info("Predicate Bitmap in {}", st.stopAndShow());
-	    st.reset();
-	    IOUtil.closeQuietly(predCount);
-	    predCount=null;
+				ListenerUtil.notifyCond(iListener, "Counting appearances of predicates", i, triples.getSeqY().getNumberOfElements(), 20000);
+			}
+			predCount.aggressiveTrimToSize();
+
+			// Convert predicate count to bitmap
+			bitmap = triples.createBitmap375(diskLocation, "bitmap", triples.getSeqY().getNumberOfElements());
+			long tempCountPred = 0;
+			for (long i = 0; i < predCount.getNumberOfElements(); i++) {
+				tempCountPred += predCount.get(i);
+				bitmap.set(tempCountPred - 1, true);
+				ListenerUtil.notifyCond(iListener, "Creating Predicate bitmap", i, predCount.getNumberOfElements(), 100000);
+			}
+			bitmap.set(triples.getSeqY().getNumberOfElements() - 1, true);
+			log.info("Predicate Bitmap in {}", st.stopAndShow());
+			st.reset();
+		} finally {
+			IOUtil.closeQuietly(predCount);
+		}
 
 
 	    // Create predicate index
-		DynamicSequence array = new SequenceLog64Big(BitUtil.log2(triples.getSeqY().getNumberOfElements()), triples.getSeqY().getNumberOfElements());
-	    array.resize(triples.getSeqY().getNumberOfElements());
+		DynamicSequence array = triples.createSequence64(diskLocation, "array", BitUtil.log2(triples.getSeqY().getNumberOfElements()), triples.getSeqY().getNumberOfElements());
+		try {
+			array.resize(triples.getSeqY().getNumberOfElements());
 
-		DynamicSequence insertArray = new SequenceLog64Big(BitUtil.log2(triples.getSeqY().getNumberOfElements()), bitmap.countOnes());
-	    insertArray.resize(bitmap.countOnes());
+			DynamicSequence insertArray = triples.createSequence64(diskLocation, "insertArray", BitUtil.log2(triples.getSeqY().getNumberOfElements()), bitmap.countOnes());
+			try {
+				insertArray.resize(bitmap.countOnes());
+				for (long i = 0; i < triples.getSeqY().getNumberOfElements(); i++) {
+					long predicateValue = triples.getSeqY().get(i);
 
-	    for(long i=0;i<triples.getSeqY().getNumberOfElements(); i++) {
-	            long predicateValue = triples.getSeqY().get(i);
+					long insertBase = predicateValue == 1 ? 0 : bitmap.select1(predicateValue - 1) + 1;
+					long insertOffset = insertArray.get(predicateValue - 1);
+					insertArray.set(predicateValue - 1, insertOffset + 1);
 
-	            long insertBase = predicateValue==1 ? 0 : bitmap.select1(predicateValue-1)+1;
-	            long insertOffset = insertArray.get(predicateValue-1);
-	            insertArray.set(predicateValue-1, insertOffset+1);
+					array.set(insertBase + insertOffset, i);
 
-	            array.set(insertBase+insertOffset, i);
-
-	            ListenerUtil.notifyCond(iListener,  "Generating predicate references", i, triples.getSeqY().getNumberOfElements(), 100000);
-	    }
-	    IOUtil.closeQuietly(insertArray);
-
+					ListenerUtil.notifyCond(iListener, "Generating predicate references", i, triples.getSeqY().getNumberOfElements(), 100000);
+				}
+			} finally {
+				IOUtil.closeQuietly(insertArray);
+			}
+		} catch (Throwable t) {
+			try {
+				throw t;
+			} finally {
+				IOUtil.closeQuietly(array);
+			}
+		}
 	    this.array = array;
 	    this.bitmap = bitmap;
         log.info("Count predicates in {}", st.stopAndShow());
@@ -144,18 +167,13 @@ class PredicateIndexArray implements PredicateIndex {
 	@Override
 	public void close() throws IOException {
 		try {
-			if (array != null) {
-				array.close();
-			}
+			Closer.closeAll(
+				array,
+				bitmap
+			);
 		} finally {
-			try {
-				if (bitmap instanceof Closeable) {
-					((Closeable) bitmap).close();
-				}
-			} finally {
-				bitmap=null;
-				array=null;
-			}
+			bitmap=null;
+			array=null;
 		}
 	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
@@ -8,7 +8,6 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 
 import org.rdfhdt.hdt.compact.bitmap.Bitmap;
-import org.rdfhdt.hdt.compact.bitmap.Bitmap375;
 import org.rdfhdt.hdt.compact.bitmap.BitmapFactory;
 import org.rdfhdt.hdt.compact.bitmap.ModifiableBitmap;
 import org.rdfhdt.hdt.compact.sequence.*;
@@ -150,6 +149,10 @@ class PredicateIndexArray implements PredicateIndex {
 			} finally {
 				IOUtil.closeQuietly(array);
 			}
+		}
+		try {
+			Closer.closeAll(this.array, this.bitmap);
+		} catch (IOException ignore) {
 		}
 	    this.array = array;
 	    this.bitmap = bitmap;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LargeLongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LargeLongArray.java
@@ -1,0 +1,54 @@
+package org.rdfhdt.hdt.util.disk;
+
+import org.visnow.jlargearrays.LargeArray;
+import org.visnow.jlargearrays.LargeArrayUtils;
+import org.visnow.jlargearrays.LongLargeArray;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link LongArray} using a LargeArray
+ *
+ * @author Antoine Willerval
+ */
+public class LargeLongArray implements LongArray {
+    private LargeArray array;
+
+    /**
+     * @param array large array
+     */
+    public LargeLongArray(LargeArray array) {
+        this.array = array;
+    }
+
+    @Override
+    public long get(long index) {
+        return array.getLong(index);
+    }
+
+    @Override
+    public void set(long index, long value) {
+        array.setLong(index, value);
+    }
+
+    @Override
+    public long length() {
+        return array.length();
+    }
+
+    @Override
+    public int sizeOf() {
+        return (int) array.getType().sizeOf() * 8;
+    }
+
+    @Override
+    public void resize(long newSize) throws IOException {
+        if (newSize > 0) {
+            if (array.length() != newSize) {
+                LongLargeArray a = new LongLargeArray(newSize);
+                LargeArrayUtils.arraycopy(array, 0, a, 0, Math.min(newSize, array.length()));
+                array = a;
+            }
+        }
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArray.java
@@ -1,24 +1,42 @@
 package org.rdfhdt.hdt.util.disk;
 
+import java.io.IOException;
+
 /**
  * Describe a large array of longs
  */
-public interface LongArray {
-	/**
-	 * get an element at a particular index
-	 * @param index the index
-	 * @return the value
-	 */
-	long get(long index);
-	/**
-	 * Set a new value at the specified position.
-	 * @param index the index
-	 * @param value the value
-	 */
-	void set(long index, long value);
+public interface LongArray{
+    /**
+     * get an element at a particular index
+     *
+     * @param index the index
+     * @return the value
+     */
+    long get(long index);
 
-	/**
-	 * @return the length of the array
-	 */
-	long length();
+    /**
+     * Set a new value at the specified position.
+     *
+     * @param index the index
+     * @param value the value
+     */
+    void set(long index, long value);
+
+
+    /**
+     * @return the length of the array
+     */
+    long length();
+
+    /**
+     * @return size of the components (in bits)
+     */
+    int sizeOf();
+
+    /**
+     * resize the array
+     * @param newSize new size
+     * @throws IOException io exception
+     */
+    void resize(long newSize) throws IOException;
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArrayDisk.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArrayDisk.java
@@ -77,6 +77,7 @@ public class LongArrayDisk implements Closeable, LongArray {
                 } else {
                     sizeMapping = MAPPING_SIZE;
                 }
+                assert mappings[block] == null;
                 mappings[block] = IOUtil.mapChannel(location.toAbsolutePath().toString(), channel, FileChannel.MapMode.READ_WRITE, block * MAPPING_SIZE, sizeMapping);
             }
             if (overwrite) {
@@ -138,6 +139,11 @@ public class LongArrayDisk implements Closeable, LongArray {
     @Override
     public long length() {
         return size;
+    }
+
+    @Override
+    public int sizeOf() {
+        return Long.SIZE;
     }
 
     public void set0(long startIndex, long endIndex) {
@@ -204,6 +210,7 @@ public class LongArrayDisk implements Closeable, LongArray {
         }
     }
 
+    @Override
     public void resize(long newSize) throws IOException {
         if (this.size == newSize) {
             return;
@@ -247,6 +254,13 @@ public class LongArrayDisk implements Closeable, LongArray {
                 IOUtil.closeAll(mappings);
             }
         }
+    }
+
+    /**
+     * @return the location of the array disk
+     */
+    public Path getLocation() {
+        return location;
     }
 
     public long getSize() {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArray.java
@@ -1,0 +1,115 @@
+package org.rdfhdt.hdt.util.disk;
+
+import org.rdfhdt.hdt.util.BitUtil;
+import org.rdfhdt.hdt.util.io.IOUtil;
+import org.visnow.jlargearrays.LongLargeArray;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Implementation of LongArray for simple int64 splits
+ */
+public class SimpleSplitLongArray implements LongArray, Closeable {
+    final LongArray array;
+    private final int shift;
+    private final long max;
+    private final int indexMask;
+    private final int numbits;
+
+    private long size;
+    private SimpleSplitLongArray(LongArray array, int numbits, long size) {
+        this.size = size;
+        this.array = array;
+        int b = Long.bitCount(numbits);
+        if (b != 1 || numbits < 1 || numbits > 64) {
+            throw new IllegalArgumentException("numbits should be 2, 4, 8, ... 64");
+        }
+        shift = 6 - BitUtil.log2(numbits - 1);
+        max = (~0L) >>> (64 - numbits);
+        indexMask = (1 << shift) - 1;
+        this.numbits = numbits;
+    }
+
+    public static SimpleSplitLongArray int8Array(long size) {
+        return intXArray(size, 8);
+    }
+
+    public static SimpleSplitLongArray int16Array(long size) {
+        return intXArray(size, 16);
+    }
+
+    public static SimpleSplitLongArray int32Array(long size) {
+        return intXArray(size, 32);
+    }
+
+    public static SimpleSplitLongArray int64Array(long size) {
+        return intXArray(size, 64);
+    }
+
+    public static SimpleSplitLongArray intXArray(long size, int x) {
+        return new SimpleSplitLongArray(new LargeLongArray(new LongLargeArray(1 + size / (64 / x))), x, size);
+    }
+
+    public static SimpleSplitLongArray int8ArrayDisk(Path location, long size) {
+        return intXArrayDisk(location, size, 8);
+    }
+
+    public static SimpleSplitLongArray int16ArrayDisk(Path location, long size) {
+        return intXArrayDisk(location, size, 16);
+    }
+
+    public static SimpleSplitLongArray int32ArrayDisk(Path location, long size) {
+        return intXArrayDisk(location, size, 32);
+    }
+
+    public static SimpleSplitLongArray int64ArrayDisk(Path location, long size) {
+        return intXArrayDisk(location, size, 64);
+    }
+
+    public static SimpleSplitLongArray intXArrayDisk(Path location, long size, int x) {
+        return new SimpleSplitLongArray(new LongArrayDisk(location, 1 + size / (64 / x)), x, size);
+    }
+
+    @Override
+    public long get(long index) {
+        long rindex = index >>> shift;
+        int sindex = (int) (index & indexMask) << (6 - shift);
+        return max & (array.get(rindex) >>> sindex);
+    }
+
+    @Override
+    public void set(long index, long value) {
+        long rindex = index >>> shift;
+        int sindex = (int) (index & indexMask) << (6 - shift);
+
+        long old = array.get(rindex);
+        long v = (old & ~(max << sindex)) | ((max & value) << sindex);
+
+        if (old != v) {
+            array.set(rindex, v);
+        }
+    }
+
+    @Override
+    public long length() {
+        return size;
+    }
+
+    @Override
+    public int sizeOf() {
+        return 1 << (6 - shift);
+    }
+
+    @Override
+    public void resize(long newSize) throws IOException {
+        size = newSize;
+        array.resize(newSize / (64 / numbits));
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtil.closeObject(array);
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/IOUtil.java
@@ -31,7 +31,6 @@ import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.rdfhdt.hdt.compact.integer.VByte;
 import org.rdfhdt.hdt.enums.CompressionType;
 import org.rdfhdt.hdt.listener.ProgressListener;
-import org.rdfhdt.hdt.util.Reference;
 import org.rdfhdt.hdt.util.string.ByteString;
 import org.rdfhdt.hdt.util.string.ByteStringUtil;
 import org.visnow.jlargearrays.LargeArrayUtils;
@@ -60,21 +59,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.*;
 
 /**
  * @author mario.arias
  */
 public class IOUtil {
-	private static int mappedBuffer;
-
 	private IOUtil() {
 	}
 
@@ -331,17 +324,8 @@ public class IOUtil {
 	}
 
 	public static void decompressGzip(File src, File trgt) throws IOException {
-		InputStream in = new GZIPInputStream(new BufferedInputStream(new FileInputStream(src)));
-		try {
-			OutputStream out = new BufferedOutputStream(new FileOutputStream(trgt));
-
-			try {
-				copyStream(in, out);
-			} finally {
-				out.close();
-			}
-		} finally {
-			in.close();
+		try (InputStream in = new GZIPInputStream(new BufferedInputStream(new FileInputStream(src)))) {
+			Files.copy(in, trgt.toPath());
 		}
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/WriteLongArrayBuffer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/WriteLongArrayBuffer.java
@@ -147,6 +147,16 @@ public class WriteLongArrayBuffer implements LongArray, Closeable {
 		return array.length();
 	}
 
+	@Override
+	public int sizeOf() {
+		return array.sizeOf();
+	}
+
+	@Override
+	public void resize(long newSize) throws IOException {
+		array.resize(newSize);
+	}
+
 	/**
 	 * @return the used size of the buffer
 	 */

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/bitmap/BitSequence375Test.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/bitmap/BitSequence375Test.java
@@ -1,39 +1,90 @@
 package org.rdfhdt.hdt.compact.bitmap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.rdfhdt.hdt.util.io.CloseSuppressPath;
+import org.rdfhdt.hdt.util.io.Closer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.BitSet;
+import java.util.Collection;
+import java.util.List;
 import java.util.Random;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+@RunWith(Parameterized.class)
 public class BitSequence375Test {
-	final static int num=10000;
-	
-	Bitmap375 bitseq;
-	BitSet bitset; 
-	
-	@Before
-	public void setUp() throws Exception {
-		Random r = new Random(1);
-		
-		bitseq = new Bitmap375(num);
-		bitset = new BitSet();
-				
-		for(int i=0;i<num;i++) {
-			boolean value =r.nextBoolean(); 
-			bitset.set(i, value);
-			bitseq.set(i, value);
-		}	
-	}
-	
+    private static final String MEMORY = "memory";
+    private static final String DISK = "disk";
+    private static final String FULL_DISK = "full_disk";
 
-	// Naive impl of select0
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object> params() {
+        return List.of(MEMORY, DISK, FULL_DISK);
+    }
+
+    static final long num = 10000;
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Parameterized.Parameter
+    public String disk;
+    Bitmap375Big bitseq;
+    BitSet bitset;
+    Closer add;
+
+    @Before
+    public void setUp() throws Exception {
+        Random r = new Random(1);
+
+        add = Closer.of();
+
+        switch (disk) {
+            case MEMORY: {
+                bitseq = Bitmap375Big.memory(num);
+                break;
+            }
+            case DISK: {
+                Path file = tempDir.getRoot().toPath().resolve("test.bin");
+                bitseq = Bitmap375Big.disk(file, num, false);
+                add.with(CloseSuppressPath.of(file));
+                break;
+            }
+            case FULL_DISK: {
+                Path file = tempDir.getRoot().toPath().resolve("test.bin");
+                bitseq = Bitmap375Big.disk(file, num, true);
+                add.with(CloseSuppressPath.of(file));
+                break;
+            }
+            default:
+                throw new AssertionError();
+        }
+        bitset = new BitSet();
+
+        for (int i = 0; i < num; i++) {
+            boolean value = r.nextBoolean();
+            bitset.set(i, value);
+            bitseq.set(i, value);
+        }
+    }
+
+    @After
+    public void closer() throws IOException {
+        Closer.closeAll(bitseq, bitset);
+    }
+
+
+    // Naive impl of select0
 //		public long select0b(long x) {
 //			if(x<=0) {
 //				return -1;
@@ -50,164 +101,168 @@ public class BitSequence375Test {
 //			return getNumBits();
 //		}
 
-	@Test
-	public void testLoadSave() {
-		try {
-			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			bitseq.save(out, null);
-			
-			ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-			
-			Bitmap375 loaded = new Bitmap375();
-			loaded.load(in, null);
-			
-			assertEquals("Save/Load different number of elements", bitseq.getNumBits(), loaded.getNumBits());
-			for(int i=0;i<bitseq.getNumBits();i++) {
-				assertEquals("Save/Load different value", bitseq.access(i), loaded.access(i));
-			}
-		} catch (IOException e) {
-			fail("Exception thrown: "+e);
-		}
-		
-	}
-	
-	@Test
-	public void testNumbits() {
-		assertEquals(0, Bitmap64.lastWordNumBits(0));
-		assertEquals(1, Bitmap64.lastWordNumBits(1));
-		assertEquals(64, Bitmap64.lastWordNumBits(64));
-		assertEquals(1, Bitmap64.lastWordNumBits(65));
-		assertEquals(64, Bitmap64.lastWordNumBits(128));
-		assertEquals(1, Bitmap64.lastWordNumBits(129));
-		
+    @Test
+    public void testLoadSave() {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            bitseq.save(out, null);
+
+            ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+
+            try (Bitmap375Big loaded = Bitmap375Big.memory(0)) {
+                loaded.load(in, null);
+
+                assertEquals("Save/Load different number of elements", bitseq.getNumBits(), loaded.getNumBits());
+                for (int i = 0; i < bitseq.getNumBits(); i++) {
+                    assertEquals("Save/Load different value", bitseq.access(i), loaded.access(i));
+                }
+            }
+        } catch (IOException e) {
+            fail("Exception thrown: " + e);
+        }
+
+    }
+
+    @Test
+    public void testNumbits() {
+        assertEquals(0, Bitmap64Big.lastWordNumBits(0));
+        assertEquals(1, Bitmap64Big.lastWordNumBits(1));
+        assertEquals(64, Bitmap64Big.lastWordNumBits(64));
+        assertEquals(1, Bitmap64Big.lastWordNumBits(65));
+        assertEquals(64, Bitmap64Big.lastWordNumBits(128));
+        assertEquals(1, Bitmap64Big.lastWordNumBits(129));
+
 //		assertEquals(0, Bitmap64.numWords(0));
-		assertEquals(1, Bitmap64.numWords(1));
-		assertEquals(1, Bitmap64.numWords(64));
-		assertEquals(2, Bitmap64.numWords(65));
-		assertEquals(5, Bitmap64.numWords(257));
-		
+        assertEquals(1, Bitmap64Big.numWords(1));
+        assertEquals(1, Bitmap64Big.numWords(64));
+        assertEquals(2, Bitmap64Big.numWords(65));
+        assertEquals(5, Bitmap64Big.numWords(257));
+
 //		for(int i=0;i<1000;i++) {
 //			int words=(int) Bitmap64.numWords(i);
 //			int bitsLast=Bitmap64.lastWordNumBits(i);
 //			int bytes = (int) Bitmap64.numBytes(i);
 //			System.out.println(i+" bits  "+bytes+" bytes  "+words+" words / "+bitsLast+" bits last.");
 //		}	
-	}
-	
-	@Test 
-	public void testSize() {
-		assertEquals(bitseq.getNumBits(), num);
-	}
-	
-	@Test
-	public void testAccess() {
-		for(int i=0;i<bitset.size();i++) {
-			assertEquals(bitset.get(i), bitseq.access(i));
-		}
-	}
+    }
 
-	@Test
-	public void testRank1() {
-		long count = 0;
-		for(long i=0;i<bitseq.getNumBits();i++) {
-			if(bitseq.access(i)) {
-				count++;
+    @Test
+    public void testSize() {
+        assertEquals(bitseq.getNumBits(), num);
+    }
+
+    @Test
+    public void testAccess() {
+        for (int i = 0; i < bitset.size(); i++) {
+            assertEquals(bitset.get(i), bitseq.access(i));
+        }
+    }
+
+    @Test
+    public void testRank1() {
+        long count = 0;
+        for (long i = 0; i < bitseq.getNumBits(); i++) {
+            if (bitseq.access(i)) {
+                count++;
 //				assertEquals("Wrong rank1", count, bitseq.rank1(i));
 //				assertEquals("Wrong rank new", bitseq.rank1(i), bitnew.rank1(i));
-				
-				if(bitseq.rank1(i)!=count) {
-					System.out.println("Different");
-					
-					long a= bitseq.rank1(i);
-				}
-				
-				assertEquals(count, bitseq.rank1(i));
-			}
-		}
-	}
 
-	@Test
-	public void testSelect1() {
-		for(long i=0;i<bitseq.getNumBits();i++) {
-			
+                if (bitseq.rank1(i) != count) {
+                    System.out.println("Different");
+
+                    long a = bitseq.rank1(i);
+                }
+
+                assertEquals(count, bitseq.rank1(i));
+            }
+        }
+    }
+
+    @Test
+    public void testSelect1() {
+        for (long i = 0; i < bitseq.getNumBits(); i++) {
+
 //			System.out.print("***"+i+"> "+(bitseq.access(i)?1:0)+ " \t  Rank1("+i+"): "+ bitseq.rank1(i) + " Select1("+bitseq.rank1(i)+"): " + bitseq.select1(bitseq.rank1(i))+ " SelectNext1("+i+"): "+ bitseq.selectNext1(i));
-			if(bitseq.access(i)) {
-				assertEquals("Select1 wrong",i,  (bitseq.select1(bitseq.rank1(i))));
-			}
-		}	
-	}
-	
-	@Test
-	public void testSelectNext1() {
-		for(long i=0;i<bitseq.getNumBits();i++) {
+            if (bitseq.access(i)) {
+                assertEquals("Select1 wrong", i, (bitseq.select1(bitseq.rank1(i))));
+            }
+        }
+    }
+
+    @Test
+    public void testSelectNext1() {
+        for (long i = 0; i < bitseq.getNumBits(); i++) {
 //			System.out.println("Pos: "+i+" => "+ (bitseq.access(i)?"1":"0")+ " Next: "+bitseq.selectNext1(i));
-		}	
-	}
-	
-	public long select0b(Bitmap375 bitseq, long x) {
-		if(x<=0) {
-			return -1;
-		}
-		long numzeros=0;
-		for(long i=0;i<bitseq.getNumBits();i++) {
-			if(!bitseq.access(i)) {
-				numzeros++;
-			}
-			if(numzeros==x) {
-				return i;
-			}
-		}
-		return bitseq.getNumBits();
-	}
-	
-	@Test
-	public void testSelect0() {
-		long numzeros=0;
-		for(long i=0;i<bitseq.getNumBits();i++) {
-			
+        }
+    }
+
+    public long select0b(ModifiableBitmap bitseq, long x) {
+        if (x <= 0) {
+            return -1;
+        }
+        long numzeros = 0;
+        for (long i = 0; i < bitseq.getNumBits(); i++) {
+            if (!bitseq.access(i)) {
+                numzeros++;
+            }
+            if (numzeros == x) {
+                return i;
+            }
+        }
+        return bitseq.getNumBits();
+    }
+
+    @Test
+    public void testSelect0() {
+        long numzeros = 0;
+        for (long i = 0; i < bitseq.getNumBits(); i++) {
+
 //			System.out.print("***"+i+"> "+(bitseq.access(i)?1:0)+ " \t  Rank1("+i+"): "+ bitseq.rank1(i) + " Select1("+bitseq.rank1(i)+"): " + bitseq.select1(bitseq.rank1(i))+ " SelectNext1("+i+"): "+ bitseq.selectNext1(i));
-			if(bitseq.access(i)) {
-//				assertEquals("Select0 wrong",i,  (bitseq.select0(bitseq.rank0(i))));
-			} else {
-				numzeros++;
-			}
-			long rk = bitseq.rank0(i);
-			long sel = bitseq.select0(rk);
-			long selb = select0b(bitseq, rk);
+            if (bitseq.access(i)) {
+//				assertEquals("Select0 wrong", i, (bitseq.select0(bitseq.rank0(i))));
+            } else {
+                numzeros++;
+            }
+            long rk = bitseq.rank0(i);
+            long sel = bitseq.select0(rk);
+            long selb = select0b(bitseq, rk);
 //			System.out.println(i+" => "+ (bitseq.access(i) ? "1" : "0") +" Zeros: "+numzeros+" Rank0="+rk+ " Sel0="+sel+" Sel0b="+selb);
-			assertEquals("Select0 wrong", sel, selb);
-		}	
-	}
+            assertEquals("Select0 wrong", sel, selb);
+        }
+    }
 
-	@Test
-	public void testCountOnes() {
-		int count = 0;
-		for(int i=0;i<bitseq.getNumBits();i++) {
-			if(bitseq.access(i)) {
-				count++;
-			}
-		}
-		assertEquals("Wrong count ones", count, bitseq.countOnes());
-	}
+    @Test
+    public void testCountOnes() {
+        int count = 0;
+        for (int i = 0; i < bitseq.getNumBits(); i++) {
+            if (bitseq.access(i)) {
+                count++;
+            }
+        }
+        assertEquals("Wrong count ones", count, bitseq.countOnes());
+    }
 
-	@Test
-	public void testCountZeros() {
-		int count = 0;
-		for(int i=0;i<bitseq.getNumBits();i++) {
-			if(!bitseq.access(i)) {
-				count++;
-			}
-		}
-		assertEquals("Wrong count zeros", count, bitseq.countZeros());
-	}
-	
+    @Test
+    public void testCountZeros() {
+        int count = 0;
+        for (int i = 0; i < bitseq.getNumBits(); i++) {
+            if (!bitseq.access(i)) {
+                count++;
+            }
+        }
+        assertEquals("Wrong count zeros", count, bitseq.countZeros());
+    }
 
-	@Test
-	public void testBitutilSelect0() {
+
+    @Test
+    public void testBitutilSelect0() {
 //		IOUtil.printBitsln(bitseq.words[0],64);
-		int numbits = 64-Long.bitCount(bitseq.words[0]);
+
+        long word = bitseq.words.get(0);
+
+        int numbits = 64 - Long.bitCount(word);
 //		for(int i=1;i<=numbits;i++) {
 //			System.out.println("Select0("+i+") = "+BitUtil.select0(bitseq.words[0], i));
 //		}
-	}
+    }
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/HDTManagerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/hdt/HDTManagerTest.java
@@ -806,7 +806,9 @@ public class HDTManagerTest {
 			// create DISK HDT
 			try (InputStream in = IOUtil.getFileInputStream(ntFile)) {
 				try (PipedCopyIterator<TripleString> it = RDFParserFactory.readAsIterator(
-						RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, true),
+						RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, HDTOptions.of(
+								Map.of(HDTOptionsKeys.NT_SIMPLE_PARSER_KEY, "true")
+						)),
 						in, HDTTestUtils.BASE_URI, true, RDFNotation.NTRIPLES
 				)) {
 					try (HDT expected = HDTManager.generateHDT(

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/RDFContainer.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/RDFContainer.java
@@ -1,0 +1,22 @@
+package org.rdfhdt.hdt.rdf.parsers;
+
+import org.rdfhdt.hdt.rdf.RDFParserCallback;
+import org.rdfhdt.hdt.triples.TripleString;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RDFContainer implements RDFParserCallback.RDFCallback {
+    private final Set<TripleString> triples = new HashSet<>();
+
+
+    @Override
+    public void processTriple(TripleString triple, long pos) {
+        // clone the triple
+        triples.add(triple.tripleToString());
+    }
+
+    public Set<TripleString> getTriples() {
+        return triples;
+    }
+}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/RDFParserDirTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/RDFParserDirTest.java
@@ -1,5 +1,6 @@
 package org.rdfhdt.hdt.rdf.parsers;
 
+import org.apache.commons.io.file.PathUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -7,10 +8,14 @@ import org.junit.rules.TemporaryFolder;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.ParserException;
 import org.rdfhdt.hdt.header.HeaderUtil;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.triples.TripleString;
+import org.rdfhdt.hdt.triples.impl.utils.HDTTestUtils;
 import org.rdfhdt.hdt.util.LargeFakeDataSetStreamSupplier;
+import org.rdfhdt.hdt.util.StopWatch;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,66 +23,173 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RDFParserDirTest {
+    private static final boolean LOG_TIME = false;
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
-	@Test
-	public void dirTest() throws IOException, ParserException {
-		Path root = tempDir.newFolder().toPath();
-		Files.createDirectories(root);
+    @Test
+    public void dirTest() throws IOException, ParserException {
+        Path root = tempDir.newFolder().toPath();
+        Files.createDirectories(root);
 
-		Path testDir1 = root.resolve("testDir1");
-		Path testDir2 = root.resolve("testDir2");
-		Path testDir3 = root.resolve("testDir3");
-		Path testDir4 = testDir3.resolve("testDir4");
+        Path testDir1 = root.resolve("testDir1");
+        Path testDir2 = root.resolve("testDir2");
+        Path testDir3 = root.resolve("testDir3");
+        Path testDir4 = testDir3.resolve("testDir4");
 
-		Files.createDirectories(testDir1);
-		Files.createDirectories(testDir2);
-		Files.createDirectories(testDir3);
-		Files.createDirectories(testDir4);
+        Files.createDirectories(testDir1);
+        Files.createDirectories(testDir2);
+        Files.createDirectories(testDir3);
+        Files.createDirectories(testDir4);
 
-		LargeFakeDataSetStreamSupplier supplier = LargeFakeDataSetStreamSupplier
-				.createSupplierWithMaxTriples(20, 34);
+        LargeFakeDataSetStreamSupplier supplier = LargeFakeDataSetStreamSupplier
+                .createSupplierWithMaxTriples(20, 34);
 
-		supplier.createNTFile(root.resolve("test.nt").toAbsolutePath().toString());
-		supplier.createNTFile(testDir1.resolve("test1.nt").toAbsolutePath().toString());
-		supplier.createNTFile(testDir2.resolve("test21.nt").toAbsolutePath().toString());
-		supplier.createNTFile(testDir2.resolve("test22.nt").toAbsolutePath().toString());
-		supplier.createNTFile(testDir3.resolve("test31.nt").toAbsolutePath().toString());
-		supplier.createNTFile(testDir3.resolve("test32.nt").toAbsolutePath().toString());
+        supplier.createNTFile(root.resolve("test.nt").toAbsolutePath().toString());
+        supplier.createNTFile(testDir1.resolve("test1.nt").toAbsolutePath().toString());
+        supplier.createNTFile(testDir2.resolve("test21.nt").toAbsolutePath().toString());
+        supplier.createNTFile(testDir2.resolve("test22.nt").toAbsolutePath().toString());
+        supplier.createNTFile(testDir3.resolve("test31.nt").toAbsolutePath().toString());
+        supplier.createNTFile(testDir3.resolve("test32.nt").toAbsolutePath().toString());
 
-		Files.writeString(testDir2.resolve("thing.txt"), "Not parsable RDF DATA");
-		Files.writeString(root.resolve("thing.py"), "print('Not parsable RDF DATA')");
-		Files.writeString(testDir4.resolve("thing.sh"), "echo \"Not Parsable RDF data\"");
+        Files.writeString(testDir2.resolve("thing.txt"), "Not parsable RDF DATA");
+        Files.writeString(root.resolve("thing.py"), "print('Not parsable RDF DATA')");
+        Files.writeString(testDir4.resolve("thing.sh"), "echo \"Not Parsable RDF data\"");
 
-		supplier.reset();
+        supplier.reset();
 
-		List<TripleString> excepted = new ArrayList<>();
-		// 6 for the 6 files
-		for (int i = 0; i < 6; i++) {
-			Iterator<TripleString> it = supplier.createTripleStringStream();
-			while (it.hasNext()) {
-				TripleString ts = it.next();
-				TripleString e = new TripleString(
-						HeaderUtil.cleanURI(ts.getSubject().toString()),
-						HeaderUtil.cleanURI(ts.getPredicate().toString()),
-						HeaderUtil.cleanURI(ts.getObject().toString())
-				);
-				excepted.add(e);
-			}
-		}
+        List<TripleString> excepted = new ArrayList<>();
+        // 6 for the 6 files
+        for (int i = 0; i < 6; i++) {
+            Iterator<TripleString> it = supplier.createTripleStringStream();
+            while (it.hasNext()) {
+                TripleString ts = it.next();
+                TripleString e = new TripleString(
+                        HeaderUtil.cleanURI(ts.getSubject().toString()),
+                        HeaderUtil.cleanURI(ts.getPredicate().toString()),
+                        HeaderUtil.cleanURI(ts.getObject().toString())
+                );
+                excepted.add(e);
+            }
+        }
 
-		String filename = root.toAbsolutePath().toString();
-		RDFNotation dir = RDFNotation.guess(filename);
-		Assert.assertEquals(dir, RDFNotation.DIR);
-		RDFParserCallback callback = RDFParserFactory.getParserCallback(dir);
-		Assert.assertTrue(callback instanceof RDFParserDir);
+        String filename = root.toAbsolutePath().toString();
+        RDFNotation dir = RDFNotation.guess(filename);
+        Assert.assertEquals(dir, RDFNotation.DIR);
+        RDFParserCallback callback = RDFParserFactory.getParserCallback(dir);
+        assertTrue(callback instanceof RDFParserDir);
 
-		callback.doParse(filename, "http://example.org/#", dir, true, (triple, pos) ->
-				Assert.assertTrue("triple " + triple + " wasn't excepted", excepted.remove(triple))
-		);
-	}
+        callback.doParse(filename, "http://example.org/#", dir, true, (triple, pos) ->
+                assertTrue("triple " + triple + " wasn't excepted", excepted.remove(triple))
+        );
+    }
+
+    @Test
+    public void asyncTest() throws IOException, ParserException {
+        // create fake dataset
+        int maxThread = 20;
+        int filePerDir = maxThread * 2 / 3;
+        int files = maxThread * 10;
+        long triplePerFile = 1000;
+
+        Path root = tempDir.newFolder().toPath();
+        Files.createDirectories(root);
+        LargeFakeDataSetStreamSupplier supplier = LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(triplePerFile, 86);
+        try {
+            List<Path> allFiles = new ArrayList<>();
+            for (int i = 0; i < files; i++) {
+                Path location = root;
+                int j = i;
+                while (j > filePerDir) {
+                    location = location.resolve("sub" + (j % filePerDir));
+                    j /= filePerDir;
+                }
+                Files.createDirectories(location);
+                Path tmpFile = location.resolve("test_" + i + ".nt");
+                supplier.createNTFile(tmpFile);
+                allFiles.add(tmpFile);
+            }
+
+            StopWatch time = new StopWatch();
+            RDFContainer containerSimple = new RDFContainer();
+            {
+                for (Path path : allFiles) {
+                    RDFParserCallback parser = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES);
+                    parser.doParse(
+                            path.toAbsolutePath().toString(),
+                            HDTTestUtils.BASE_URI,
+                            RDFNotation.NTRIPLES,
+                            true,
+                            containerSimple
+                    );
+                }
+            }
+            time.stop();
+            if (LOG_TIME) {
+                System.out.println("simple parsing: " + time);
+            }
+            time.reset();
+
+            RDFContainer containerAsync = new RDFContainer();
+            {
+                RDFNotation notation = RDFNotation.guess(root);
+                assertEquals(notation, RDFNotation.DIR);
+                RDFParserCallback parser = RDFParserFactory.getParserCallback(
+                        notation, HDTOptions.of(Map.of(HDTOptionsKeys.ASYNC_DIR_PARSER_KEY, "" + maxThread))
+                );
+                assertTrue(parser instanceof RDFParserDir);
+                assertEquals(maxThread, ((RDFParserDir) parser).async);
+
+                parser.doParse(
+                        root.toAbsolutePath().toString(),
+                        HDTTestUtils.BASE_URI,
+                        notation,
+                        true,
+                        containerAsync
+                );
+            }
+            time.stop();
+            if (LOG_TIME) {
+                System.out.println("async parsing: " + time);
+            }
+            time.reset();
+
+            assertEquals("Triples aren't matching with async version!", containerSimple.getTriples(), containerAsync.getTriples());
+
+            RDFContainer containerSync = new RDFContainer();
+            {
+                RDFNotation notation = RDFNotation.guess(root);
+                assertEquals(notation, RDFNotation.DIR);
+                RDFParserCallback parser = RDFParserFactory.getParserCallback(notation, HDTOptions.EMPTY);
+                assertTrue(parser instanceof RDFParserDir);
+                assertEquals(1, ((RDFParserDir) parser).async);
+
+                parser.doParse(
+                        root.toAbsolutePath().toString(),
+                        HDTTestUtils.BASE_URI,
+                        notation,
+                        true,
+                        containerSync
+                );
+            }
+
+            time.stop();
+            if (LOG_TIME) {
+                System.out.println("sync parsing: " + time);
+            }
+            time.reset();
+
+            assertEquals("Triples aren't matching with sync version!", containerSimple.getTriples(), containerSync.getTriples());
+        } finally {
+            PathUtils.deleteDirectory(root);
+        }
+
+    }
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesTest.java
@@ -11,6 +11,7 @@ import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.options.ControlInformation;
 import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.triples.Triples;
 import org.rdfhdt.hdt.util.LargeFakeDataSetStreamSupplier;
@@ -97,8 +98,9 @@ public class BitmapTriplesTest extends AbstractMapMemoryTest {
 
 			// set config
 			if (disk) {
-				optDisk.set("bitmaptriples.sequence.disk", "true");
-				optDisk.set("bitmaptriples.sequence.disk.location", root.resolve("indexdir").toAbsolutePath().toString());
+				optDisk.set(HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK, true);
+				optDisk.set(HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_SUBINDEX, true);
+				optDisk.set(HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_LOCATION, root.resolve("indexdir").toAbsolutePath());
 			}
 
 			try (

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplierTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/LargeFakeDataSetStreamSupplierTest.java
@@ -11,6 +11,8 @@ import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.hdt.HDTManagerTest;
 import org.rdfhdt.hdt.iterator.utils.CombinedIterator;
 import org.rdfhdt.hdt.iterator.utils.PipedCopyIterator;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
@@ -25,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -191,7 +194,9 @@ public class LargeFakeDataSetStreamSupplierTest {
 
 		supplier2.createNTFile(p3);
 
-		RDFParserCallback parser = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, true);
+		RDFParserCallback parser = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, HDTOptions.of(
+				Map.of(HDTOptionsKeys.NT_SIMPLE_PARSER_KEY, "true")
+		));
 		try {
 			try (
 					InputStream stream = new BufferedInputStream(Files.newInputStream(p12));

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/UnicodeEscapeTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/UnicodeEscapeTest.java
@@ -3,17 +3,15 @@ package org.rdfhdt.hdt.util;
 import org.junit.Test;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.rdf.RDFParserFactory;
 import org.rdfhdt.hdt.triples.TripleString;
 import org.rdfhdt.hdt.triples.impl.utils.HDTTestUtils;
 
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -22,8 +20,12 @@ public class UnicodeEscapeTest {
 	public void encodeTest() throws ParserException {
 		String file = Objects.requireNonNull(UnicodeEscapeTest.class.getClassLoader().getResource("unicodeTest.nt"), "can't find file").getFile();
 
-		RDFParserCallback factory = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, true);
-		RDFParserCallback factory2 = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, false);
+		RDFParserCallback factory = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, HDTOptions.of(
+				Map.of(HDTOptionsKeys.NT_SIMPLE_PARSER_KEY, "true")
+		));
+		RDFParserCallback factory2 = RDFParserFactory.getParserCallback(RDFNotation.NTRIPLES, HDTOptions.of(
+				Map.of(HDTOptionsKeys.NT_SIMPLE_PARSER_KEY, "false")
+		));
 
 
 		Set<TripleString> ts1 = new TreeSet<>(Comparator.comparing(t -> {

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArrayTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArrayTest.java
@@ -1,0 +1,65 @@
+package org.rdfhdt.hdt.util.disk;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.visnow.jlargearrays.LongLargeArray;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class SimpleSplitLongArrayTest {
+    @Parameterized.Parameters(name = "numbits={0}")
+    public static Collection<Object> params() {
+        return IntStream.range(0, 6 + 1).mapToObj(i -> 1 << i).collect(Collectors.toList());
+    }
+
+    @Parameterized.Parameter
+    public int bits;
+
+    @Test
+    public void setTest() throws IOException {
+        LargeLongArray arrayExcepted = new LargeLongArray(new LongLargeArray(128L));
+        try (SimpleSplitLongArray array = SimpleSplitLongArray.intXArray(128, bits)) {
+
+            long max = (~0L) >>> (64 - bits);
+            assertEquals("non matching size", arrayExcepted.length(), array.length());
+
+            assertEquals("bad sizeof", bits, array.sizeOf());
+
+            for (int i = 0; i < arrayExcepted.length(); i++) {
+                arrayExcepted.set(i, i & max);
+                array.set(i, i & max);
+                assertEquals("non matching value #" + i, i & max, arrayExcepted.get(i));
+                assertEquals("non matching value #" + i, i & max, array.get(i));
+            }
+            for (int i = 0; i < arrayExcepted.length(); i++) {
+                assertEquals("non matching value #" + i, i & max, arrayExcepted.get(i));
+                assertEquals("non matching value #" + i, i & max, array.get(i));
+            }
+        }
+    }
+
+    @Test
+    public void resizeTest() throws IOException {
+        LargeLongArray arrayExcepted = new LargeLongArray(new LongLargeArray(128L));
+        try (SimpleSplitLongArray array = SimpleSplitLongArray.intXArray(128, bits)) {
+
+            assertEquals("non matching size", arrayExcepted.length(), array.length());
+
+            assertEquals("bad sizeof", bits, array.sizeOf());
+
+            arrayExcepted.resize(256);
+            array.resize(256);
+
+            assertEquals("non matching size", arrayExcepted.length(), array.length());
+
+            assertEquals("non matching size", arrayExcepted.length(), array.array.length() * (64 / bits));
+        }
+    }
+}


### PR DESCRIPTION
This PR add 2 async versions for the DirParser and the CatTree

The CatTree async version can be selected with the `loader.cattree.async=[boolean]` option, knowing a cat is most likely faster than the time before the next cat, you can't select more than 2 threads.

The DirParser async version can be selected with the `parser.dir.async=[number]` option, 1 = sync, 0 = processor count, n = using n threads.

I've also added a commit to use large arrays in Bitmap375Disk to use larger indexes.

EDIT:
For example, when loading 200 different NT files (same size), it take 4 times less time to load them with the dir parser:

```
async parsing: 295 ms 526 us
sync parsing: 1 sec 178 ms 398 us
```