### PR TITLE
Disk co-indexing with KWay merge

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTManager.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTManager.java
@@ -3,8 +3,11 @@ package org.rdfhdt.hdt.hdt;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.rdfhdt.hdt.compact.bitmap.Bitmap;
 import org.rdfhdt.hdt.enums.CompressionType;
@@ -25,22 +28,28 @@ public abstract class HDTManager {
 			try {
 				// Try to instantiate pro
 				Class<?> managerImplClass = Class.forName("org.rdfhdt.hdt.pro.HDTManagerProImpl");
-				instance = (HDTManager) managerImplClass.newInstance();
+				instance = (HDTManager) managerImplClass.getDeclaredConstructor().newInstance();
 			} catch (Exception e1) {
 				try {
 					// Pro not found, instantiate normal
 					Class<?> managerImplClass = Class.forName("org.rdfhdt.hdt.hdt.HDTManagerImpl");
-					instance = (HDTManager) managerImplClass.newInstance();
+					instance = (HDTManager) managerImplClass.getDeclaredConstructor().newInstance();
 				} catch (ClassNotFoundException e) {
-					throw new RuntimeException("Class org.rdfhdt.hdt.hdt.HDTManagerImpl not found. Did you include the HDT implementation jar?");
-				} catch (InstantiationException e) {
-					throw new RuntimeException("Cannot create implementation for HDTManager. Does the class org.rdfhdt.hdt.hdt.HDTManagerImpl inherit from HDTManager?");
+					throw new RuntimeException("Class org.rdfhdt.hdt.hdt.HDTManagerImpl not found. Did you include the HDT implementation jar?", e);
+				} catch (InstantiationException | InvocationTargetException e) {
+					throw new RuntimeException("Cannot create implementation for HDTManager. Does the class org.rdfhdt.hdt.hdt.HDTManagerImpl inherit from HDTManager?", e);
+				} catch (NoSuchMethodException e) {
+					throw new RuntimeException("Cannot create implementation for HDTManager. Does the class org.rdfhdt.hdt.hdt.HDTManagerImpl has a default empty constructor?", e);
 				} catch (IllegalAccessException e) {
 					throw new RuntimeException(e);
 				}
 			}
 		}
 		return instance;
+	}
+
+	public static HDTOptions readOptions(Path file) throws IOException {
+		return readOptions(file.toAbsolutePath().toString());
 	}
 
 	public static HDTOptions readOptions(String file) throws IOException {
@@ -56,8 +65,21 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 * @return HDT
 	 */
+	public static HDT loadHDT(Path hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
+		return loadHDT(hdtFileName.toAbsolutePath().toString(), listener, hdtFormat);
+	}
+
+	/**
+	 * Load an HDT file into memory to use it. NOTE: Use this method to go through all elements. If you plan
+	 * to do queries, use loadIndexedHDT() instead.
+	 * @param hdtFileName file path to load
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @param hdtFormat Parameters to tune the loaded HDT index. Can be null for default options.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
 	public static HDT loadHDT(String hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doLoadHDT(hdtFileName, listener, hdtFormat);
+		return HDTManager.getInstance().doLoadHDT(hdtFileName, ProgressListener.ofNullable(listener), HDTOptions.ofNullable(hdtFormat));
 	}
 
 	/**
@@ -68,8 +90,19 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 * @return HDT
 	 */
+	public static HDT loadHDT(Path hdtFileName, ProgressListener listener) throws IOException {
+		return loadHDT(hdtFileName.toAbsolutePath().toString(), listener);
+	}
+	/**
+	 * Load an HDT file into memory to use it. NOTE: Use this method to go through all elements. If you plan
+	 * to do queries, use loadIndexedHDT() instead.
+	 * @param hdtFileName file path to load
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
 	public static HDT loadHDT(String hdtFileName, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doLoadHDT(hdtFileName, listener, null);
+		return loadHDT(hdtFileName, listener, null);
 	}
 
 	/**
@@ -79,10 +112,34 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 * @return HDT
 	 */
+	public static HDT loadHDT(Path hdtFileName) throws IOException {
+		return loadHDT(hdtFileName.toAbsolutePath().toString());
+	}
+	/**
+	 * Load an HDT file into memory to use it. NOTE: Use this method to go through all elements. If you plan
+	 * to do queries, use loadIndexedHDT() instead.
+	 * @param hdtFileName file path to load
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
 	public static HDT loadHDT(String hdtFileName) throws IOException {
-		return HDTManager.getInstance().doLoadHDT(hdtFileName, null, null);
+		return loadHDT(hdtFileName, null, null);
 	}
 
+	/**
+	 * Map an HDT file into memory to use it. This method does not load the whole file into memory,
+	 * it lets the OS to handle memory pages as desired. Therefore it uses less memory but can be slower
+	 * for querying because it needs to load those blocks from disk.
+	 * NOTE: Use this method to go through all elements. If you plan to do queries, use mapIndexedHDT() instead.
+	 * @param hdtFileName file path to map
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @param hdtFormat Parameters to tune the loaded HDT index. Can be null for default options.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT mapHDT(Path hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
+		return mapHDT(hdtFileName.toAbsolutePath().toString(), listener, hdtFormat);
+	}
 	/**
 	 * Map an HDT file into memory to use it. This method does not load the whole file into memory,
 	 * it lets the OS to handle memory pages as desired. Therefore it uses less memory but can be slower
@@ -95,7 +152,20 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT mapHDT(String hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doMapHDT(hdtFileName, listener, hdtFormat);
+		return HDTManager.getInstance().doMapHDT(hdtFileName, ProgressListener.ofNullable(listener), HDTOptions.ofNullable(hdtFormat));
+	}
+	/**
+	 * Map an HDT file into memory to use it. This method does not load the whole file into memory,
+	 * it lets the OS to handle memory pages as desired. Therefore it uses less memory but can be slower
+	 * for querying because it needs to load those blocks from disk.
+	 * NOTE: Use this method to go through all elements. If you plan to do queries, use mapIndexedHDT() instead.
+	 * @param hdtFileName file path to map
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT mapHDT(Path hdtFileName, ProgressListener listener) throws IOException {
+		return mapHDT(hdtFileName.toAbsolutePath().toString(), listener);
 	}
 	/**
 	 * Map an HDT file into memory to use it. This method does not load the whole file into memory,
@@ -108,7 +178,19 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT mapHDT(String hdtFileName, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doMapHDT(hdtFileName, listener, null);
+		return mapHDT(hdtFileName, listener, null);
+	}
+	/**
+	 * Map an HDT file into memory to use it. This method does not load the whole file into memory,
+	 * it lets the OS to handle memory pages as desired. Therefore it uses less memory but can be slower
+	 * for querying because it needs to load those blocks from disk.
+	 * NOTE: Use this method to go through all elements. If you plan to do queries, use mapIndexedHDT() instead.
+	 * @param hdtFileName file path to map
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT mapHDT(Path hdtFileName) throws IOException {
+		return mapHDT(hdtFileName.toAbsolutePath().toString());
 	}
 	/**
 	 * Map an HDT file into memory to use it. This method does not load the whole file into memory,
@@ -120,7 +202,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT mapHDT(String hdtFileName) throws IOException {
-		return HDTManager.getInstance().doMapHDT(hdtFileName, null, null);
+		return mapHDT(hdtFileName, null, null);
 	}
 
 	/**
@@ -133,7 +215,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadHDT(InputStream hdtFile, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doLoadHDT(hdtFile, listener, hdtFormat);
+		return HDTManager.getInstance().doLoadHDT(hdtFile, ProgressListener.ofNullable(listener), HDTOptions.ofNullable(hdtFormat));
 	}
 	/**
 	 * Load an HDT from an InputStream (File, socket...). NOTE: Use this method to go through all elements. If you plan
@@ -144,7 +226,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadHDT(InputStream hdtFile, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doLoadHDT(hdtFile, listener, null);
+		return loadHDT(hdtFile, listener, null);
 	}
 	/**
 	 * Load an HDT from an InputStream (File, socket...). NOTE: Use this method to go through all elements. If you plan
@@ -154,7 +236,40 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadHDT(InputStream hdtFile) throws IOException {
-		return HDTManager.getInstance().doLoadHDT(hdtFile, null, null);
+		return loadHDT(hdtFile, null, null);
+	}
+
+	/**
+	 * Load an HDT File, and load/create additional indexes to support all kind of queries efficiently.
+	 * @param hdtFileName file path to load
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @param hdtFormat Parameters to tune the loaded HDT index. Can be null for default options.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT loadIndexedHDT(Path hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
+		return loadIndexedHDT(hdtFileName.toAbsolutePath().toString(), listener, hdtFormat);
+	}
+
+	/**
+	 * Load an HDT File, and load/create additional indexes to support all kind of queries efficiently.
+	 * @param hdtFileName file path to load
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT loadIndexedHDT(Path hdtFileName, ProgressListener listener) throws IOException {
+		return loadIndexedHDT(hdtFileName.toAbsolutePath().toString(), listener);
+	}
+
+	/**
+	 * Load an HDT File, and load/create additional indexes to support all kind of queries efficiently.
+	 * @param hdtFileName file path to load
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT loadIndexedHDT(Path hdtFileName) throws IOException {
+		return loadIndexedHDT(hdtFileName.toAbsolutePath().toString());
 	}
 
 	/**
@@ -166,7 +281,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadIndexedHDT(String hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, listener, hdtFormat);
+		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, ProgressListener.ofNullable(listener), HDTOptions.ofNullable(hdtFormat));
 	}
 
 	/**
@@ -177,7 +292,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadIndexedHDT(String hdtFileName, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, listener, null);
+		return loadIndexedHDT(hdtFileName, listener, null);
 	}
 	/**
 	 * Load an HDT File, and load/create additional indexes to support all kind of queries efficiently.
@@ -186,7 +301,38 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadIndexedHDT(String hdtFileName) throws IOException {
-		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, null, null);
+		return loadIndexedHDT(hdtFileName, null, null);
+	}
+
+	/**
+	 * Maps an HDT File into virtual memory, and load/create additional indexes to support all kind of queries efficiently.
+	 * @param hdtFileName file path to map
+	 * @param spec HDTOptions to the new mapped HDT. Can be null for default options.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT mapIndexedHDT(Path hdtFileName, HDTOptions spec, ProgressListener listener) throws IOException {
+		return mapIndexedHDT(hdtFileName.toAbsolutePath().toString(), spec, listener);
+	}
+	/**
+	 * Maps an HDT File into virtual memory, and load/create additional indexes to support all kind of queries efficiently.
+	 * @param hdtFileName file path to map
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT mapIndexedHDT(Path hdtFileName, ProgressListener listener) throws IOException {
+		return mapIndexedHDT(hdtFileName.toAbsolutePath().toString(), ProgressListener.ofNullable(listener));
+	}
+	/**
+	 * Maps an HDT File into virtual memory, and load/create additional indexes to support all kind of queries efficiently.
+	 * @param hdtFileName file path to map
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT mapIndexedHDT(Path hdtFileName) throws IOException {
+		return mapIndexedHDT(hdtFileName.toAbsolutePath().toString());
 	}
 
 	/**
@@ -198,7 +344,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT mapIndexedHDT(String hdtFileName, HDTOptions spec, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doMapIndexedHDT(hdtFileName, listener, spec);
+		return HDTManager.getInstance().doMapIndexedHDT(hdtFileName, ProgressListener.ofNullable(listener), HDTOptions.ofNullable(spec));
 	}
 
 	/**
@@ -209,7 +355,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT mapIndexedHDT(String hdtFileName, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doMapIndexedHDT(hdtFileName, listener, null);
+		return mapIndexedHDT(hdtFileName, null, listener);
 	}
 
 	/**
@@ -219,7 +365,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT mapIndexedHDT(String hdtFileName) throws IOException {
-		return HDTManager.getInstance().doMapIndexedHDT(hdtFileName, null, null);
+		return mapIndexedHDT(hdtFileName, null, null);
 	}
 
 	/**
@@ -230,7 +376,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadIndexedHDT(InputStream hdtFileName, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, listener, null);
+		return loadIndexedHDT(hdtFileName, listener, null);
 	}
 
 	/**
@@ -240,7 +386,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadIndexedHDT(InputStream hdtFileName) throws IOException {
-		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, null, null);
+		return loadIndexedHDT(hdtFileName, null, null);
 	}
 	/**
 	 * Load an HDT file from InputStream, and create additional indexes to support all kind of queries efficiently.
@@ -250,7 +396,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT loadIndexedHDT(InputStream hdtFileName, ProgressListener listener, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, listener, hdtFormat);
+		return HDTManager.getInstance().doLoadIndexedHDT(hdtFileName, ProgressListener.ofNullable(listener), HDTOptions.ofNullable(hdtFormat));
 	}
 
 	/**
@@ -261,7 +407,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT indexedHDT(HDT hdt, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doIndexedHDT(hdt, listener);
+		return HDTManager.getInstance().doIndexedHDT(hdt, ProgressListener.ofNullable(listener));
 	}
 
 	/**
@@ -276,8 +422,23 @@ public abstract class HDTManager {
 	 * @throws ParserException when the file cannot be parsed
 	 * @return HDT
 	 */
+	public static HDT generateHDT(Path rdfFileName, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
+		return generateHDT(rdfFileName.toAbsolutePath().toString(), baseURI, rdfNotation, hdtFormat, listener);
+	}
+	/**
+	 * Create an HDT file from an RDF file.
+	 * @param rdfFileName File name.
+	 * @param baseURI Base URI for the dataset.
+	 * @param rdfNotation Format of the source RDF File (NTriples, N3, RDF-XML...)
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 *
+	 * @throws IOException when the file cannot be found
+	 * @throws ParserException when the file cannot be parsed
+	 * @return HDT
+	 */
 	public static HDT generateHDT(String rdfFileName, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDT(rdfFileName, baseURI, rdfNotation, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDT(rdfFileName, baseURI, rdfNotation, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	/**
@@ -291,7 +452,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT generateHDT(Iterator<TripleString> iterator, String baseURI, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDT(iterator, baseURI, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDT(iterator, baseURI, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from a RDF stream.
@@ -305,7 +466,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF stream can't be parsed
 	 */
 	public static HDT generateHDT(InputStream fileStream, String baseURI, String filename, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDT(fileStream, baseURI, RDFNotation.guess(filename), CompressionType.guess(filename), hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDT(fileStream, baseURI, RDFNotation.guess(filename), CompressionType.guess(filename), HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from a RDF stream.
@@ -320,7 +481,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF stream can't be parsed
 	 */
 	public static HDT generateHDT(InputStream fileStream, String baseURI, RDFNotation rdfNotation, CompressionType compressionType, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDT(fileStream, baseURI, rdfNotation, compressionType, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDT(fileStream, baseURI, rdfNotation, compressionType, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from a RDF stream.
@@ -334,7 +495,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF stream can't be parsed
 	 */
 	public static HDT generateHDT(InputStream fileStream, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDT(fileStream, baseURI, rdfNotation, CompressionType.NONE, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDT(fileStream, baseURI, rdfNotation, CompressionType.NONE, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	/**
@@ -351,7 +512,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF file can't be parsed
 	 */
 	public static HDT generateHDTDisk(String rdfFileName, String baseURI, RDFNotation rdfNotation, CompressionType compressionType, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(rdfFileName, baseURI, rdfNotation, compressionType, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(rdfFileName, baseURI, rdfNotation, compressionType, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF file without compression by sorting the triples on disk, reduce the memory
@@ -366,7 +527,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF file can't be parsed
 	 */
 	public static HDT generateHDTDisk(String rdfFileName, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(rdfFileName, baseURI, rdfNotation, CompressionType.NONE, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(rdfFileName, baseURI, rdfNotation, CompressionType.NONE, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF file by sorting the triples on disk, reduce the memory required by increasing the
@@ -380,7 +541,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF file can't be parsed
 	 */
 	public static HDT generateHDTDisk(String rdfFileName, String baseURI, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(rdfFileName, baseURI, RDFNotation.guess(rdfFileName), CompressionType.guess(rdfFileName), hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(rdfFileName, baseURI, RDFNotation.guess(rdfFileName), CompressionType.guess(rdfFileName), HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF stream by sorting the triples on disk, reduce the memory required by increasing
@@ -395,7 +556,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF stream can't be parsed
 	 */
 	public static HDT generateHDTDisk(InputStream fileStream, String baseURI, String filename, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(fileStream, baseURI, RDFNotation.guess(filename), CompressionType.guess(filename), hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(fileStream, baseURI, RDFNotation.guess(filename), CompressionType.guess(filename), HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF stream by sorting the triples on disk, reduce the memory required by increasing
@@ -411,7 +572,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF stream can't be parsed
 	 */
 	public static HDT generateHDTDisk(InputStream fileStream, String baseURI, RDFNotation rdfNotation, CompressionType compressionType, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(fileStream, baseURI, rdfNotation, compressionType, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(fileStream, baseURI, rdfNotation, compressionType, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF stream by sorting the triples on disk, reduce the memory required by increasing
@@ -426,7 +587,7 @@ public abstract class HDTManager {
 	 * @throws ParserException when the RDF stream can't be parsed
 	 */
 	public static HDT generateHDTDisk(InputStream fileStream, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(fileStream, baseURI, rdfNotation, CompressionType.NONE, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(fileStream, baseURI, rdfNotation, CompressionType.NONE, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF stream by sorting the triples on disk, reduce the memory required by increasing
@@ -438,15 +599,33 @@ public abstract class HDTManager {
 	 * @throws IOException when the stream cannot be used
 	 */
 	public static HDT generateHDTDisk(Iterator<TripleString> iterator, String baseURI, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doGenerateHDTDisk(iterator, baseURI, hdtFormat, listener);
+		return HDTManager.getInstance().doGenerateHDTDisk(iterator, baseURI, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	public static TripleWriter getHDTWriter(OutputStream out, String baseURI, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doGetHDTWriter(out, baseURI, hdtFormat);
+		return HDTManager.getInstance().doGetHDTWriter(out, baseURI, HDTOptions.ofNullable(hdtFormat));
+	}
+
+	public static TripleWriter getHDTWriter(Path outFile, String baseURI, HDTOptions hdtFormat) throws IOException {
+		return getHDTWriter(outFile.toAbsolutePath().toString(), baseURI, hdtFormat);
 	}
 
 	public static TripleWriter getHDTWriter(String outFile, String baseURI, HDTOptions hdtFormat) throws IOException {
-		return HDTManager.getInstance().doGetHDTWriter(outFile, baseURI, hdtFormat);
+		return HDTManager.getInstance().doGetHDTWriter(outFile, baseURI, HDTOptions.ofNullable(hdtFormat));
+	}
+
+	/**
+	 * Create an HDT file from two HDT files by joining the triples.
+	 * @param location where the new HDT file is stored
+	 * @param hdtFileName1 First hdt file name
+	 * @param hdtFileName2 Second hdt file name
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
+	public static HDT catHDT(Path location, Path hdtFileName1, Path hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		return catHDT(location.toAbsolutePath().toString(), hdtFileName1.toAbsolutePath().toString(), hdtFileName2.toAbsolutePath().toString(), hdtFormat, listener);
 	}
 
 	/**
@@ -460,7 +639,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT catHDT(String location, String hdtFileName1, String hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doHDTCat(location, hdtFileName1, hdtFileName2, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTCat(location, hdtFileName1, hdtFileName2, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	/**
@@ -471,8 +650,31 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 * @return HDT
 	 */
+	public static HDT catHDTPath(List<Path> hdtFileNames, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		return catHDT(hdtFileNames.stream().map(p -> p.toAbsolutePath().toString()).collect(Collectors.toList()), hdtFormat, listener);
+	}
+	/**
+	 * Create an HDT file from HDT files by joining the triples.
+	 * @param hdtFileNames hdt file names
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
 	public static HDT catHDT(List<String> hdtFileNames, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doHDTCat(hdtFileNames, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTCat(hdtFileNames, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
+	}
+	/**
+	 * Create a new HDT by removing from hdt1 the triples of hdt2.
+	 * @param hdtFileName1 First hdt file name
+	 * @param hdtFileName2 Second hdt file name
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @return HDT
+	 * @throws IOException when the file cannot be found
+	 */
+	public static HDT diffHDT(Path hdtFileName1, Path hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		return diffHDT(hdtFileName1.toAbsolutePath().toString(), hdtFileName2.toAbsolutePath().toString(), hdtFormat, listener);
 	}
 	/**
 	 * Create a new HDT by removing from hdt1 the triples of hdt2.
@@ -484,7 +686,21 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 */
 	public static HDT diffHDT(String hdtFileName1, String hdtFileName2, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doHDTDiff(hdtFileName1, hdtFileName2, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTDiff(hdtFileName1, hdtFileName2, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
+	}
+
+	/**
+	 * Create a new HDT by removing from a hdt all the triples marked to delete in a bitmap
+	 * @param location where the new HDT file is stored
+	 * @param hdtFileName hdt file name
+	 * @param deleteBitmap delete bitmap
+	 * @param hdtFormat  Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @return HDT
+	 * @throws IOException when the file cannot be found
+	 */
+	public static HDT diffHDTBit(Path location, String hdtFileName, Bitmap deleteBitmap, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		return diffHDTBit(location.toAbsolutePath().toString(), hdtFileName, deleteBitmap, hdtFormat, listener);
 	}
 
 	/**
@@ -498,7 +714,7 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 */
 	public static HDT diffHDTBit(String location, String hdtFileName, Bitmap deleteBitmap, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doHDTDiffBit(location, hdtFileName, deleteBitmap, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTDiffBit(location, hdtFileName, deleteBitmap, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	/**
@@ -510,8 +726,20 @@ public abstract class HDTManager {
 	 * @throws IOException when the file cannot be found
 	 * @return HDT
 	 */
+	public static HDT diffBitCatHDTPath(List<Path> hdtFileNames, List<? extends Bitmap> deleteBitmaps, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
+		return diffBitCatHDT(hdtFileNames.stream().map(p -> p.toAbsolutePath().toString()).collect(Collectors.toList()), deleteBitmaps, hdtFormat, listener);
+	}
+	/**
+	 * Create an HDT file from HDT files by joining the triples and removing some triples with delete bitmaps
+	 * @param hdtFileNames hdt file names
+	 * @param deleteBitmaps the bitmaps for each HDT in hdtFileNames, should be the same size as hdtFileNames, see {@link org.rdfhdt.hdt.compact.bitmap.BitmapFactory#empty()}
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 * @throws IOException when the file cannot be found
+	 * @return HDT
+	 */
 	public static HDT diffBitCatHDT(List<String> hdtFileNames, List<? extends Bitmap> deleteBitmaps, HDTOptions hdtFormat, ProgressListener listener) throws IOException {
-		return HDTManager.getInstance().doHDTDiffBitCat(hdtFileNames, deleteBitmaps, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTDiffBitCat(hdtFileNames, deleteBitmaps, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 
@@ -530,8 +758,27 @@ public abstract class HDTManager {
 	 * @throws ParserException when the file cannot be parsed
 	 * @return HDT
 	 */
+	public static HDT catTree(RDFFluxStop fluxStop, HDTSupplier supplier, Path rdfFileName, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
+		return catTree(fluxStop, supplier, rdfFileName.toAbsolutePath().toString(), baseURI, rdfNotation, hdtFormat, listener);
+	}
+
+	/**
+	 * Create an HDT file from an RDF file in a tree, stop the chunk creation with the fluxStop
+	 *
+	 * @param fluxStop Flux stopper
+	 * @param supplier HDT supplier to create initial HDT before cat
+	 * @param rdfFileName File name.
+	 * @param baseURI Base URI for the dataset.
+	 * @param rdfNotation Format of the source RDF File (NTriples, N3, RDF-XML...)
+	 * @param hdtFormat Parameters to tune the generated HDT.
+	 * @param listener Listener to get notified of loading progress. Can be null if no notifications needed.
+	 *
+	 * @throws IOException when the file cannot be found
+	 * @throws ParserException when the file cannot be parsed
+	 * @return HDT
+	 */
 	public static HDT catTree(RDFFluxStop fluxStop, HDTSupplier supplier, String rdfFileName, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doHDTCatTree(fluxStop, supplier, rdfFileName, baseURI, rdfNotation, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTCatTree(fluxStop, supplier, rdfFileName, baseURI, rdfNotation, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 	/**
 	 * Create an HDT file from an RDF stream, stop the chunk creation with the fluxStop
@@ -549,7 +796,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT catTree(RDFFluxStop fluxStop, HDTSupplier supplier, InputStream rdfStream, String baseURI, RDFNotation rdfNotation, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doHDTCatTree(fluxStop, supplier, rdfStream, baseURI, rdfNotation, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTCatTree(fluxStop, supplier, rdfStream, baseURI, rdfNotation, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	/**
@@ -566,7 +813,7 @@ public abstract class HDTManager {
 	 * @return HDT
 	 */
 	public static HDT catTree(RDFFluxStop fluxStop, HDTSupplier supplier, Iterator<TripleString> iterator, String baseURI, HDTOptions hdtFormat, ProgressListener listener) throws IOException, ParserException {
-		return HDTManager.getInstance().doHDTCatTree(fluxStop, supplier, iterator, baseURI, hdtFormat, listener);
+		return HDTManager.getInstance().doHDTCatTree(fluxStop, supplier, iterator, baseURI, HDTOptions.ofNullable(hdtFormat), ProgressListener.ofNullable(listener));
 	}
 
 	// Abstract methods for the current implementation

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/listener/MultiThreadListener.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/listener/MultiThreadListener.java
@@ -5,6 +5,32 @@ package org.rdfhdt.hdt.listener;
  */
 @FunctionalInterface
 public interface MultiThreadListener extends ProgressListener {
+	/**
+	 * empty progress listener
+	 *
+	 * @return progress listener
+	 */
+	static MultiThreadListener ignore() {
+		return ((thread, level, message) -> {
+		});
+	}
+
+	/**
+	 * @return progress listener returning to sdtout
+	 */
+	static MultiThreadListener sout() {
+		return ((thread, level, message) -> System.out.println(level + " - " + message));
+	}
+
+	/**
+	 * progress listener of a nullable listener
+	 *
+	 * @param listener listener
+	 * @return listener or ignore listener
+	 */
+	static MultiThreadListener ofNullable(MultiThreadListener listener) {
+		return listener == null ? ignore() : listener;
+	}
 
 	/**
 	 * Send progress notification

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/listener/ProgressListener.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/listener/ProgressListener.java
@@ -29,14 +29,41 @@ package org.rdfhdt.hdt.listener;
 
 /**
  * Interface for notifying the progress of an operation.
- * 
- * @author mario.arias
  *
+ * @author mario.arias
  */
 public interface ProgressListener {
 	/**
+	 * empty progress listener
+	 *
+	 * @return progress listener
+	 */
+	static ProgressListener ignore() {
+		return ((level, message) -> {
+		});
+	}
+
+	/**
+	 * @return progress listener returning to sdtout
+	 */
+	static ProgressListener sout() {
+		return ((level, message) -> System.out.println(level + " - " + message));
+	}
+
+	/**
+	 * progress listener of a nullable listener
+	 *
+	 * @param listener listener
+	 * @return listener or ignore listener
+	 */
+	static ProgressListener ofNullable(ProgressListener listener) {
+		return listener == null ? ignore() : listener;
+	}
+
+	/**
 	 * Send progress notification
-	 * @param level percent of the task accomplished
+	 *
+	 * @param level   percent of the task accomplished
 	 * @param message Description of the operation
 	 */
 	void notifyProgress(float level, String message);

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/HDTOptionsKeys.java
@@ -4,6 +4,7 @@ import org.rdfhdt.hdt.hdt.HDTVocabulary;
 import org.rdfhdt.hdt.rdf.RDFFluxStop;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -315,37 +316,147 @@ public class HDTOptionsKeys {
 	@Key(type = Key.Type.BOOLEAN, desc = "Delete the HDTCat temp files directory after HDTCat, default to true")
 	public static final String HDTCAT_DELETE_LOCATION = "hdtcat.deleteLocation";
 
-	@Key(type = Key.Type.BOOLEAN, desc = "Use disk implementation to generate the hdt sub-index")
+	/**
+	 * Use disk implementation to generate the hdt sub-index, default false
+	 */
+	@Key(type = Key.Type.BOOLEAN, desc = "Use disk implementation to generate the hdt sub-index, default false")
 	public static final String BITMAPTRIPLES_SEQUENCE_DISK = "bitmaptriples.sequence.disk";
-	@Key(type = Key.Type.BOOLEAN, desc = "Use disk 375 subindex implementation to generate the hdt sub-index")
+
+	/**
+	 * Use disk 375 bitmap subindex implementation to generate the HDT sub index, default false
+	 */
+	@Key(type = Key.Type.BOOLEAN, desc = "Use disk 375 subindex implementation to generate the hdt sub-index, default false")
 	public static final String BITMAPTRIPLES_SEQUENCE_DISK_SUBINDEX = "bitmaptriples.sequence.disk.subindex";
 
-	@Key(type = Key.Type.BOOLEAN, desc = "Disk location for the " + BITMAPTRIPLES_SEQUENCE_DISK + " option")
+	/**
+	 * disk location for the {@link #BITMAPTRIPLES_SEQUENCE_DISK} option
+	 */
+	@Key(type = Key.Type.PATH, desc = "Disk location for the " + BITMAPTRIPLES_SEQUENCE_DISK + " option")
 	public static final String BITMAPTRIPLES_SEQUENCE_DISK_LOCATION = "bitmaptriples.sequence.disk.location";
+
+	/**
+	 * Bitmap type for the Y bitmap, default {@link HDTVocabulary#BITMAP_TYPE_PLAIN}
+	 */
+	@Key(type = Key.Type.STRING, desc = "Bitmap type for the Y bitmap, default " + HDTVocabulary.BITMAP_TYPE_PLAIN)
+	public static final String BITMAPTRIPLES_BITMAP_Y = "bitmap.y";
+
+
+	/**
+	 * Bitmap type for the Z bitmap, default {@link HDTVocabulary#BITMAP_TYPE_PLAIN}
+	 */
+	@Key(type = Key.Type.STRING, desc = "Bitmap type for the Z bitmap, default " + HDTVocabulary.BITMAP_TYPE_PLAIN)
+	public static final String BITMAPTRIPLES_BITMAP_Z = "bitmap.z";
+
+	/**
+	 * Sequence type for the Y sequence, default {@link HDTVocabulary#SEQ_TYPE_LOG}
+	 */
+	@Key(type = Key.Type.STRING, desc = "Sequence type for the Y sequence, default " + HDTVocabulary.SEQ_TYPE_LOG)
+	public static final String BITMAPTRIPLES_SEQ_Y = "seq.y";
+
+	/**
+	 * Sequence type for the Z sequence, default {@link HDTVocabulary#SEQ_TYPE_LOG}
+	 */
+	@Key(type = Key.Type.STRING, desc = "Sequence type for the Z sequence, default " + HDTVocabulary.SEQ_TYPE_LOG)
+	public static final String BITMAPTRIPLES_SEQ_Z = "seq.z";
+
+	/**
+	 * Indexing method for the bitmap triples, default {@link #BITMAPTRIPLES_INDEX_METHOD_VALUE_RECOMMENDED}
+	 */
+	@Key(type = Key.Type.ENUM, desc = "Indexing method for the bitmap triples")
+	public static final String BITMAPTRIPLES_INDEX_METHOD_KEY = "bitmaptriples.indexmethod";
+
+	/**
+	 * value for {@link #BITMAPTRIPLES_INDEX_METHOD_KEY}. Recommended implementation, default value
+	 */
+	@Value(key = BITMAPTRIPLES_INDEX_METHOD_KEY, desc = "Recommended implementation, default value")
+	public static final String BITMAPTRIPLES_INDEX_METHOD_VALUE_RECOMMENDED = "recommended";
+
+	/**
+	 * value for {@link #BITMAPTRIPLES_INDEX_METHOD_KEY}. Legacy implementation, fast, but memory inefficient
+	 */
+	@Value(key = BITMAPTRIPLES_INDEX_METHOD_KEY, desc = "Legacy implementation, fast, but memory inefficient")
+	public static final String BITMAPTRIPLES_INDEX_METHOD_VALUE_LEGACY = "legacy";
+
+	/**
+	 * value for {@link #BITMAPTRIPLES_INDEX_METHOD_KEY}. Disk option, handle the indexing on disk to reduce usage
+	 */
+	@Value(key = BITMAPTRIPLES_INDEX_METHOD_KEY, desc = "Disk option, handle the indexing on disk to reduce usage")
+	public static final String BITMAPTRIPLES_INDEX_METHOD_VALUE_DISK = "disk";
+	/**
+	 * value for {@link #BITMAPTRIPLES_INDEX_METHOD_KEY}. Memory optimized option
+	 */
+	@Value(key = BITMAPTRIPLES_INDEX_METHOD_KEY, desc = "Memory optimized option")
+	public static final String BITMAPTRIPLES_INDEX_METHOD_VALUE_OPTIMIZED = "optimized";
+
+	/**
+	 * Key for the {@link org.rdfhdt.hdt.hdt.HDTManager} loadIndexed methods,
+	 * say the number of workers to merge the data. default to the number of processor. long value.
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "Number of core used to index the HDT with " + BITMAPTRIPLES_INDEX_METHOD_VALUE_DISK + " index method.")
+	public static final String BITMAPTRIPLES_DISK_WORKER_KEY = "bitmaptriples.indexmethod.disk.compressWorker";
+	/**
+	 * Key for the maximum size of a chunk on disk for the {@link org.rdfhdt.hdt.hdt.HDTManager} generateHDTDisk
+	 * methods, the chunk should be in RAM before writing it on disk and should be sorted. long value.
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "Maximum size of a chunk")
+	public static final String BITMAPTRIPLES_DISK_CHUNK_SIZE_KEY = "bitmaptriples.indexmethod.disk.chunkSize";
+	/**
+	 * Key for the size of the buffers when opening a file
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "Size of the file buffers")
+	public static final String BITMAPTRIPLES_DISK_BUFFER_SIZE_KEY = "bitmaptriples.indexmethod.disk.fileBufferSize";
+	/**
+	 * Key for the maximum number of file opened at the same time, should be greater than {@link #BITMAPTRIPLES_DISK_KWAY_KEY},
+	 * 1024 by default
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "Maximum number of file " + BITMAPTRIPLES_INDEX_METHOD_VALUE_DISK + " index method can open at the same time")
+	public static final String BITMAPTRIPLES_DISK_MAX_FILE_OPEN_KEY = "bitmaptriples.indexmethod.disk.maxFileOpen";
+	/**
+	 * Key for the number of chunk layers opened at the same time, by default
+	 * <p>min(log2(maxFileOpen), chunkSize / (fileBufferSize * compressWorker))</p>
+	 */
+	@Key(type = Key.Type.NUMBER, desc = "log of the number of way the system can merge in " + BITMAPTRIPLES_INDEX_METHOD_VALUE_DISK + " index method")
+	public static final String BITMAPTRIPLES_DISK_KWAY_KEY = "bitmaptriples.indexmethod.disk.kway";
+
 	// use tree-map to have a better order
 	private static final Map<String, Option> OPTION_MAP = new TreeMap<>();
 
 	static {
 		try {
-			for (Field f : HDTOptionsKeys.class.getDeclaredFields()) {
-				Key key = f.getAnnotation(Key.class);
-				if (key != null) {
-					String keyValue = (String) f.get(null);
+			registerOptionsClass(HDTOptionsKeys.class);
+		} catch (Exception e) {
+			throw new Error("Can't load option keys", e);
+		}
+	}
 
-					OPTION_MAP.put(keyValue, new Option(keyValue, key));
-				} else {
-					Value value = f.getAnnotation(Value.class);
-					if (value != null) {
-						String valueValue = (String) f.get(null);
-						Option opt = OPTION_MAP.get(value.key());
-						if (opt != null) {
-							opt.values.add(new OptionValue(valueValue, value));
-						}
+	/**
+	 * register an options class for the {@link #getOptionMap()} method,
+	 * will read all the public static fields with {@link Key} and {@link Value}
+	 *
+	 * @param cls class
+	 * @throws Exception register exception
+	 */
+	public static void registerOptionsClass(Class<?> cls) throws Exception {
+		for (Field f : cls.getDeclaredFields()) {
+			if ((f.getModifiers() & Modifier.STATIC) == 0
+					|| (f.getModifiers() & Modifier.PUBLIC) == 0) {
+				continue; // no static modifier
+			}
+			Key key = f.getAnnotation(Key.class);
+			if (key != null) {
+				String keyValue = String.valueOf(f.get(null));
+
+				OPTION_MAP.put(keyValue, new Option(keyValue, key));
+			} else {
+				Value value = f.getAnnotation(Value.class);
+				if (value != null) {
+					String valueValue = String.valueOf(f.get(null));
+					Option opt = OPTION_MAP.get(value.key());
+					if (opt != null) {
+						opt.values.add(new OptionValue(valueValue, value));
 					}
 				}
 			}
-		} catch (Exception e) {
-			throw new Error("Can't load option keys", e);
 		}
 	}
 

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/options/Key.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/options/Key.java
@@ -1,7 +1,9 @@
 package org.rdfhdt.hdt.options;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * define a key in the HDTOptionsKey class
@@ -9,6 +11,7 @@ import java.lang.annotation.RetentionPolicy;
  * @author Antoine Willerval
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
 public @interface Key {
     /**
      * Type enum for a key

--- a/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDTCat.java
+++ b/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/HDTCat.java
@@ -85,13 +85,13 @@ public class HDTCat implements ProgressListener {
 
 
     public void execute() throws IOException {
-        HDTSpecification spec;
-        if(configFile!=null) {
-            spec = new HDTSpecification(configFile);
+        HDTOptions spec;
+        if(configFile != null) {
+            spec = HDTOptions.readFromFile(configFile);
         } else {
-            spec = new HDTSpecification();
+            spec = HDTOptions.of();
         }
-        if(options!=null) {
+        if (options != null) {
             spec.setOptions(options);
         }
 

--- a/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/RDF2HDT.java
+++ b/hdt-java-cli/src/main/java/org/rdfhdt/hdt/tools/RDF2HDT.java
@@ -40,6 +40,7 @@ import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.hdt.HDTSupplier;
 import org.rdfhdt.hdt.hdt.HDTVersion;
 import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.options.HDTSpecification;
 import org.rdfhdt.hdt.rdf.RDFFluxStop;
@@ -135,11 +136,11 @@ public class RDF2HDT implements ProgressListener {
 	}
 
 	public void execute() throws ParserException, IOException {
-		HDTSpecification spec;
-		if (configFile != null) {
-			spec = new HDTSpecification(configFile);
+		HDTOptions spec;
+		if(configFile != null) {
+			spec = HDTOptions.readFromFile(configFile);
 		} else {
-			spec = new HDTSpecification();
+			spec = HDTOptions.of();
 		}
 		if (options != null) {
 			spec.setOptions(options);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/AdjacencyList.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/AdjacencyList.java
@@ -47,7 +47,7 @@ public class AdjacencyList {
 		this.array = array;
 		this.bitmap = bitmap;
 		if (array.getNumberOfElements() != bitmap.getNumBits()) {
-			throw new IllegalArgumentException("Adjacency list bitmap and array should have the same size");
+			throw new IllegalArgumentException("Adjacency list bitmap and array should have the same size " + array.getNumberOfElements() + "!=" + bitmap.getNumBits());
 		}
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap375Big.java
@@ -26,7 +26,6 @@ import org.rdfhdt.hdt.util.disk.SimpleSplitLongArray;
 import org.rdfhdt.hdt.util.io.CloseSuppressPath;
 import org.rdfhdt.hdt.util.io.Closer;
 import org.rdfhdt.hdt.util.io.IOUtil;
-import org.visnow.jlargearrays.LongLargeArray;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -86,7 +85,7 @@ public class Bitmap375Big extends Bitmap64Big {
      * @return bitmap
      */
     public static Bitmap375Big memory(long nbits, Path location) {
-        return new Bitmap375Big(new LargeLongArray(new LongLargeArray(numWords(nbits))), location, location != null);
+        return new Bitmap375Big(new LargeLongArray(IOUtil.createLargeArray(numWords(nbits))), location, location != null);
     }
 
     // Constants

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64Big.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/Bitmap64Big.java
@@ -68,7 +68,7 @@ public class Bitmap64Big implements Closeable, ModifiableBitmap {
      * @return bitmap
      */
     public static Bitmap64Big memory(long nbits) {
-        return new Bitmap64Big(new LargeLongArray(new LongLargeArray(numWords(nbits))));
+        return new Bitmap64Big(new LargeLongArray(IOUtil.createLargeArray(numWords(nbits))));
     }
 
     // Constants
@@ -221,8 +221,9 @@ public class Bitmap64Big implements Closeable, ModifiableBitmap {
     }
 
     public void set(long bitIndex, boolean value) {
-        if (bitIndex < 0)
+        if (bitIndex < 0) {
             throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+        }
 
         long wordIndex = wordIndex(bitIndex);
         try {
@@ -353,5 +354,12 @@ public class Bitmap64Big implements Closeable, ModifiableBitmap {
     @Override
     public void close() throws IOException {
         closer.close();
+    }
+
+    /**
+     * @return sync version of this bitmap
+     */
+    public ModifiableBitmap asSync() {
+        return SyncBitmap.of(this);
     }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/SyncBitmap.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/bitmap/SyncBitmap.java
@@ -1,0 +1,141 @@
+package org.rdfhdt.hdt.compact.bitmap;
+
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.util.io.IOUtil;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * sync version of a bitmap
+ * @param <T> bitmap
+ */
+public class SyncBitmap<T extends Bitmap> implements Bitmap, Closeable {
+    /**
+     * create sync bitmap from a bitmap
+     * @param bitmap bitmap
+     * @return sync bitmap
+     */
+    public static Bitmap of(Bitmap bitmap) {
+        if (bitmap instanceof SyncBitmap) {
+            return bitmap;
+        }
+        if (bitmap instanceof ModifiableBitmap) {
+            return new SyncModBitmap<>((ModifiableBitmap) bitmap);
+        }
+
+        return new SyncBitmap<>(bitmap);
+    }
+
+    /**
+     * create sync mod bitmap from a mod bitmap
+     * @param bitmap bitmap
+     * @return sync mod bitmap
+     */
+    public static ModifiableBitmap of(ModifiableBitmap bitmap) {
+        if (bitmap instanceof SyncBitmap) {
+            return bitmap;
+        }
+        return new SyncModBitmap<>(bitmap);
+    }
+
+    protected final T bitmap;
+
+    private SyncBitmap(T bitmap) {
+        this.bitmap = bitmap;
+    }
+
+    @Override
+    public synchronized boolean access(long position) {
+        return bitmap.access(position);
+    }
+
+    @Override
+    public synchronized long rank1(long position) {
+        return bitmap.rank1(position);
+    }
+
+    @Override
+    public synchronized long rank0(long position) {
+        return bitmap.rank0(position);
+    }
+
+    @Override
+    public synchronized long selectPrev1(long start) {
+        return bitmap.selectPrev1(start);
+    }
+
+    @Override
+    public synchronized long selectNext1(long start) {
+        return bitmap.selectNext1(start);
+    }
+
+    @Override
+    public synchronized long select0(long n) {
+        return bitmap.select0(n);
+    }
+
+    @Override
+    public synchronized long select1(long n) {
+        return bitmap.select1(n);
+    }
+
+    @Override
+    public synchronized long getNumBits() {
+        return bitmap.getNumBits();
+    }
+
+    @Override
+    public synchronized long countOnes() {
+        return bitmap.countOnes();
+    }
+
+    @Override
+    public synchronized long countZeros() {
+        return bitmap.countZeros();
+    }
+
+    @Override
+    public synchronized long getSizeBytes() {
+        return bitmap.getSizeBytes();
+    }
+
+    @Override
+    public synchronized void save(OutputStream output, ProgressListener listener) throws IOException {
+        bitmap.save(output, listener);
+    }
+
+    @Override
+    public synchronized void load(InputStream input, ProgressListener listener) throws IOException {
+        bitmap.load(input, listener);
+    }
+
+    @Override
+    public synchronized String getType() {
+        return bitmap.getType();
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtil.closeObject(bitmap);
+    }
+
+    private static class SyncModBitmap<T extends ModifiableBitmap> extends SyncBitmap<T> implements ModifiableBitmap {
+
+        protected SyncModBitmap(T bitmap) {
+            super(bitmap);
+        }
+
+        @Override
+        public synchronized void set(long position, boolean value) {
+            bitmap.set(position, value);
+        }
+
+        @Override
+        public synchronized void append(boolean value) {
+            bitmap.append(value);
+        }
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/integer/VByte.java
@@ -39,20 +39,52 @@ import org.rdfhdt.hdt.util.io.BigMappedByteBuffer;
 
 /**
  * Typical implementation of Variable-Byte encoding for integers.
- * http://nlp.stanford.edu/IR-book/html/htmledition/variable-byte-codes-1.html
- * 
+ * <a href="http://nlp.stanford.edu/IR-book/html/htmledition/variable-byte-codes-1.html">variable-byte-codes</a>
+ *
  * The first bit of each byte specifies whether there are more bytes available.
  * Numbers from 0 to 126 are encoded using just one byte.
  * Numbers from 127 to 16383 are encoded using two bytes.
  * Numbers from 16384 to 2097151 are encoded using three bytes.
- * 
+ *
  * @author mario.arias
  *
  */
 public class VByte {
 	
 	private VByte() {}
-	
+
+	/**
+	 * encode a Variable-Byte adding a bit for the sign, should be decoded with {@link #decodeSigned(InputStream)}
+	 * @param out   out stream
+	 * @param value value to encode
+	 * @throws IOException write exception
+	 */
+	public static void encodeSigned(OutputStream out, long value) throws IOException {
+		if (value < 0) {
+			// set the 1st bit to 1
+			encode(out, ~(value << 1));
+		} else {
+			encode(out, value << 1);
+		}
+	}
+
+	/**
+	 * decode a signed Variable-Byte, should be encoded with {@link #encodeSigned(OutputStream, long)}
+	 * @param in in stream
+	 * @return decoded value
+	 * @throws IOException write exception
+	 */
+	public static long decodeSigned(InputStream in) throws IOException {
+		long decode = decode(in);
+		if ((decode & 1) == 0) {
+			// +
+			return decode >>> 1;
+		} else {
+			// -
+			return ~(decode >>> 1);
+		}
+	}
+
 	public static void encode(OutputStream out, long value) throws IOException {
 		if(value<0) {
 			throw new IllegalArgumentException("Only can encode VByte of positive values");

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/Sequence.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/Sequence.java
@@ -71,6 +71,10 @@ public interface Sequence extends Closeable {
 	long size();
 
 	/**
+	 * @return size of the components (in bits)
+	 */
+	int sizeOf();
+	/**
 	 * Saves the array to an OutputStream
 	 *
 	 * @param output

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt32.java
@@ -30,6 +30,7 @@ package org.rdfhdt.hdt.compact.sequence;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Iterator;
 
@@ -69,6 +70,11 @@ public class SequenceInt32 implements DynamicSequence {
 		}
 		resizeArray((int) numentries);
 		this.numelements = (int) numentries;
+	}
+
+	@Override
+	public void clear() {
+		Arrays.fill(data, 0);
 	}
 
 	private void resizeArray(int size) {
@@ -214,7 +220,7 @@ public class SequenceInt32 implements DynamicSequence {
 	 */
 	@Override
 	public long size() {
-		return 4*numelements;
+		return 4L*numelements;
 	}
 
 	/* (non-Javadoc)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceInt64.java
@@ -30,6 +30,7 @@ package org.rdfhdt.hdt.compact.sequence;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Iterator;
 
 import org.rdfhdt.hdt.exceptions.IllegalFormatException;
@@ -70,6 +71,11 @@ public class SequenceInt64 implements DynamicSequence {
 		}
 		resizeArray((int) numentries);
 		this.numelements = numentries;
+	}
+
+	@Override
+	public void clear() {
+		Arrays.fill(data, 0);
 	}
 
 	private void resizeArray(int size) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64.java
@@ -293,6 +293,11 @@ public class SequenceLog64 implements DynamicSequence {
 		resizeArray((int)numWordsFor(numbits, numentries));	
 	}
 
+	@Override
+	public void clear() {
+		Arrays.fill(data, 0);
+	}
+
 	/* (non-Javadoc)
 	 * @see hdt.triples.array.Stream#getNumberOfElements()
 	 */

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Map.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/compact/sequence/SequenceLog64Map.java
@@ -123,7 +123,12 @@ public class SequenceLog64Map implements Sequence,Closeable {
 		
 		mapFiles(f, 0);
 	}
-	
+
+	@Override
+	public int sizeOf() {
+		return numbits;
+	}
+
 	private void mapFiles(File f, long base) throws IOException {
 		// Read packed data
 		ch = FileChannel.open(Paths.get(f.toString()));

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTManagerImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/HDTManagerImpl.java
@@ -114,7 +114,7 @@ public class HDTManagerImpl extends HDTManager {
 
 	@Override
 	public HDT doIndexedHDT(HDT hdt, ProgressListener listener) throws IOException {
-		((HDTPrivate)hdt).loadOrCreateIndex(listener, new HDTSpecification());
+		((HDTPrivate)hdt).loadOrCreateIndex(listener, HDTOptions.of());
 		return hdt;
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTBase.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTBase.java
@@ -33,11 +33,7 @@ public abstract class HDTBase<H extends Header, D extends DictionaryPrivate, T e
 	protected T triples;
 
 	protected HDTBase(HDTOptions spec) {
-		if (spec == null) {
-			this.spec = new HDTSpecification();
-		} else {
-			this.spec = spec;
-		}
+		this.spec = HDTOptions.ofNullable(spec);
 	}
 
 	/**

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTDiskImporter.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTDiskImporter.java
@@ -45,11 +45,17 @@ import java.util.Iterator;
  */
 public class HDTDiskImporter implements Closeable {
 	/**
+	 * @return ram on the system
+	 */
+	public static long getAvailableMemory() {
+		Runtime runtime = Runtime.getRuntime();
+		return (runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory()));
+	}
+	/**
 	 * @return a theoretical maximum amount of memory the JVM will attempt to use
 	 */
 	static long getMaxChunkSize(int workers) {
-		Runtime runtime = Runtime.getRuntime();
-		return (long) ((runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory())) * 0.85 / (1.5 * 3 * workers));
+		return (long) (getAvailableMemory() * 0.85 / (1.5 * 3 * workers));
 	}
 
 	// configs

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -402,7 +402,7 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 
 			// GENERATE
 			StopWatch st = new StopWatch();
-			triples.generateIndex(listener, spec);
+			triples.generateIndex(listener, spec, dictionary);
 
 			// SAVE
 			if(this.hdtFileName!=null) {

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskimport/AsyncCatTreeWorker.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskimport/AsyncCatTreeWorker.java
@@ -118,7 +118,7 @@ public class AsyncCatTreeWorker implements Closeable {
 	private void runMergeThread() throws IOException, InterruptedException {
 		long cat = 0;
 
-		HideHDTOptions spec = new HideHDTOptions(impl.getHdtFormat(), Function.identity());
+		HideHDTOptions spec = new HideHDTOptions(impl.getHdtFormat());
 
 		spec.set(HDTOptionsKeys.HDTCAT_LOCATION, hdtCatLocationPath);
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskindex/DiskIndexSort.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskindex/DiskIndexSort.java
@@ -1,0 +1,160 @@
+package org.rdfhdt.hdt.hdt.impl.diskindex;
+
+import org.rdfhdt.hdt.iterator.utils.AsyncIteratorFetcher;
+import org.rdfhdt.hdt.iterator.utils.ExceptionIterator;
+import org.rdfhdt.hdt.iterator.utils.SizeFetcher;
+import org.rdfhdt.hdt.listener.MultiThreadListener;
+import org.rdfhdt.hdt.util.ParallelSortableArrayList;
+import org.rdfhdt.hdt.util.concurrent.KWayMerger;
+import org.rdfhdt.hdt.util.io.CloseSuppressPath;
+import org.rdfhdt.hdt.util.io.IOUtil;
+import org.rdfhdt.hdt.util.io.compress.Pair;
+import org.rdfhdt.hdt.util.io.compress.PairMergeIterator;
+import org.rdfhdt.hdt.util.io.compress.PairReader;
+import org.rdfhdt.hdt.util.io.compress.PairWriter;
+import org.rdfhdt.hdt.util.listener.IntermediateListener;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Implementation to use K-Way merge sort to create Object index
+ *
+ * @author Antoine Willerval
+ */
+public class DiskIndexSort implements KWayMerger.KWayMergerImpl<Pair, SizeFetcher<Pair>> {
+    private final CloseSuppressPath baseFileName;
+    private final AsyncIteratorFetcher<Pair> source;
+    private final MultiThreadListener listener;
+    private final int bufferSize;
+    private final long chunkSize;
+    private final int k;
+    private final Comparator<Pair> comparator;
+    private final AtomicLong read = new AtomicLong();
+
+    public DiskIndexSort(CloseSuppressPath baseFileName, AsyncIteratorFetcher<Pair> source, MultiThreadListener listener, int bufferSize, long chunkSize, int k, Comparator<Pair> comparator) {
+        this.source = source;
+        this.listener = MultiThreadListener.ofNullable(listener);
+        this.baseFileName = baseFileName;
+        this.bufferSize = bufferSize;
+        this.chunkSize = chunkSize;
+        this.k = k;
+        this.comparator = comparator;
+    }
+
+    @Override
+    public void createChunk(SizeFetcher<Pair> flux, CloseSuppressPath output) throws KWayMerger.KWayMergerException {
+        ParallelSortableArrayList<Pair> pairs = new ParallelSortableArrayList<>(Pair[].class);
+
+        Pair pair;
+        // loading the pairs
+        listener.notifyProgress(10, "reading pairs part 0");
+        while ((pair = flux.get()) != null) {
+            pairs.add(pair);
+            long r = read.incrementAndGet();
+            if (r % 1_000_000 == 0) {
+                listener.notifyProgress(10, "reading pairs part " + r);
+            }
+        }
+
+        // sort the pairs
+        pairs.parallelSort(comparator);
+
+        // write the result on disk
+        int count = 0;
+        int block = pairs.size() < 10 ? 1 : pairs.size() / 10;
+        IntermediateListener il = new IntermediateListener(listener);
+        il.setRange(70, 100);
+        il.notifyProgress(0, "creating file");
+        try (PairWriter w = new PairWriter(output.openOutputStream(bufferSize), pairs.size())) {
+            // encode the size of the chunk
+            for (int i = 0; i < pairs.size(); i++) {
+                if (i % block == 0) {
+                    il.notifyProgress(i / (block / 10f), "writing pair " + count + "/" + pairs.size());
+                }
+                w.append(pairs.get(i));
+            }
+            listener.notifyProgress(100, "writing completed " + pairs.size() + " " + output.getFileName());
+        } catch (IOException e) {
+            throw new KWayMerger.KWayMergerException("Can't write chunk", e);
+        }
+    }
+
+    @Override
+    public void mergeChunks(List<CloseSuppressPath> inputs, CloseSuppressPath output) throws KWayMerger.KWayMergerException {
+        try {
+            listener.notifyProgress(0, "merging pairs " + output.getFileName());
+            PairReader[] readers = new PairReader[inputs.size()];
+            long count = 0;
+            try {
+                for (int i = 0; i < inputs.size(); i++) {
+                    readers[i] = new PairReader(inputs.get(i).openInputStream(bufferSize));
+                }
+
+                ExceptionIterator<Pair, IOException> it = PairMergeIterator.buildOfTree(readers, comparator);
+                // at least one
+                long rSize = it.getSize();
+                long size = Math.max(rSize, 1);
+                long block = size < 10 ? 1 : size / 10;
+                try (PairWriter w = new PairWriter(output.openOutputStream(bufferSize), rSize)) {
+                    while (it.hasNext()) {
+                        w.append(it.next());
+                        if (count % block == 0) {
+                            listener.notifyProgress(count / (block / 10f), "merging pairs " + count + "/" + size);
+                        }
+                        count++;
+                    }
+                }
+            } finally {
+                IOUtil.closeAll(readers);
+            }
+            listener.notifyProgress(100, "pairs merged " + output.getFileName() + " " + count);
+            // delete old pairs
+            IOUtil.closeAll(inputs);
+        } catch (IOException e) {
+            throw new KWayMerger.KWayMergerException(e);
+        }
+    }
+
+    @Override
+    public SizeFetcher<Pair> newStopFlux(Supplier<Pair> flux) {
+        return SizeFetcher.of(flux, p -> 3 * Long.BYTES, chunkSize);
+    }
+
+    /**
+     * sort the pairs
+     *
+     * @param workers number of workers to handle the kway merge
+     * @return exception iterator, might implement {@link java.io.Closeable}, use {@link IOUtil#closeObject(Object)} if required
+     * @throws InterruptedException           thread interruption
+     * @throws IOException                    io exception
+     * @throws KWayMerger.KWayMergerException exception during the kway merge
+     */
+    public ExceptionIterator<Pair, IOException> sort(int workers) throws InterruptedException, IOException, KWayMerger.KWayMergerException {
+        listener.notifyProgress(0, "Pair sort asked in " + baseFileName.toAbsolutePath());
+        // force to create the first file
+        KWayMerger<Pair, SizeFetcher<Pair>> merger = new KWayMerger<>(baseFileName, source, this, Math.max(1, workers - 1), k);
+        merger.start();
+        // wait for the workers to merge the sections and create the triples
+        Optional<CloseSuppressPath> sections = merger.waitResult();
+        if (sections.isEmpty()) {
+            return ExceptionIterator.empty();
+        }
+        CloseSuppressPath path = sections.get();
+        return new PairReader(path.openInputStream(bufferSize)) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    IOUtil.closeObject(path);
+                }
+            }
+        };
+    }
+
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskindex/ObjectAdjReader.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/diskindex/ObjectAdjReader.java
@@ -1,0 +1,37 @@
+package org.rdfhdt.hdt.hdt.impl.diskindex;
+
+import org.rdfhdt.hdt.compact.bitmap.Bitmap;
+import org.rdfhdt.hdt.compact.sequence.Sequence;
+import org.rdfhdt.hdt.iterator.utils.FetcherIterator;
+import org.rdfhdt.hdt.util.io.compress.Pair;
+
+public class ObjectAdjReader extends FetcherIterator<Pair> {
+    private final Sequence seqZ, seqY;
+    private final Bitmap bitmapZ;
+    private long indexY, indexZ;
+
+    public ObjectAdjReader(Sequence seqZ, Sequence seqY, Bitmap bitmapZ) {
+        this.seqZ = seqZ;
+        this.seqY = seqY;
+        this.bitmapZ = bitmapZ;
+    }
+
+    @Override
+    protected Pair getNext() {
+        if (indexZ >= seqZ.getNumberOfElements()) {
+            return null;
+        }
+
+        Pair pair = new Pair();
+        // create a pair object
+        pair.object = seqZ.get(indexZ);
+        pair.predicatePosition = indexY;
+        pair.predicate = seqY.get(indexY);
+
+        // shift to the next predicate if required
+        if (bitmapZ.access(indexZ++)) {
+            indexY++;
+        }
+        return pair;
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/ExceptionIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/ExceptionIterator.java
@@ -1,5 +1,6 @@
 package org.rdfhdt.hdt.iterator.utils;
 
+import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.listener.ProgressListener;
 
 import java.util.Iterator;
@@ -219,5 +220,12 @@ public interface ExceptionIterator<T, E extends Exception> {
 				}
 			}
 		};
+	}
+
+	/**
+	 * @return -1 if undefined, the size of the iterator otherwise
+	 */
+	default long getSize() {
+		return -1;
 	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/FetcherIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/FetcherIterator.java
@@ -1,0 +1,59 @@
+package org.rdfhdt.hdt.iterator.utils;
+
+import java.util.Iterator;
+import java.util.function.Function;
+
+/**
+ * Iterator implementation without the next element fetching method
+ * @param <T> iterator type
+ */
+public abstract class FetcherIterator<T> implements Iterator<T> {
+    private T next;
+
+    protected FetcherIterator() {
+    }
+
+    /**
+     * @return the next element, or null if it is the end
+     */
+    protected abstract T getNext();
+
+    @Override
+    public boolean hasNext() {
+        if (next != null) {
+            return true;
+        }
+        next = getNext();
+        return next != null;
+    }
+
+    @Override
+    public T next() {
+        try {
+            return peek();
+        } finally {
+            next = null;
+        }
+    }
+
+    /**
+     * @return peek the element without passing to the next element
+     */
+    public T peek() {
+        if (hasNext()) {
+            return next;
+        }
+        return null;
+    }
+
+    /**
+     * map this iterator
+     *
+     * @param mappingFunction func
+     * @param <M>             new type
+     * @return iterator
+     */
+    public <M> Iterator<M> map(Function<T, M> mappingFunction) {
+        return new MapIterator<>(this, mappingFunction);
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MapExceptionIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MapExceptionIterator.java
@@ -35,6 +35,11 @@ public class MapExceptionIterator<M, N, E extends Exception> implements Exceptio
 		base.remove();
 	}
 
+	@Override
+	public long getSize() {
+		return base.getSize();
+	}
+
 	@FunctionalInterface
 	public interface MapWithIdFunction<M, N, E extends Exception> {
 		N apply(M element, long index) throws E;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MergeExceptionIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/MergeExceptionIterator.java
@@ -188,6 +188,16 @@ public class MergeExceptionIterator<T, E extends Exception> implements Exception
 	}
 
 	@Override
+	public long getSize() {
+		long s1 = in1.getSize();
+		long s2 = in2.getSize();
+		if (s1 == -1 || s2 == -1) {
+			return -1;
+		}
+		return s2 + s1;
+	}
+
+	@Override
 	public T next() throws E {
 		if (!hasNext()) {
 			return null;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/NotificationExceptionIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/NotificationExceptionIterator.java
@@ -54,4 +54,9 @@ public class NotificationExceptionIterator<T, E extends Exception> implements Ex
 	public void remove() throws E {
 		it.remove();
 	}
+
+	@Override
+	public long getSize() {
+		return it.getSize();
+	}
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/SizeFetcher.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/iterator/utils/SizeFetcher.java
@@ -13,11 +13,15 @@ import java.util.function.ToLongFunction;
  */
 public class SizeFetcher<E> implements Supplier<E> {
     public static SizeFetcher<TripleString> ofTripleString(Supplier<TripleString> supplier, long maxSize) {
-        return new SizeFetcher<>(supplier, FileTripleIterator::estimateSize, maxSize);
+        return of(supplier, FileTripleIterator::estimateSize, maxSize);
     }
 
     public static SizeFetcher<TripleID> ofTripleLong(Supplier<TripleID> supplier, long maxSize) {
-        return new SizeFetcher<>(supplier, tripleID -> 4L * Long.BYTES, maxSize);
+        return of(supplier, tripleID -> 4L * Long.BYTES, maxSize);
+    }
+
+    public static <E> SizeFetcher<E> of(Supplier<E> supplier, ToLongFunction<E> sizeGetter, long maxSize) {
+        return new SizeFetcher<>(supplier, sizeGetter, maxSize);
     }
 
     private final Supplier<E> supplier;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HDTSpecification.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HDTSpecification.java
@@ -27,8 +27,12 @@
 
 package org.rdfhdt.hdt.options;
 
-import java.io.FileInputStream;
+import org.rdfhdt.hdt.util.io.IOUtil;
+
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Holds the properties of HDT from a configuration file
@@ -38,8 +42,6 @@ public class HDTSpecification extends HDTOptionsBase {
 
 	/**
 	 * Default constructor, reads the file config.properties
-	 * 
-	 *
 	 */
 	public HDTSpecification() {
 		super();
@@ -47,23 +49,38 @@ public class HDTSpecification extends HDTOptionsBase {
 
 	/**
 	 * Constructor that reads a specific filename
-	 * 
-	 * @param filename
-	 * @throws IOException 
+	 *
+	 * @param filename file
+	 * @throws IOException load io exception
 	 */
 	public HDTSpecification(String filename) throws IOException {
 		super();
 		load(filename);
 	}
 
-	public void load(String filename) throws IOException {
-		FileInputStream	fin = new FileInputStream(filename);
-		try {
-			properties.load(fin);
-		} finally {
-			fin.close();
-		}
+	/**
+	 * Constructor that reads a specific filename
+	 *
+	 * @param filename file
+	 * @throws IOException load io exception
+	 */
+	public HDTSpecification(Path filename) throws IOException {
+		super();
+		load(filename);
+	}
 
+	@Override
+	public void load(String filename) throws IOException {
+		try (InputStream is = IOUtil.getFileInputStream(filename)) {
+			properties.load(is);
+		}
+	}
+
+	@Override
+	public void load(Path filename) throws IOException {
+		try (InputStream is = Files.newInputStream(filename)) {
+			properties.load(is);
+		}
 	}
 
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HideHDTOptions.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HideHDTOptions.java
@@ -15,6 +15,12 @@ public class HideHDTOptions implements HDTOptions {
 
     /**
      * @param spec   wrapped options
+     */
+    public HideHDTOptions(HDTOptions spec) {
+        this(spec, Function.identity());
+    }
+    /**
+     * @param spec   wrapped options
      * @param mapper mapping function (key) {@literal ->} newKey?
      */
     public HideHDTOptions(HDTOptions spec, Function<String, String> mapper) {
@@ -37,7 +43,7 @@ public class HideHDTOptions implements HDTOptions {
     }
 
     @Override
-    public Set<Object> getKeys() {
+    public Set<?> getKeys() {
         return spec.getKeys();
     }
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesPrivate.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/TriplesPrivate.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
 import org.rdfhdt.hdt.iterator.SuppliableIteratorTripleID;
 import org.rdfhdt.hdt.listener.ProgressListener;
@@ -46,7 +47,7 @@ public interface TriplesPrivate extends Triples {
 	 * Generates the associated Index
 	 * @param listener
 	 */
-	void generateIndex(ProgressListener listener, HDTOptions spec) throws IOException;
+	void generateIndex(ProgressListener listener, HDTOptions spec, Dictionary dictionary) throws IOException;
 	
 	/**
 	 * Loads the associated Index from an InputStream

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/OneReadTempTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/OneReadTempTriples.java
@@ -1,5 +1,6 @@
 package org.rdfhdt.hdt.triples.impl;
 
+import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.impl.DictionaryIDMapping;
 import org.rdfhdt.hdt.enums.ResultEstimationType;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
@@ -105,7 +106,7 @@ public class OneReadTempTriples implements TempTriples {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener, HDTOptions disk) {
+	public void generateIndex(ProgressListener listener, HDTOptions disk, Dictionary dictionary) {
 		throw new NotImplementedException();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndex.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndex.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.util.io.CountInputStream;
@@ -20,7 +21,7 @@ public interface PredicateIndex {
 	
 	void mapIndex(CountInputStream input, File f, ProgressListener listener) throws IOException;
 	
-	void generate(ProgressListener listener, HDTOptions spec);
+	void generate(ProgressListener listener, HDTOptions spec, Dictionary dictionary);
 	
 	void close() throws IOException;
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesList.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesList.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.impl.DictionaryIDMapping;
 import org.rdfhdt.hdt.enums.ResultEstimationType;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
@@ -350,7 +351,7 @@ public class TriplesList implements TempTriples {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener, HDTOptions specIndex) {
+	public void generateIndex(ProgressListener listener, HDTOptions specIndex, Dictionary dictionary) {
 		// TODO Auto-generated method stub
 
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesListLong.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/TriplesListLong.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.dictionary.impl.DictionaryIDMapping;
 import org.rdfhdt.hdt.enums.ResultEstimationType;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
@@ -360,7 +361,7 @@ public class TriplesListLong implements TempTriples {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener, HDTOptions specIndex) {
+	public void generateIndex(ProgressListener listener, HDTOptions specIndex, Dictionary dictionary) {
 		// TODO Auto-generated method stub
 
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/WriteBitmapTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/WriteBitmapTriples.java
@@ -2,6 +2,7 @@ package org.rdfhdt.hdt.triples.impl;
 
 import org.rdfhdt.hdt.compact.bitmap.AppendableWriteBitmap;
 import org.rdfhdt.hdt.compact.sequence.SequenceLog64BigDisk;
+import org.rdfhdt.hdt.dictionary.Dictionary;
 import org.rdfhdt.hdt.enums.TripleComponentOrder;
 import org.rdfhdt.hdt.exceptions.IllegalFormatException;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
@@ -134,7 +135,7 @@ public class WriteBitmapTriples implements TriplesPrivate {
 	}
 
 	@Override
-	public void generateIndex(ProgressListener listener, HDTOptions disk) {
+	public void generateIndex(ProgressListener listener, HDTOptions disk, Dictionary dictionary) {
 		throw new NotImplementedException();
 	}
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LargeLongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LargeLongArray.java
@@ -1,6 +1,6 @@
 package org.rdfhdt.hdt.util.disk;
 
-import org.visnow.jlargearrays.LargeArray;
+import org.rdfhdt.hdt.util.io.IOUtil;
 import org.visnow.jlargearrays.LargeArrayUtils;
 import org.visnow.jlargearrays.LongLargeArray;
 
@@ -12,12 +12,12 @@ import java.io.IOException;
  * @author Antoine Willerval
  */
 public class LargeLongArray implements LongArray {
-    private LargeArray array;
+    private LongLargeArray array;
 
     /**
      * @param array large array
      */
-    public LargeLongArray(LargeArray array) {
+    public LargeLongArray(LongLargeArray array) {
         this.array = array;
     }
 
@@ -45,10 +45,15 @@ public class LargeLongArray implements LongArray {
     public void resize(long newSize) throws IOException {
         if (newSize > 0) {
             if (array.length() != newSize) {
-                LongLargeArray a = new LongLargeArray(newSize);
+                LongLargeArray a = IOUtil.createLargeArray(newSize, false);
                 LargeArrayUtils.arraycopy(array, 0, a, 0, Math.min(newSize, array.length()));
                 array = a;
             }
         }
+    }
+
+    @Override
+    public void clear() {
+        IOUtil.fillLargeArray(array, 0);
     }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/LongArray.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 /**
  * Describe a large array of longs
  */
-public interface LongArray{
+public interface LongArray {
     /**
      * get an element at a particular index
      *
@@ -39,4 +39,16 @@ public interface LongArray{
      * @throws IOException io exception
      */
     void resize(long newSize) throws IOException;
+
+    /**
+     * clear the long array, ie: set 0s
+     */
+    void clear();
+
+    /**
+     * @return sync version of this long array, might return this if this LongArray is already a sync array
+     */
+    default LongArray asSync() {
+        return SyncLongArray.of(this);
+    }
 }

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArray.java
@@ -49,7 +49,7 @@ public class SimpleSplitLongArray implements LongArray, Closeable {
     }
 
     public static SimpleSplitLongArray intXArray(long size, int x) {
-        return new SimpleSplitLongArray(new LargeLongArray(new LongLargeArray(1 + size / (64 / x))), x, size);
+        return new SimpleSplitLongArray(new LargeLongArray(IOUtil.createLargeArray(1 + size / (64 / x))), x, size);
     }
 
     public static SimpleSplitLongArray int8ArrayDisk(Path location, long size) {
@@ -106,6 +106,11 @@ public class SimpleSplitLongArray implements LongArray, Closeable {
     public void resize(long newSize) throws IOException {
         size = newSize;
         array.resize(newSize / (64 / numbits));
+    }
+
+    @Override
+    public void clear() {
+        array.clear();
     }
 
     @Override

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/SyncLongArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/disk/SyncLongArray.java
@@ -1,0 +1,59 @@
+package org.rdfhdt.hdt.util.disk;
+
+import java.io.IOException;
+
+/**
+ * sync a long array
+ *
+ * @author Antoine Willerval
+ */
+public class SyncLongArray implements LongArray {
+    /**
+     * Sync a long array
+     *
+     * @param other the array
+     * @return sync version of the long array, might return the array if already sync
+     */
+    public static SyncLongArray of(LongArray other) {
+        if (other instanceof SyncLongArray) {
+            return (SyncLongArray) other;
+        }
+        return new SyncLongArray(other);
+    }
+
+    private final LongArray array;
+
+    private SyncLongArray(LongArray array) {
+        this.array = array;
+    }
+
+    @Override
+    public synchronized long get(long index) {
+        return array.get(index);
+    }
+
+    @Override
+    public synchronized void set(long index, long value) {
+        array.set(index, value);
+    }
+
+    @Override
+    public synchronized long length() {
+        return array.length();
+    }
+
+    @Override
+    public synchronized int sizeOf() {
+        return array.sizeOf();
+    }
+
+    @Override
+    public synchronized void resize(long newSize) throws IOException {
+        array.resize(newSize);
+    }
+
+    @Override
+    public synchronized void clear() {
+        array.clear();
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/CompressNodeReader.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/CompressNodeReader.java
@@ -43,6 +43,7 @@ public class CompressNodeReader implements ExceptionIterator<IndexedNode, IOExce
 		consumer = DebugOrderNodeIterator.of("stream", true);
 	}
 
+	@Override
 	public long getSize() {
 		return size;
 	}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/Pair.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/Pair.java
@@ -1,0 +1,34 @@
+package org.rdfhdt.hdt.util.io.compress;
+
+public class Pair implements Cloneable {
+    public long predicatePosition;
+    public long object;
+    public long predicate;
+
+    public void setAll(long predicatePosition, long object, long predicate) {
+        this.predicatePosition = predicatePosition;
+        this.object = object;
+        this.predicate = predicate;
+    }
+
+    public void setAll(Pair pair) {
+        predicatePosition = pair.predicatePosition;
+        object = pair.object;
+        predicate = pair.predicate;
+    }
+
+    public void increaseAll(long predicatePosition, long object, long predicate) {
+        this.predicatePosition += predicatePosition;
+        this.object += object;
+        this.predicate += predicate;
+    }
+
+    @Override
+    public Pair clone() {
+        try {
+            return (Pair) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/PairMergeIterator.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/PairMergeIterator.java
@@ -1,0 +1,19 @@
+package org.rdfhdt.hdt.util.io.compress;
+
+import org.rdfhdt.hdt.iterator.utils.ExceptionIterator;
+import org.rdfhdt.hdt.iterator.utils.MergeExceptionIterator;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+public class PairMergeIterator extends MergeExceptionIterator<Pair, IOException> {
+
+    public PairMergeIterator(ExceptionIterator<Pair, IOException> in1, ExceptionIterator<Pair, IOException> in2, Comparator<Pair> comparator) {
+        super(in1, in2, comparator);
+    }
+
+    public static <T extends ExceptionIterator<Pair, IOException>> ExceptionIterator<Pair, IOException> buildOfTree(
+            T[] lst, Comparator<Pair> comparator) {
+        return buildOfTree(it -> it, comparator, lst, 0, lst.length);
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/PairReader.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/PairReader.java
@@ -1,0 +1,86 @@
+package org.rdfhdt.hdt.util.io.compress;
+
+import org.rdfhdt.hdt.compact.integer.VByte;
+import org.rdfhdt.hdt.exceptions.CRCException;
+import org.rdfhdt.hdt.iterator.utils.ExceptionIterator;
+import org.rdfhdt.hdt.util.crc.CRC32;
+import org.rdfhdt.hdt.util.crc.CRCInputStream;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reader for file wrote with {@link PairWriter}
+ *
+ * @author Antoine Willerval
+ */
+public class PairReader implements ExceptionIterator<Pair, IOException>, Closeable {
+    private final CRCInputStream stream;
+    private final Pair next = new Pair();
+    private boolean read = false, end = false;
+    private final long size;
+    private long index;
+
+    public PairReader(InputStream stream) throws IOException {
+        this.stream = new CRCInputStream(stream, new CRC32());
+        size = VByte.decode(this.stream);
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public boolean hasNext() throws IOException {
+        if (read) {
+            return true;
+        }
+
+        // the reader is empty, null end triple
+        if (end) {
+            return false;
+        }
+
+        if (index == size) {
+            end = true;
+            if (!stream.readCRCAndCheck()) {
+                throw new CRCException("CRC Error while reading PreMapped pairs.");
+            }
+            return false;
+        }
+
+        index++;
+
+        long p = VByte.decodeSigned(stream);
+        long v = VByte.decodeSigned(stream);
+        long pred = VByte.decodeSigned(stream);
+
+        return !setAllOrEnd(p, v, pred);
+    }
+
+    private boolean setAllOrEnd(long p, long v, long pred) {
+        if (end) {
+            // already completed
+            return true;
+        }
+        // map the triples to the end id, compute the shared with the end shared size
+        next.increaseAll(p, v, pred);
+        read = true;
+        return false;
+    }
+
+    @Override
+    public Pair next() throws IOException {
+        if (!hasNext()) {
+            return null;
+        }
+        read = false;
+        return next;
+    }
+
+    @Override
+    public void close() throws IOException {
+        stream.close();
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/PairWriter.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/PairWriter.java
@@ -1,0 +1,63 @@
+package org.rdfhdt.hdt.util.io.compress;
+
+import org.rdfhdt.hdt.compact.integer.VByte;
+import org.rdfhdt.hdt.util.crc.CRC32;
+import org.rdfhdt.hdt.util.crc.CRCOutputStream;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Writer for {@link Pair}, if the stream is stored, the file size will be reduced
+ *
+ * @author Antoine Willerval
+ */
+public class PairWriter implements Closeable {
+    private final CRCOutputStream out;
+    private final long size;
+    private long index;
+    private final Pair lastValue = new Pair();
+
+    public PairWriter(OutputStream writer, long size) throws IOException {
+        if (size < 0) {
+            throw new IllegalArgumentException("Negative size!");
+        }
+        this.out = new CRCOutputStream(writer, new CRC32());
+        VByte.encode(this.out, size);
+        this.size = size;
+    }
+
+    public void append(Pair pair) throws IOException {
+        if (index >= size) {
+            throw new IllegalArgumentException("add more elements than size!");
+        }
+        // encode the delta with the previous pair to reduce the size used by the pair on disk
+        // if the stream isn't sorted, it will add at worse 3 bits / pair, if the stream is sorted,
+        // the file's size will be drastically reduced
+        VByte.encodeSigned(out, pair.predicatePosition - lastValue.predicatePosition);
+        VByte.encodeSigned(out, pair.object - lastValue.object);
+        VByte.encodeSigned(out, pair.predicate - lastValue.predicate);
+
+        // save previous value
+        lastValue.setAll(pair);
+
+        index++;
+    }
+
+    public void writeCRC() throws IOException {
+        out.writeCRC();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (index != size) {
+                throw new IllegalArgumentException("less elements than size were added!");
+            }
+            writeCRC();
+        } finally {
+            out.close();
+        }
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/WriteLongArrayBuffer.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/io/compress/WriteLongArrayBuffer.java
@@ -43,6 +43,7 @@ public class WriteLongArrayBuffer implements LongArray, Closeable {
 	/**
 	 * clear all the elements
 	 */
+	@Override
 	public void clear() {
 		index = 0;
 	}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/array/LongArrayTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/array/LongArrayTest.java
@@ -9,11 +9,14 @@ import java.io.IOException;
 import java.util.Random;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.rdfhdt.hdt.compact.sequence.SequenceInt64;
+import org.rdfhdt.hdt.util.disk.LongArrayDisk;
 
 public class LongArrayTest {
-	
+
 	private static final int numentries = 10000;
 	SequenceInt64 array;
 	long [] plain;

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/sequence/LargeArrayTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/compact/sequence/LargeArrayTest.java
@@ -1,6 +1,7 @@
 package org.rdfhdt.hdt.compact.sequence;
 
 import org.junit.Test;
+import org.rdfhdt.hdt.util.io.IOUtil;
 import org.visnow.jlargearrays.LargeArray;
 import org.visnow.jlargearrays.LongLargeArray;
 
@@ -12,7 +13,7 @@ public class LargeArrayTest {
 		try {
 			LargeArray.setMaxSizeOf32bitArray(100);
 			long size = LargeArray.getMaxSizeOf32bitArray() + 2L;
-			new LongLargeArray(size);
+			IOUtil.createLargeArray(size, false);
 		} finally {
 			LargeArray.setMaxSizeOf32bitArray(old);
 		}

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMergerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/kcat/KCatMergerTest.java
@@ -21,7 +21,6 @@ import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
 import org.rdfhdt.hdt.hdt.HDTManagerTest;
 import org.rdfhdt.hdt.options.HDTOptions;
-import org.rdfhdt.hdt.options.HDTOptionsBase;
 import org.rdfhdt.hdt.options.HDTOptionsKeys;
 import org.rdfhdt.hdt.util.LargeFakeDataSetStreamSupplier;
 import org.rdfhdt.hdt.util.concurrent.SyncSeq;
@@ -84,7 +83,7 @@ public class KCatMergerTest extends AbstractMapMemoryTest {
     }
 
     private DictionarySection loadSection(InputStream stream) throws IOException {
-        PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
+        PFCDictionarySection section = new PFCDictionarySection(HDTOptions.EMPTY);
         section.load(stream, null);
         return section;
     }
@@ -92,7 +91,7 @@ public class KCatMergerTest extends AbstractMapMemoryTest {
     private Map<? extends CharSequence, DictionarySection> loadMultiSection(List<CharSequence> seq, InputStream stream) throws IOException {
         Map<ByteString, DictionarySection> sectionMap = new TreeMap<>();
         for (CharSequence key : seq) {
-            PFCDictionarySection section = new PFCDictionarySection(new HDTOptionsBase());
+            PFCDictionarySection section = new PFCDictionarySection(HDTOptions.EMPTY);
             section.load(stream, null);
             sectionMap.put(ByteString.of(key), section);
         }
@@ -103,7 +102,7 @@ public class KCatMergerTest extends AbstractMapMemoryTest {
     public void mergerTest() throws ParserException, IOException, InterruptedException {
         Path root = tempDir.getRoot().toPath();
         try {
-            HDTOptions spec = new HDTOptionsBase();
+            HDTOptions spec = HDTOptions.of();
 
             if (multi) {
                 spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
@@ -276,7 +275,7 @@ public class KCatMergerTest extends AbstractMapMemoryTest {
             Random rnd = new Random(58);
 
             // create the config
-            HDTOptions spec = new HDTOptionsBase();
+            HDTOptions spec = HDTOptions.of();
             if (multi) {
                 spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
                 spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
@@ -332,7 +331,7 @@ public class KCatMergerTest extends AbstractMapMemoryTest {
             Random rnd = new Random(58);
 
             // create the config
-            HDTOptions spec = new HDTOptionsBase();
+            HDTOptions spec = HDTOptions.of();
             if (multi) {
                 spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
                 spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);
@@ -412,7 +411,7 @@ public class KCatMergerTest extends AbstractMapMemoryTest {
             Random rnd = new Random(58);
 
             // create the config
-            HDTOptions spec = new HDTOptionsBase();
+            HDTOptions spec = HDTOptions.of();
             if (multi) {
                 spec.set(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
                 spec.set(HDTOptionsKeys.TEMP_DICTIONARY_IMPL_KEY, HDTOptionsKeys.TEMP_DICTIONARY_IMPL_VALUE_MULT_HASH);

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/triples/impl/BitmapTriplesTest.java
@@ -1,14 +1,19 @@
 package org.rdfhdt.hdt.triples.impl;
 
 import org.apache.commons.io.file.PathUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Suite;
 import org.rdfhdt.hdt.compact.bitmap.Bitmap;
 import org.rdfhdt.hdt.compact.sequence.Sequence;
 import org.rdfhdt.hdt.exceptions.ParserException;
 import org.rdfhdt.hdt.hdt.HDT;
 import org.rdfhdt.hdt.hdt.HDTManager;
+import org.rdfhdt.hdt.listener.ProgressListener;
 import org.rdfhdt.hdt.options.ControlInformation;
 import org.rdfhdt.hdt.options.HDTOptions;
 import org.rdfhdt.hdt.options.HDTOptionsKeys;
@@ -21,19 +26,19 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
-public class BitmapTriplesTest extends AbstractMapMemoryTest {
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+		BitmapTriplesTest.HandTest.class,
+		BitmapTriplesTest.DynamicTest.class
+})
+public class BitmapTriplesTest {
 
-	private HDT loadOrMap(Path path, HDTOptions spec, boolean map) throws IOException {
+	public static HDT loadOrMapIndexed(Path path, HDTOptions spec, boolean map) throws IOException {
 		String location = path.toAbsolutePath().toString();
 		if (map) {
 			return HDTManager.mapIndexedHDT(location, spec, null);
@@ -42,8 +47,8 @@ public class BitmapTriplesTest extends AbstractMapMemoryTest {
 		}
 	}
 
-	private void assertEqualsSeq(String name, Sequence seqE, Sequence seqA) {
-		assertEquals(seqE.getNumberOfElements(), seqA.getNumberOfElements());
+	public static void assertEqualsSeq(String name, Sequence seqE, Sequence seqA) {
+		assertEquals(name, seqE.getNumberOfElements(), seqA.getNumberOfElements());
 
 		for (long i = 0; i < seqE.getNumberOfElements(); i++) {
 			long e = seqE.get(i);
@@ -53,121 +58,278 @@ public class BitmapTriplesTest extends AbstractMapMemoryTest {
 		}
 	}
 
-	private void assertEqualsBM(String name, Bitmap seqE, Bitmap seqA) {
-		assertEquals(seqE.getNumBits(), seqA.getNumBits());
+	private static String closeValues(Bitmap excepted, Bitmap actual, long id) {
+		long start = Math.max(0, id - 5);
+		long endE = Math.min(excepted.getNumBits(), id + 5);
+		long endA = Math.min(actual.getNumBits(), id + 5);
 
-		for (long i = 0; i < seqE.getNumBits(); i++) {
+		StringBuilder buffer = new StringBuilder("\n");
+
+		buffer.append("excepted: ");
+		for (long i = start; i < endA; i++) {
+			buffer.append(actual.access(i) ? '1' : '0');
+		}
+		for (long i = endA; i < endE; i++) {
+			buffer.append('0');
+		}
+		buffer.append('\n');
+		buffer.append("actual:   ");
+		for (long i = start; i < endE; i++) {
+			buffer.append(excepted.access(i) ? '1' : '0');
+		}
+		for (long i = endE; i < endA; i++) {
+			buffer.append('0');
+		}
+		return buffer.toString();
+	}
+
+	public static void assertEqualsBM(String name, Bitmap seqE, Bitmap seqA) {
+		long start = Math.min(seqE.getNumBits(), seqA.getNumBits());
+		long end = Math.max(seqE.getNumBits(), seqA.getNumBits());
+
+		for (long i = 0; i < start; i++) {
 			boolean e = seqE.access(i);
 			boolean a = seqA.access(i);
 
-			assertEquals(name + " | bits #" + i + "/" + seqE.getNumBits() + " aren't the same", e, a);
+			if (e != a) {
+				fail(
+						name + " | bits #" + i + "/" + seqE.getNumBits() + " aren't the same" + closeValues(seqE, seqA, i)
+				);
+			}
+		}
+		if (start != end) {
+			if (end == seqE.getNumBits()) {
+				for (long i = start; i < end; i++) {
+					assertFalse(name + " | bits #" + i + "/" + seqE.getNumBits() + " aren't the same", seqE.access(i));
+				}
+			} else {
+				for (long i = start; i < end; i++) {
+					assertFalse(name + " | bits #" + i + "/" + seqE.getNumBits() + " aren't the same", seqA.access(i));
+				}
+			}
 		}
 	}
 
-	private void assertBitmapTriplesEquals(BitmapTriples excepted, BitmapTriples actual) {
+	public static void assertBitmapTriplesEquals(BitmapTriples excepted, BitmapTriples actual) {
 		// maps
-		assertEqualsSeq("seqY", excepted.getSeqY(), actual.getSeqY());
-		assertEqualsSeq("seqZ", excepted.getSeqZ(), actual.getSeqZ());
-		assertEqualsBM("bitmapY", excepted.getBitmapY(), actual.getBitmapY());
-		assertEqualsBM("bitmapZ", excepted.getBitmapZ(), actual.getBitmapZ());
+		assertAdjEquals("AdjY", excepted.getBitmapY(), excepted.getSeqY(), actual.getBitmapY(), actual.getSeqY());
+		assertAdjEquals("AdjZ", excepted.getBitmapZ(), excepted.getSeqZ(), actual.getBitmapZ(), actual.getSeqZ());
 		// INDEX
-		assertEqualsBM("bitmapIndexZ", excepted.getBitmapIndex(), actual.getBitmapIndex());
-		assertEqualsSeq("indexZ", excepted.getIndexZ(), actual.getIndexZ());
+		assertAdjEquals("AdjIndex", excepted.getBitmapIndex(), excepted.getIndexZ(), actual.getBitmapIndex(), actual.getIndexZ());
 		assertEqualsSeq("predicateCount", excepted.getPredicateCount(), actual.getPredicateCount());
 	}
 
-	public void diskBitmapIndexTest(boolean map, boolean disk) throws IOException, ParserException {
-		Path root = tempDir.newFolder().toPath();
+	private static String closeAdj(Bitmap bitmapExcepted, Sequence seqExcepted, Bitmap bitmapActual, Sequence seqActual, long id) {
+		long start = Math.max(0, id - 10);
+		long end = Math.min(bitmapExcepted.getNumBits(), id + 10);
 
-		Path hdt1Path = root.resolve("hdt1.hdt");
-		Path hdt2Path = root.resolve("hdt2.hdt");
+		StringBuilder buffer = new StringBuilder("\n");
 
-		try {
-			// create 1 one fake HDT
-			try (HDT hdt = LargeFakeDataSetStreamSupplier
-					.createSupplierWithMaxTriples(10_000L, 42)
-					.createFakeHDT(new HDTSpecification())) {
-				hdt.saveToHDT(hdt1Path.toAbsolutePath().toString(), null);
+		buffer.append("excepted:\n");
+		for (long i = start; i < end; i++) {
+			boolean b = bitmapExcepted.access(i);
+			buffer.append((b ? '1' : '0')).append("     ");
+		}
+		buffer.append('\n');
+		for (long i = start; i < end; i++) {
+			long l = seqExcepted.get(i);
+			buffer.append(String.format("%05d ", l));
+		}
+		buffer.append('\n');
+		buffer.append("actual:\n");
+		for (long i = start; i < end; i++) {
+			boolean b = bitmapActual.access(i);
+			buffer.append((b ? '1' : '0')).append("     ");
+		}
+		buffer.append('\n');
+		for (long i = start; i < end; i++) {
+			long l = seqActual.get(i);
+			buffer.append(String.format("%05d ", l));
+		}
+		return buffer.toString();
+	}
+
+	public static void assertAdjEquals(String name, Bitmap bitmapExcepted, Sequence seqExcepted, Bitmap bitmapActual, Sequence seqActual) {
+		assertEquals(bitmapExcepted.getNumBits(), bitmapActual.getNumBits());
+		assertEquals(seqExcepted.getNumberOfElements(), seqActual.getNumberOfElements());
+		assertEquals(bitmapActual.getNumBits(), seqExcepted.getNumberOfElements());
+
+		for (long i = 0; i < seqExcepted.getNumberOfElements(); i++) {
+			boolean a = bitmapActual.access(i);
+			boolean e = bitmapExcepted.access(i);
+			long al = seqActual.get(i);
+			long el = seqExcepted.get(i);
+
+			if (a != e) {
+				fail(name + "\n" +
+						"Expected :" + a + "\n" +
+						"Actual   :" + e + "\n" +
+						closeAdj(bitmapExcepted, seqExcepted, bitmapActual, seqActual, i));
 			}
-			// copy this fake HDT to another file (faster than creating the same twice)
-			Files.copy(hdt1Path, hdt2Path);
 
-			// hdt1 = DISK, hdt2 = OLD IMPLEMENTATION
-			HDTOptions optDisk = new HDTSpecification();
-			HDTOptions optDefault = new HDTSpecification();
+			if (al != el) {
+				fail(name + "\n" +
+								"Expected :" + el + "\n" +
+								"Actual   :" + al + "\n" +
+						closeAdj(bitmapExcepted, seqExcepted, bitmapActual, seqActual, i));
 
-			// set config
-			if (disk) {
-				optDisk.set(HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK, true);
-				optDisk.set(HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_SUBINDEX, true);
-				optDisk.set(HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_LOCATION, root.resolve("indexdir").toAbsolutePath());
 			}
+		}
 
-			try (
-					ByteArrayOutputStream indexDisk = new ByteArrayOutputStream();
-					ByteArrayOutputStream indexDefault = new ByteArrayOutputStream()
-			) {
+	}
 
-				// create the index for both HDTs
-				try (HDT hdt = loadOrMap(hdt1Path, optDisk, map && disk)) {
-					Triples triples = hdt.getTriples();
+	public static abstract class AbstractTest extends AbstractMapMemoryTest {
+		@Rule
+		public TemporaryFolder tempDir = new TemporaryFolder();
+	}
 
-					assertTrue(triples instanceof BitmapTriples);
+	@RunWith(Parameterized.class)
+	public static class DynamicTest extends AbstractTest {
+		@Parameterized.Parameters(name = "indexing: {0}")
+		public static Collection<Object> params() {
+			return List.of(
+					HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_VALUE_DISK,
+					HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_VALUE_OPTIMIZED
+			);
+		}
 
-					BitmapTriples bitmapTriples = (BitmapTriples) triples;
+		@Parameterized.Parameter
+		public String indexMethod;
 
-					if (disk) {
-						assertNotNull(bitmapTriples.diskSequenceLocation);
-						assertTrue(bitmapTriples.diskSequence);
-					}
+		public void diskBitmapIndexTest(boolean map, boolean disk) throws IOException, ParserException {
+			Path root = tempDir.newFolder().toPath();
 
-					try (HDT hdt2 = loadOrMap(hdt2Path, optDefault, map)) {
-						Triples triples2 = hdt2.getTriples();
+			Path hdt1Path = root.resolve("hdt1.hdt");
+			Path hdt2Path = root.resolve("hdt2.hdt");
 
-						assertTrue(triples2 instanceof BitmapTriples);
+			try {
+				// create 1 one fake HDT
+				long maxTriples = 10_000L;
+				try (HDT hdt = LargeFakeDataSetStreamSupplier
+						.createSupplierWithMaxTriples(maxTriples, 42)
+						.createFakeHDT(new HDTSpecification())) {
+					hdt.saveToHDT(hdt1Path.toAbsolutePath().toString(), null);
+				}
+				// copy this fake HDT to another file (faster than creating the same twice)
+				Files.copy(hdt1Path, hdt2Path);
 
-						BitmapTriples bitmapTriples2 = (BitmapTriples) triples2;
+				// optDisk = DISK, optDefault = OLD IMPLEMENTATION
+				HDTOptions optDisk = HDTOptions.of(
+						HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_KEY,
+						indexMethod
+				);
+				HDTOptions optDefault = HDTOptions.of(
+						HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_KEY,
+						HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_VALUE_LEGACY
+				);
 
-						if (disk) {
-							assertNull(bitmapTriples2.diskSequenceLocation);
-							assertFalse(bitmapTriples2.diskSequence);
-						}
-						bitmapTriples2.saveIndex(indexDefault, new ControlInformation(), null);
-
-						assertBitmapTriplesEquals(bitmapTriples2, bitmapTriples);
-					}
-
-					bitmapTriples.saveIndex(indexDisk, new ControlInformation(), null);
+				// set config
+				if (disk) {
+					optDisk.setOptions(
+							HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK, true,
+							HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_SUBINDEX, true,
+							HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_LOCATION, root.resolve("indexdir").toAbsolutePath()
+					);
 				}
 
-				// read and compare indexes
-				byte[] indexDiskArr = indexDisk.toByteArray();
-				byte[] indexDefaultArr = indexDefault.toByteArray();
+				try (
+						ByteArrayOutputStream indexDisk = new ByteArrayOutputStream();
+						ByteArrayOutputStream indexDefault = new ByteArrayOutputStream()
+				) {
 
-				assertArrayEquals("index not equals", indexDefaultArr, indexDiskArr);
+					// create the index for both HDTs
+					try (HDT hdt = loadOrMapIndexed(hdt1Path, optDisk, map && disk)) {
+						Triples triples = hdt.getTriples();
+
+						assertTrue(triples instanceof BitmapTriples);
+
+						BitmapTriples bitmapTriples = (BitmapTriples) triples;
+
+						if (disk) {
+							assertNotNull(bitmapTriples.diskSequenceLocation);
+							assertTrue(bitmapTriples.diskSequence);
+						}
+
+						try (HDT hdt2 = loadOrMapIndexed(hdt2Path, optDefault, map)) {
+							Triples triples2 = hdt2.getTriples();
+
+							assertTrue(triples2 instanceof BitmapTriples);
+
+							BitmapTriples bitmapTriples2 = (BitmapTriples) triples2;
+
+							if (disk) {
+								assertNull(bitmapTriples2.diskSequenceLocation);
+								assertFalse(bitmapTriples2.diskSequence);
+							}
+							bitmapTriples2.saveIndex(indexDefault, new ControlInformation(), null);
+
+							assertBitmapTriplesEquals(bitmapTriples2, bitmapTriples);
+						}
+
+						bitmapTriples.saveIndex(indexDisk, new ControlInformation(), null);
+					}
+
+					// read and compare indexes
+					byte[] indexDiskArr = indexDisk.toByteArray();
+					byte[] indexDefaultArr = indexDefault.toByteArray();
+
+					assertArrayEquals("index not equals", indexDefaultArr, indexDiskArr);
+				}
+			} finally {
+				PathUtils.deleteDirectory(root);
 			}
-		} finally {
-			PathUtils.deleteDirectory(root);
+		}
+
+		@Test
+		public void diskBitmapMapIndexedTest() throws IOException, ParserException {
+			diskBitmapIndexTest(false, true);
+		}
+
+		@Test
+		public void diskBitmapLoadIndexedTest() throws IOException, ParserException {
+			diskBitmapIndexTest(false, true);
+		}
+
+		@Test
+		public void memBitmapMapIndexedTest() throws IOException, ParserException {
+			diskBitmapIndexTest(false, false);
+		}
+
+		@Test
+		public void memBitmapLoadIndexedTest() throws IOException, ParserException {
+			diskBitmapIndexTest(false, false);
 		}
 	}
 
-	@Test
-	public void diskBitmapMapIndexedTest() throws IOException, ParserException {
-		diskBitmapIndexTest(false, true);
-	}
+	@Ignore("Hand tests")
+	public static class HandTest extends AbstractTest {
+		@Test
+		public void largeTest() throws IOException {
+			/*
+			 * Hand test to test the indexing of a large HDT with the disk indexer, hdtFile is the file to index,
+			 * workDir is the location to handle the indexing.
+			 */
+			Path hdtFile = Path.of("N:\\qEndpoint\\qendpoint\\hdt-store\\index_dev.hdt"); //ASC42
+			Path workdir = Path.of("N:\\WIP\\bitmaptriples");
+			// Path hdtFile = Path.of("C:\\Users\\wilat\\workspace\\qEndpoint\\qendpoint\\hdt-store\\index_dev.hdt"); //NAMAW
+			// Path workDir = tempDir.getRoot().toPath();
 
-	@Test
-	public void diskBitmapLoadIndexedTest() throws IOException, ParserException {
-		diskBitmapIndexTest(false, true);
-	}
+			Files.createDirectories(workdir);
 
-	@Test
-	public void memBitmapMapIndexedTest() throws IOException, ParserException {
-		diskBitmapIndexTest(false, false);
-	}
+			HDTOptions opt = HDTOptions.of(
+					HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_KEY, HDTOptionsKeys.BITMAPTRIPLES_INDEX_METHOD_VALUE_DISK,
+					HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK, true,
+					HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_SUBINDEX, true,
+					HDTOptionsKeys.BITMAPTRIPLES_SEQUENCE_DISK_LOCATION, workdir
+			);
 
-	@Test
-	public void memBitmapLoadIndexedTest() throws IOException, ParserException {
-		diskBitmapIndexTest(false, false);
+			try {
+				HDTManager.mapIndexedHDT(hdtFile, opt, ProgressListener.sout()).close();
+			} finally {
+				if (Files.exists(workdir)) {
+					PathUtils.deleteDirectory(workdir);
+				}
+			}
+		}
 	}
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/ProfilerTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/ProfilerTest.java
@@ -3,7 +3,7 @@ package org.rdfhdt.hdt.util;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.rdfhdt.hdt.options.HDTOptionsBase;
+import org.rdfhdt.hdt.options.HDTOptions;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -151,7 +151,7 @@ public class ProfilerTest {
 
 	@Test
 	public void loadBackOpt() {
-		HDTOptionsBase opt = new HDTOptionsBase();
+		HDTOptions opt = HDTOptions.of();
 		long id;
 		try (Profiler prof = Profiler.createOrLoadSubSection("test", opt, true)) {
 			id = prof.getId();

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/LongArrayDiskTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/LongArrayDiskTest.java
@@ -14,6 +14,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -102,6 +103,32 @@ public class LongArrayDiskTest  extends AbstractMapMemoryTest {
             assertEquals(array.get(1), 2);
             assertEquals(array.get(2), 3);
             assertEquals(array.get(3), 4);
+        }
+    }
+
+    @Test
+    public void clearTest() throws IOException {
+        Path root = tempDir.getRoot().toPath();
+
+        long size = 12543;
+        try (LongArrayDisk array = new LongArrayDisk(root.resolve("file"), size)) {
+
+            assertEquals(array.length(), size);
+
+            Random r1 = new Random(25);
+            for (long i = 0; i < array.length(); i++) {
+                array.set(i, r1.nextLong());
+            }
+            Random r2 = new Random(25);
+            for (long i = 0; i < array.length(); i++) {
+                assertEquals("#" + i, r2.nextLong(), array.get(i));
+            }
+
+            array.clear();
+
+            for (long i = 0; i < array.length(); i++) {
+                assertEquals("#" + i, 0, array.get(i));
+            }
         }
     }
     @Test

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArrayTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/disk/SimpleSplitLongArrayTest.java
@@ -3,6 +3,7 @@ package org.rdfhdt.hdt.util.disk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.rdfhdt.hdt.util.io.IOUtil;
 import org.visnow.jlargearrays.LongLargeArray;
 
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class SimpleSplitLongArrayTest {
 
     @Test
     public void setTest() throws IOException {
-        LargeLongArray arrayExcepted = new LargeLongArray(new LongLargeArray(128L));
+        LargeLongArray arrayExcepted = new LargeLongArray(IOUtil.createLargeArray(128L));
         try (SimpleSplitLongArray array = SimpleSplitLongArray.intXArray(128, bits)) {
 
             long max = (~0L) >>> (64 - bits);
@@ -47,7 +48,7 @@ public class SimpleSplitLongArrayTest {
 
     @Test
     public void resizeTest() throws IOException {
-        LargeLongArray arrayExcepted = new LargeLongArray(new LongLargeArray(128L));
+        LargeLongArray arrayExcepted = new LargeLongArray(IOUtil.createLargeArray(128L));
         try (SimpleSplitLongArray array = SimpleSplitLongArray.intXArray(128, bits)) {
 
             assertEquals("non matching size", arrayExcepted.length(), array.length());

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/compress/CompressTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/util/io/compress/CompressTest.java
@@ -2,12 +2,15 @@ package org.rdfhdt.hdt.util.io.compress;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.rdfhdt.hdt.compact.integer.VByte;
 import org.rdfhdt.hdt.iterator.utils.ExceptionIterator;
 import org.rdfhdt.hdt.triples.IndexedNode;
 import org.rdfhdt.hdt.util.string.ByteString;
 import org.rdfhdt.hdt.util.string.CharSequenceComparator;
-import org.rdfhdt.hdt.util.string.DelayedString;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -77,5 +80,36 @@ public class CompressTest {
 
 		Assert.assertEquals(index1, CompressUtil.computeSharedNode(sharedIndex1, sharedCount));
 		Assert.assertEquals(sharedCount + index1, CompressUtil.computeSharedNode(CompressUtil.getHeaderId(index1), sharedCount));
+	}
+
+	@Test
+	public void decodeSignedTest() throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		VByte.encodeSigned(out, 0xFFL);
+		VByte.encodeSigned(out, -0xFFL);
+
+		VByte.encodeSigned(out, 0x18L);
+		VByte.encodeSigned(out, 0x91L);
+		VByte.encodeSigned(out, 0x75L);
+
+		VByte.encodeSigned(out, 0x186878L);
+		VByte.encodeSigned(out, 0x9167L);
+		VByte.encodeSigned(out, 0x75L);
+		VByte.encodeSigned(out, -0x186878L);
+
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+
+		Assert.assertEquals(0xFFL, VByte.decodeSigned(in));
+		Assert.assertEquals(-0xFFL, VByte.decodeSigned(in));
+
+		Assert.assertEquals(0x18L, VByte.decodeSigned(in));
+		Assert.assertEquals(0x91L, VByte.decodeSigned(in));
+		Assert.assertEquals(0x75L, VByte.decodeSigned(in));
+
+		Assert.assertEquals(0x186878L, VByte.decodeSigned(in));
+		Assert.assertEquals(0x9167L, VByte.decodeSigned(in));
+		Assert.assertEquals(0x75L, VByte.decodeSigned(in));
+		Assert.assertEquals(-0x186878L, VByte.decodeSigned(in));
 	}
 }

--- a/hdt-java-package/bin/hdtSearch.ps1
+++ b/hdt-java-package/bin/hdtSearch.ps1
@@ -1,4 +1,10 @@
 param(
+    [String]
+    $options,
+    [String]
+    $config,
+    [Switch]
+    $color,
     [Parameter()]
     [Switch]
     $version,

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/HDTGraphAssembler.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/HDTGraphAssembler.java
@@ -66,9 +66,9 @@ public class HDTGraphAssembler extends AssemblerBase implements Assembler {
 			// FIXME: Read more properties. Cache config?
 			HDT hdt;
 			if(loadInMemory) {
-				hdt = HDTManager.loadIndexedHDT(file, null);				
+				hdt = HDTManager.loadIndexedHDT(file);
 			} else {
-				hdt = HDTManager.mapIndexedHDT(file, null);
+				hdt = HDTManager.mapIndexedHDT(file);
 			}
 			HDTGraph graph = new HDTGraph(hdt);
 			return ModelFactory.createModelForGraph(graph);

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
@@ -48,7 +48,7 @@ public class HDTSparql {
 
 	public void execute() throws IOException {
 		// Create HDT
-		HDT hdt = HDTManager.mapIndexedHDT(fileHDT, null);
+		HDT hdt = HDTManager.mapIndexedHDT(fileHDT);
 
 		try {
 			// Create Jena wrapper on top of HDT.


### PR DESCRIPTION
This PR contains a version of the first generateIndex method for the co-index (.hdt.index* file), but implemented using the k-ways merge sort method of #162, I was trying to index Wikidata nt file (17.5B triples) with my machine with only 16GB of RAM and noticed that even with the optimized implementation of #140 with the disk version #178, it wasn't able to handle the large amount of triples (too many random accesses)

With this version I was able to create the co-index in 5h17min. (the other implementation was stopped after 8h)

A lot of changes were made, I tried to optimize the previous implementation before working on the new one.

## API changes

Add default implementations for HDTOptions and add the options to config the indexing:

- `bitmaptriples.indexmethod` - Indexing method for the bitmap triples, can be used with:
	- `recommended` - Recommended implementation, default value
	- `optimized` - Memory optimized option (current default for recommended)
	- `legacy` - Legacy implementation, fast, but memory inefficient
	- `disk` - Disk option, handle the indexing on disk to reduce usage
- `bitmaptriples.indexmethod.disk.compressWorker` - Number of core used to index the HDT with ``disk`` index method.
- `bitmaptriples.indexmethod.disk.chunkSize` - Maximum size of a chunk for the ``disk`` index method
- `bitmaptriples.indexmethod.disk.fileBufferSize` - Size of the file buffers for the ``disk`` index method
- `bitmaptriples.indexmethod.disk.maxFileOpen` - Maximum number of file ``disk`` index method can open at the same time
- `bitmaptriples.indexmethod.disk.kway` - log of the number of way the system can merge in ``disk`` index method

## CLI changes

add `-options [opt]`, `-config [file]` and `-color` to hdtSearch.

## CORE changes

### BitmapXBig

Implementation of Bitmap375Big and Bitmap64Big, working with both disk and memory bitmaps, use LargeArrays if required, removing the limit of 128B elements and allowing the Bitmap375 to have a disk co-index. The previous implementations are now deprecated and were replaced in the library with the new implementation.

### LongLargeArray bug

[A bug was found in LongLargeArray preventing a fast 0 set of the arrays](https://gitlab.com/visnow.org/JLargeArrays/-/issues/7), knowing how not updated this library is, a fix was added to IOUtil.

### LongArrayDisk bug

Another bug to the LongArrayDisk was found, a fix is contained in this method.

```java
// LongArrayDisk#192
mapping.position(startBuffer); // before
mapping.position(startBuffer + shift); // after
```

### KWay sort to create index

The legacy code was using ArrayLists to sort the seqZ/bitmapZ/seqY ids to create the object index, but  it was taking a lot of memory, the optimized implementation was using bitmap375 to use the rank/select operations to reduce the memory usage, but it was still a lot of memory and the accesses were more random so a disk version can't work. So I used the kway merger of the disk generation method to sort like with the legacy version. 

To store the chunks during the sort, I've applied a basic compression to store the ids with the delta instead of the plain values, it saved 120GB for a 17.5B seqZ, leading to max chunk of 80GB, but maybe it can be optimized to reduce the time/disk usage.

### Tests

Obviously everything is tested with unit tests.

