### PR TITLE
Use logger instead of stdout/stderr outside of the the CLI

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/util/Profiler.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/util/Profiler.java
@@ -196,7 +196,7 @@ public class Profiler implements AutoCloseable {
 		this.name = Objects.requireNonNull(name, "name can't be null!");
 		if (spec != null) {
 			String b = spec.get(async ? HDTOptionsKeys.PROFILER_ASYNC_KEY : HDTOptionsKeys.PROFILER_KEY);
-			disabled = b == null || b.length() == 0 || !(b.charAt(0) == '!' || "true".equalsIgnoreCase(b));
+			disabled = b == null || b.length() == 0 || !("true".equalsIgnoreCase(b));
 			String profilerOutputLocation = spec.get(async ? HDTOptionsKeys.PROFILER_ASYNC_OUTPUT_KEY : HDTOptionsKeys.PROFILER_OUTPUT_KEY);
 			if (profilerOutputLocation != null && !profilerOutputLocation.isEmpty()) {
 				outputPath = Path.of(profilerOutputLocation);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/hdt/impl/HDTImpl.java
@@ -187,11 +187,11 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 			f = new File(hdtFileName);
 
 			if(!f.exists()) {
-				System.err.println("We cannot map a gzipped HDT, decompressing into "+hdtFileName+" first.");
+				log.warn("We cannot map a gzipped HDT, decompressing into {} first.", hdtFileName);
 				IOUtil.decompressGzip(old, f);
-				System.err.println("Gzipped HDT successfully decompressed. You might want to delete "+old.getAbsolutePath()+" to save disk space.");
+				log.warn("Gzipped HDT successfully decompressed. You might want to delete {} to save disk space.", old.getAbsolutePath());
 			} else {
-				System.err.println("We cannot map a gzipped HDT, using "+hdtFileName+" instead.");
+				log.warn("We cannot map a gzipped HDT, using {} instead.", hdtFileName);
 			}
 		}
 
@@ -345,20 +345,16 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 
         // Convert triples to final format
         if(triples.getClass().equals(modifiableTriples.getClass())) {
-                triples = modifiableTriples;
+			triples = modifiableTriples;
         } else {
-        		//StopWatch tripleConvTime = new StopWatch();
-                triples.load(modifiableTriples, listener);
-                //System.out.println("Triples conversion time: "+tripleConvTime.stopAndShow());
+			triples.load(modifiableTriples, listener);
         }
 
         // Convert dictionary to final format
         if(dictionary.getClass().equals(modifiableDictionary.getClass())) {
-                dictionary = (DictionaryPrivate)modifiableDictionary;
+			dictionary = (DictionaryPrivate)modifiableDictionary;
         } else {
-                //StopWatch dictConvTime = new StopWatch();
-                dictionary.load(modifiableDictionary, listener);
-                //System.out.println("Dictionary conversion time: "+dictConvTime.stopAndShow());
+			dictionary.load(modifiableDictionary, listener);
         }
 
         this.baseUri = modHdt.getBaseURI();
@@ -396,8 +392,7 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 			}
 		} catch (Exception e) {
 			if (!(e instanceof FileNotFoundException)) {
-				System.out.println("Error reading .hdt.index, generating a new one. The error was: "+e.getMessage());
-				e.printStackTrace();
+				log.error("Error reading .hdt.index, generating a new one.", e);
 			}
 
 			// GENERATE
@@ -411,11 +406,9 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 					out = new BufferedOutputStream(new FileOutputStream(versionName));
 					ci.clear();
 					triples.saveIndex(out, ci, listener);
-					out.close();
-					System.out.println("Index generated and saved in "+st.stopAndShow());
+					log.info("Index generated and saved in {}", st.stopAndShow());
 				} catch (IOException e2) {
-					System.err.println("Error writing index file.");
-					e2.printStackTrace();
+					log.error("Error writing index file.", e2);
 				} finally {
 					IOUtil.closeQuietly(out);
 				}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserSimple.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserSimple.java
@@ -72,10 +72,7 @@ public class RDFParserSimple implements RDFParserCallback {
 		try {
 			doParse(reader, baseUri, notation, keepBNode, callback);
 		} finally {
-			try {
-				reader.close();
-			} catch (IOException e) {
-			}
+			IOUtil.closeQuietly(reader);
 		}
 	}
 
@@ -110,7 +107,7 @@ public class RDFParserSimple implements RDFParserCallback {
 						//System.out.println(triple);
 						callback.processTriple(triple, 0);
 					} else {
-						System.err.println("Warning: Could not parse triple at line "+numLine+", ignored and not processed.\n"+line);
+						log.warn("Could not parse triple at line {}, ignored and not processed.\n{}", numLine, line);
 					}
 				}
 				numLine++;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/BitmapTriples.java
@@ -850,8 +850,8 @@ public class BitmapTriples implements TriplesPrivate {
 		}
 
 		ArrayList<List<Pair>> list=new ArrayList<>();
-		
-		System.out.println("Generating HDT Index for ?PO, and ??O queries.");
+
+		log.info("Generating HDT Index for ?PO, and ??O queries.");
 		// Generate lists
 		long total=seqZ.getNumberOfElements();
 		for(long i=0;i<total;i++) {
@@ -876,12 +876,12 @@ public class BitmapTriples implements TriplesPrivate {
 			
 			inner.add(pair);
 
-			if((i%100000)==0) {
-				System.out.println("Processed: "+i+" objects out of "+total);
+			if((i % 100000)==0) {
+				log.info("Processed {}/{} objects", i, total);
 			}
 		}
-		
-		System.out.println("Serialize object lists");
+
+		log.info("Serialize object lists");
 		// Serialize
 		DynamicSequence indexZ = new SequenceLog64(BitUtil.log2(seqY.getNumberOfElements()), list.size());
 		Bitmap375Big bitmapIndexZ = Bitmap375Big.memory(seqY.getNumberOfElements());
@@ -903,7 +903,7 @@ public class BitmapTriples implements TriplesPrivate {
 			}
 			
 			if((i%100000)==0) {
-				System.out.println("Serialized: "+i+" lists out of "+total);
+				log.info("Serialized {}/{} lists", i, total);
 			}
 			
 			// Dereference processed list to let GC release the memory.
@@ -955,11 +955,7 @@ public class BitmapTriples implements TriplesPrivate {
 		}
 
 		predicateIndex = new PredicateIndexArray(this);
-		if (!specIndex.getBoolean("debug.bitmaptriples.ignorePredicateIndex", false)) {
-			predicateIndex.generate(listener, specIndex, dictionary);
-		} else {
-			System.err.println("WARNING!!! PREDICATE INDEX IGNORED, THE INDEX WON'T BE COMPLETED!");
-		}
+		predicateIndex.generate(listener, specIndex, dictionary);
 	}
 
 	/* (non-Javadoc)

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/triples/impl/PredicateIndexArray.java
@@ -102,8 +102,8 @@ class PredicateIndexArray implements PredicateIndex {
 				maxCount = Math.max(count, maxCount);
 				predCount.set(val - 1, count);
 
-				if (listener != null && i % 1_000_000 == 0) {
-					listener.notifyProgress((float) (i * 100 / triples.getSeqY().getNumberOfElements()), "Counting appearances of predicates " + i + " / "+ triples.getSeqY().getNumberOfElements());
+				if (i % 1_000_000 == 0) {
+					iListener.notifyProgress((float) (i * 100 / triples.getSeqY().getNumberOfElements()), "Counting appearances of predicates " + i + " / "+ triples.getSeqY().getNumberOfElements());
 				}
 			}
 			predCount.aggressiveTrimToSize();
@@ -114,15 +114,13 @@ class PredicateIndexArray implements PredicateIndex {
 			for (long i = 0; i < predCount.getNumberOfElements(); i++) {
 				tempCountPred += predCount.get(i);
 				bitmap.set(tempCountPred - 1, true);
-				if (listener != null && i % 1_000_000 == 0) {
-					listener.notifyProgress((float) (i * 100 / predCount.getNumberOfElements()), "Creating Predicate bitmap " + i + " / "+ triples.getSeqY().getNumberOfElements());
+				if (i % 1_000_000 == 0) {
+					iListener.notifyProgress((float) (i * 100 / predCount.getNumberOfElements()), "Creating Predicate bitmap " + i + " / "+ triples.getSeqY().getNumberOfElements());
 				}
 			}
 			bitmap.set(triples.getSeqY().getNumberOfElements() - 1, true);
 			log.info("Predicate Bitmap in {}", st.stopAndShow());
-			if (listener != null) {
-				listener.notifyProgress(100, "Predicate Bitmap in " + st);
-			}
+			iListener.notifyProgress(100, "Predicate Bitmap in " + st);
 			st.reset();
 		} finally {
 			IOUtil.closeQuietly(predCount);
@@ -146,8 +144,8 @@ class PredicateIndexArray implements PredicateIndex {
 
 					array.set(insertBase + insertOffset, i);
 
-					if (listener != null && i % 1_000_000 == 0) {
-						listener.notifyProgress( (float) (i * 100 / triples.getSeqY().getNumberOfElements()), "Generating predicate references");
+					if (i % 1_000_000 == 0) {
+						iListener.notifyProgress( (float) (i * 100 / triples.getSeqY().getNumberOfElements()), "Generating predicate references");
 					}
 				}
 			} finally {


### PR DESCRIPTION
It removes the logs using System.(out|err) in the library, except obviously in the tests and in the CLI.

I've also fixed a Profiler issue printing things in the logs even when it is disabled.