### PR TITLE
Add simple parser extension to parse NQuad and QuadString

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/exceptions/ParserException.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/exceptions/ParserException.java
@@ -35,12 +35,22 @@ public class ParserException extends Exception {
 
 	private static final long serialVersionUID = -5159336711525269027L;
 
+	private static String createMessage(String message, String line, int location) {
+		int start = Math.max(0, location - 10);
+		int end = Math.min(line.length(), location + 10);
+		return message + " near " + line.substring(start, end);
+	}
+
 	public ParserException() {
 		super();
 	}
 
 	public ParserException(String message) {
 		super(message);
+	}
+
+	public ParserException(String message, String line, int location) {
+		this(createMessage(message, line, location));
 	}
 
 	public ParserException(Throwable e) {

--- a/hdt-api/src/main/java/org/rdfhdt/hdt/quad/QuadString.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/quad/QuadString.java
@@ -1,0 +1,119 @@
+package org.rdfhdt.hdt.quad;
+
+import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.triples.TripleString;
+
+public class QuadString extends TripleString {
+	protected CharSequence context;
+
+	public QuadString() {
+		super();
+		context = "";
+	}
+
+	public QuadString(CharSequence subject, CharSequence predicate, CharSequence object, CharSequence context) {
+		super(subject, predicate, object);
+		this.context = context;
+	}
+
+	public QuadString(TripleString other) {
+		super(other);
+		this.context = other.getObject();
+	}
+
+	@Override
+	public void clear() {
+		super.clear();
+		context = "";
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (context.length() == 0) {
+			return super.equals(other);
+		}
+		if (!(other instanceof QuadString)) {
+			return false;
+		}
+		QuadString qs = (QuadString) other;
+		return equalsCharSequence(subject, qs.subject)
+				&& equalsCharSequence(predicate, qs.predicate)
+				&& equalsCharSequence(object, qs.object)
+				&& equalsCharSequence(context, qs.context);
+	}
+
+	@Override
+	public CharSequence getGraph() {
+		return context;
+	}
+
+	@Override
+	public void setGraph(CharSequence context) {
+		this.context = context;
+	}
+
+	@Override
+	public void setAll(CharSequence subject, CharSequence predicate, CharSequence object) {
+		setAll(subject, predicate, object, "");
+	}
+
+	/**
+	 * Sets all components at once. Useful to reuse existing object instead of
+	 * creating new ones for performance.
+	 *
+	 * @param subject   subject
+	 * @param predicate predicate
+	 * @param object    object
+	 * @param context   context
+	 */
+	public void setAll(CharSequence subject, CharSequence predicate, CharSequence object, CharSequence context) {
+		super.setAll(subject, predicate, object);
+		this.context = context;
+	}
+
+	@Override
+	public boolean match(TripleString pattern) {
+		if (context.length() != 0
+				&& !(pattern instanceof QuadString && equalsCharSequence(((QuadString) pattern).context, context))) {
+			// if a context is defined, we don't match
+			return false;
+		}
+		if (pattern.getSubject().length() == 0 || equalsCharSequence(pattern.getSubject(), this.subject)) {
+			if (pattern.getPredicate().length() == 0 || equalsCharSequence(pattern.getPredicate(), this.predicate)) {
+				return pattern.getObject().length() == 0 || equalsCharSequence(pattern.getObject(), this.object);
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return super.isEmpty() && context.length() == 0;
+	}
+
+	@Override
+	public void read(String line) throws ParserException {
+		super.read(line, true);
+	}
+
+	@Override
+	public void read(String line, int start, int end) throws ParserException {
+		super.read(line, start, end, true);
+	}
+
+	@Override
+	public int hashCode() {
+		// Same as Objects.hashCode(subject, predicate, object), with fewer
+		// calls
+		int s = subject == null ? 0 : subject.hashCode();
+		int p = predicate == null ? 0 : predicate.hashCode();
+		int o = object == null ? 0 : object.hashCode();
+		int c = context == null ? 0 : context.hashCode();
+		return 31 * (31 * (31 * (31 * s) + p) + o) + c;
+	}
+
+	@Override
+	public QuadString tripleToString() {
+		return new QuadString(subject.toString(), predicate.toString(), object.toString(), context.toString());
+	}
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/RDFParserFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/RDFParserFactory.java
@@ -58,10 +58,10 @@ public class RDFParserFactory {
 	public static RDFParserCallback getParserCallback(RDFNotation notation, HDTOptions spec) {
 		switch(notation) {
 			case NTRIPLES:
+			case NQUAD:
 				if (useSimple(spec)) {
 					return new RDFParserSimple();
 				}
-			case NQUAD:
 			case TURTLE:
 			case N3:
 			case RDFXML:

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/JenaNodeFormatter.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/JenaNodeFormatter.java
@@ -42,6 +42,9 @@ public class JenaNodeFormatter {
     }
 
     public static String format(Node node) {
+        if (node == null) {
+            return "";
+        }
         if (node.isURI()) {
             return node.getURI();
 

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRIOT.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/rdf/parsers/RDFParserRIOT.java
@@ -3,71 +3,73 @@
  * Revision: $Rev: 191 $
  * Last modified: $Date: 2013-03-03 11:41:43 +0000 (dom, 03 mar 2013) $
  * Last modified by: $Author: mario.arias $
- *
+ * <p>
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation;
  * version 3.0 of the License.
- *
+ * <p>
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
+ * <p>
  * Contacting the authors:
- *   Mario Arias:               mario.arias@deri.org
- *   Javier D. Fernandez:       jfergar@infor.uva.es
- *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ * Mario Arias:               mario.arias@deri.org
+ * Javier D. Fernandez:       jfergar@infor.uva.es
+ * Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  */
 
 package org.rdfhdt.hdt.rdf.parsers;
 
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-
 import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFParser;
-import org.apache.jena.riot.RDFParserBuilder;
 import org.apache.jena.riot.lang.LabelToNode;
 import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.sparql.core.Quad;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.NotImplementedException;
 import org.rdfhdt.hdt.exceptions.ParserException;
+import org.rdfhdt.hdt.quad.QuadString;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
 import org.rdfhdt.hdt.triples.TripleString;
 import org.rdfhdt.hdt.util.io.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
 /**
  * @author mario.arias
  *
  */
-public class RDFParserRIOT implements RDFParserCallback, StreamRDF {
+public class RDFParserRIOT implements RDFParserCallback {
 	private static final Logger log = LoggerFactory.getLogger(RDFParserRIOT.class);
-	private void parse(InputStream stream, String baseUri, Lang lang, boolean keepBNode) {
+
+	private void parse(InputStream stream, String baseUri, Lang lang, boolean keepBNode, ElemStringBuffer buffer) {
 		if (keepBNode) {
-			RDFParser.source(stream).base(baseUri).lang(lang).labelToNode(LabelToNode.createUseLabelAsGiven()).parse(this);
+			RDFParser.source(stream).base(baseUri).lang(lang).labelToNode(LabelToNode.createUseLabelAsGiven())
+					.parse(buffer);
 		} else {
-			RDFParser.source(stream).base(baseUri).lang(lang).parse(this);
+			RDFParser.source(stream).base(baseUri).lang(lang).parse(buffer);
 		}
 	}
 
-	private RDFCallback callback;
-	private final TripleString triple = new TripleString();
-
-	/* (non-Javadoc)
-	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String, java.lang.String, hdt.enums.RDFNotation, hdt.rdf.RDFParserCallback.Callback)
+	/*
+	 * (non-Javadoc)
+	 * @see hdt.rdf.RDFParserCallback#doParse(java.lang.String,
+	 * java.lang.String, hdt.enums.RDFNotation,
+	 * hdt.rdf.RDFParserCallback.Callback)
 	 */
 	@Override
-	public void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
+	public void doParse(String fileName, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback)
+			throws ParserException {
 		try (InputStream input = IOUtil.getFileInputStream(fileName)) {
 			doParse(input, baseUri, notation, keepBNode, callback);
 		} catch (FileNotFoundException e) {
@@ -79,25 +81,26 @@ public class RDFParserRIOT implements RDFParserCallback, StreamRDF {
 	}
 
 	@Override
-    public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode, RDFCallback callback) throws ParserException {
-		this.callback = callback;
+	public void doParse(InputStream input, String baseUri, RDFNotation notation, boolean keepBNode,
+	                    RDFCallback callback) throws ParserException {
 		try {
-			switch(notation) {
+			ElemStringBuffer buffer = new ElemStringBuffer(notation == RDFNotation.NQUAD, callback);
+			switch (notation) {
 				case NTRIPLES:
-					parse(input, baseUri, Lang.NTRIPLES, keepBNode);
+					parse(input, baseUri, Lang.NTRIPLES, keepBNode, buffer);
 					break;
 				case NQUAD:
-					parse(input, baseUri, Lang.NQUADS, keepBNode);
+					parse(input, baseUri, Lang.NQUADS, keepBNode, buffer);
 					break;
 				case RDFXML:
-					parse(input, baseUri, Lang.RDFXML, keepBNode);
+					parse(input, baseUri, Lang.RDFXML, keepBNode, buffer);
 					break;
 				case N3:
 				case TURTLE:
-					parse(input, baseUri, Lang.TURTLE, keepBNode);
+					parse(input, baseUri, Lang.TURTLE, keepBNode, buffer);
 					break;
 				default:
-					throw new NotImplementedException("Parser not found for format "+notation);
+					throw new NotImplementedException("Parser not found for format " + notation);
 			}
 		} catch (Exception e) {
 			log.error("Unexpected exception.", e);
@@ -105,45 +108,45 @@ public class RDFParserRIOT implements RDFParserCallback, StreamRDF {
 		}
 	}
 
-	 @Override
-     public void start() {
-             // TODO Auto-generated method stub
+	private static class ElemStringBuffer implements StreamRDF {
+		private final TripleString triple;
+		private final RDFCallback callback;
 
-     }
+		private ElemStringBuffer(boolean quad, RDFCallback callback) {
+			this.triple = quad ? new QuadString() : new TripleString();
+			this.callback = callback;
+		}
 
-     @Override
-     public void triple(Triple parsedTriple) {
-             triple.setAll(
-					 JenaNodeFormatter.format(parsedTriple.getSubject()),
-					 JenaNodeFormatter.format(parsedTriple.getPredicate()),
-					 JenaNodeFormatter.format(parsedTriple.getObject()));
-    	 callback.processTriple(triple, 0);
-     }
+		@Override
+		public void triple(Triple parsedTriple) {
+			triple.setAll(JenaNodeFormatter.format(parsedTriple.getSubject()),
+					JenaNodeFormatter.format(parsedTriple.getPredicate()),
+					JenaNodeFormatter.format(parsedTriple.getObject()));
+			callback.processTriple(triple, 0);
+		}
 
-     @Override
-     public void quad(Quad quad) {
-             triple.setAll(
-					 JenaNodeFormatter.format(quad.getSubject()),
-					 JenaNodeFormatter.format(quad.getPredicate()),
-					 JenaNodeFormatter.format(quad.getObject()));
-    	 callback.processTriple(triple, 0);
-     }
+		@Override
+		public void quad(Quad quad) {
+			triple.setAll(JenaNodeFormatter.format(quad.getSubject()), JenaNodeFormatter.format(quad.getPredicate()),
+					JenaNodeFormatter.format(quad.getObject()));
+			triple.setGraph(JenaNodeFormatter.format(quad.getGraph()));
+			callback.processTriple(triple, 0);
+		}
 
-     @Override
-     public void base(String base) {
-//           System.out.println("Base: "+base);
-     }
+		@Override
+		public void start() {
+		}
 
-     @Override
-     public void prefix(String prefix, String iri) {
-//           System.out.println("Prefix: "+prefix+" iri "+iri);
-     }
+		@Override
+		public void base(String base) {
+		}
 
-     @Override
-     public void finish() {
-             // TODO Auto-generated method stub
+		@Override
+		public void prefix(String prefix, String iri) {
+		}
 
-     }
-
-
+		@Override
+		public void finish() {
+		}
+	}
 }

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/RDFParserSimpleTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/rdf/parsers/RDFParserSimpleTest.java
@@ -2,6 +2,8 @@ package org.rdfhdt.hdt.rdf.parsers;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 import org.rdfhdt.hdt.enums.RDFNotation;
 import org.rdfhdt.hdt.exceptions.ParserException;
 import org.rdfhdt.hdt.rdf.RDFParserCallback;
@@ -15,63 +17,102 @@ import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.util.Iterator;
 
-public class RDFParserSimpleTest extends AbstractNTriplesParserTest {
-	@Override
-	protected RDFParserCallback createParser() {
-		return new RDFParserSimple();
-	}
+@RunWith(Suite.class)
+@Suite.SuiteClasses({RDFParserSimpleTest.NTriplesTest.class, RDFParserSimpleTest.NQuadTest.class,
+		RDFParserSimpleTest.NQuadNoGraphTest.class})
+public class RDFParserSimpleTest {
+	public static abstract class AbstractRDFParserSimpleTest extends AbstractNTriplesParserTest {
+		protected final RDFNotation notation;
 
-	@Test
-	public void ingestTest() throws IOException, InterruptedException, ParserException {
-		LargeFakeDataSetStreamSupplier supplier =
-				LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(1_000_001, 42);
-		LargeFakeDataSetStreamSupplier supplier2 =
-				LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(1_000_001, 42);
+		protected AbstractRDFParserSimpleTest(RDFNotation notation) {
+			this.notation = notation;
+		}
 
-		PipedOutputStream out = new PipedOutputStream();
-		PipedInputStream in = new PipedInputStream();
-		in.connect(out);
+		protected abstract LargeFakeDataSetStreamSupplier createSupplier();
 
-		RuntimeException[] re = new RuntimeException[1];
-		Thread t = new Thread(() -> {
-			try {
-				Iterator<TripleString> it = supplier.createTripleStringStream();
-				PrintStream ps = new PrintStream(out);
-				while (it.hasNext()) {
-					TripleString next = it.next();
-					next.dumpNtriple(ps);
-					ps.flush();
-				}
-				out.close();
-			} catch (RuntimeException tt) {
-				re[0] = tt;
-			} catch (Throwable tt) {
-				re[0] = new RuntimeException(tt);
-			}
-		});
-		t.start();
+		@Override
+		protected RDFParserCallback createParser() {
+			return new RDFParserSimple();
+		}
 
-		RDFParserCallback parser = createParser();
+		@Test
+		public void ingestTest() throws IOException, InterruptedException, ParserException {
+			LargeFakeDataSetStreamSupplier supplier = createSupplier();
+			LargeFakeDataSetStreamSupplier supplier2 = createSupplier();
 
-		Iterator<TripleString> it = supplier2.createTripleStringStream();
+			PipedOutputStream out = new PipedOutputStream();
+			PipedInputStream in = new PipedInputStream();
+			in.connect(out);
 
-		int[] count = new int[1];
-		StopWatch watch = new StopWatch();
-		watch.reset();
-		parser.doParse(in, "http://example.org/#", RDFNotation.NTRIPLES, true,
-				(triple, pos) -> {
-					Assert.assertTrue(it.hasNext());
-					Assert.assertEquals(it.next(), triple);
-					if (count[0] % 100_000 == 0) {
-						System.out.println(count[0] + " triples " +watch.stopAndShow());
+			RuntimeException[] re = new RuntimeException[1];
+			Thread t = new Thread(() -> {
+				try {
+					Iterator<TripleString> it = supplier.createTripleStringStream();
+					PrintStream ps = new PrintStream(out);
+					while (it.hasNext()) {
+						TripleString next = it.next();
+						next.dumpNtriple(ps);
+						ps.flush();
 					}
-					count[0]++;
+					out.close();
+				} catch (RuntimeException tt) {
+					re[0] = tt;
+				} catch (Throwable tt) {
+					re[0] = new RuntimeException(tt);
 				}
-		);
+			});
+			t.start();
 
-		t.join();
-		if (re[0] != null) {
-			throw re[0];
+			RDFParserCallback parser = createParser();
+
+			Iterator<TripleString> it = supplier2.createTripleStringStream();
+
+			StopWatch watch = new StopWatch();
+			watch.reset();
+			parser.doParse(in, "http://example.org/#", notation, true, (triple, pos) -> {
+				Assert.assertTrue(it.hasNext());
+				Assert.assertEquals(it.next(), triple);
+			});
+
+			t.join();
+			if (re[0] != null) {
+				throw re[0];
+			}
 		}
 	}
+
+	public static class NTriplesTest extends AbstractRDFParserSimpleTest {
+		public NTriplesTest() {
+			super(RDFNotation.NTRIPLES);
+		}
+
+		@Override
+		protected LargeFakeDataSetStreamSupplier createSupplier() {
+			return LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(1_000_001, 42).withQuads(true)
+					.withMaxGraph(0);
+		}
+	}
+
+	public static class NQuadTest extends AbstractRDFParserSimpleTest {
+		public NQuadTest() {
+			super(RDFNotation.NQUAD);
+		}
+
+		@Override
+		protected LargeFakeDataSetStreamSupplier createSupplier() {
+			return LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(1_000_001, 42).withQuads(true);
+		}
+	}
+
+	public static class NQuadNoGraphTest extends AbstractRDFParserSimpleTest {
+		public NQuadNoGraphTest() {
+			super(RDFNotation.NQUAD);
+		}
+
+		@Override
+		protected LargeFakeDataSetStreamSupplier createSupplier() {
+			return LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(1_000_001, 42);
+		}
+	}
+
 }


### PR DESCRIPTION
Hello,

In this PR I've upgraded the canonical ntriples parser to read nquad files, I've created a QuadString class to support the context, but it can also be used with the TripleString class, but the context won't be saved. I've also added to the RIOT parser the reading of the quads.